### PR TITLE
fix: update permissions in GitHub workflows for consistency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,6 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment
 concurrency:
   group: "pages"
@@ -23,6 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: docs
@@ -69,6 +65,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-
 # Environment variables shared across all jobs
 env:
   TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable
@@ -20,6 +17,8 @@ jobs:
   test:
     name: Test with Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -77,6 +76,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -97,6 +98,8 @@ jobs:
   build:
     name: Build (${{ matrix.os }}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -136,6 +136,10 @@ func NewAdapter(connStr string, opts ...Option) (*PostgresAdapter, error) {
 
 	// Validate schema name to prevent SQL injection
 	if err := validateSchemaName(adapter.schema); err != nil {
+		// Cancel health check goroutine if it was started
+		if adapter.healthCheckCancel != nil {
+			adapter.healthCheckCancel()
+		}
 		_ = db.Close()
 		return nil, err
 	}
@@ -161,6 +165,10 @@ func NewAdapterWithDB(db *sql.DB, opts ...Option) (*PostgresAdapter, error) {
 
 	// Validate schema name to prevent SQL injection
 	if err := validateSchemaName(adapter.schema); err != nil {
+		// Cancel health check goroutine if it was started
+		if adapter.healthCheckCancel != nil {
+			adapter.healthCheckCancel()
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request refactors how permissions are set in the GitHub Actions workflow files `.github/workflows/docs.yml` and `.github/workflows/test.yml`. The main change is moving permissions from the top-level workflow configuration into individual jobs, which improves security and aligns with GitHub's recommended best practices.

## Changes
<!-- List of changes -->

**Workflow permissions refactor:**

* Removed top-level `permissions` blocks in both `.github/workflows/docs.yml` and `.github/workflows/test.yml`, and added job-specific permissions instead. [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL12-L17) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L9-L11)

**Job-specific permission updates:**

* Added `contents: read` permission to the `build` job in both workflow files, ensuring only necessary access is granted for code checkout and build steps. [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR20-R21) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R20-R21) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R79-R80) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R101-R102)
* Added `pages: write` and `id-token: write` permissions to the deployment job in `.github/workflows/docs.yml` to enable secure deployment to GitHub Pages.

## Testing
<!-- How did you test this? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [ ] Code comments added
- [ ] README updated (if applicable)
- [ ] API docs updated

## Checklist
- [ ] Code follows project style guidelines
- [ ] All tests pass
- [ ] No breaking changes (or documented if intentional)
