### PR TITLE
fix: exclude example and testing files from coverage report uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
+          exclude: "*/examples/*,*/testing/*"
 
       - name: Stop test infrastructure
         if: always()


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request makes a minor update to the test workflow configuration. The change excludes files in the `examples` and `testing` directories from code coverage reporting.

- Updated the `test.yml` workflow to exclude `*/examples/*` and `*/testing/*` from code coverage uploads.

## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
