### PR TITLE
fix: update GitHub Actions workflows and PostgreSQL adapter for improved safety and quoting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4c24fa5ec04b2e79eb40571b1cee2a0d2b705771 # v1
         with:
           ruby-version: '3.2'
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           echo "Tag $NEW_VERSION created and pushed"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.next_version.outputs.new_version }}
           name: Release ${{ steps.next_version.outputs.new_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
@@ -90,7 +90,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
           args: --timeout=5m

--- a/adapters/postgres/idempotency.go
+++ b/adapters/postgres/idempotency.go
@@ -106,8 +106,8 @@ func (s *IdempotencyStore) Initialize(ctx context.Context) error {
 			expires_at TIMESTAMPTZ NOT NULL
 		);
 
-		CREATE INDEX IF NOT EXISTS idx_` + s.table + `_expires_at ON ` + tableQ + ` (expires_at);
-		CREATE INDEX IF NOT EXISTS idx_` + s.table + `_processed_at ON ` + tableQ + ` (processed_at);
+		CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+s.table+"_expires_at") + ` ON ` + tableQ + ` (expires_at);
+		CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+s.table+"_processed_at") + ` ON ` + tableQ + ` (processed_at);
 	`
 
 	_, err := s.db.ExecContext(ctx, query)

--- a/adapters/postgres/idempotency.go
+++ b/adapters/postgres/idempotency.go
@@ -77,9 +77,9 @@ func validateIdentifier(name, kind string) error {
 	return nil
 }
 
-// fullTableName returns the fully qualified table name.
+// fullTableName returns the fully qualified and quoted table name.
 func (s *IdempotencyStore) fullTableName() string {
-	return fmt.Sprintf("%s.%s", s.schema, s.table)
+	return quoteQualifiedTable(s.schema, s.table)
 }
 
 // Initialize creates the idempotency table if it doesn't exist.
@@ -92,8 +92,9 @@ func (s *IdempotencyStore) Initialize(ctx context.Context) error {
 		return err
 	}
 
-	query := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s (
+	tableQ := s.fullTableName()
+	query := `
+		CREATE TABLE IF NOT EXISTS ` + tableQ + ` (
 			key VARCHAR(255) PRIMARY KEY,
 			command_type VARCHAR(255) NOT NULL,
 			aggregate_id VARCHAR(255),
@@ -105,9 +106,9 @@ func (s *IdempotencyStore) Initialize(ctx context.Context) error {
 			expires_at TIMESTAMPTZ NOT NULL
 		);
 
-		CREATE INDEX IF NOT EXISTS idx_%s_expires_at ON %s (expires_at);
-		CREATE INDEX IF NOT EXISTS idx_%s_processed_at ON %s (processed_at);
-	`, s.fullTableName(), s.table, s.fullTableName(), s.table, s.fullTableName())
+		CREATE INDEX IF NOT EXISTS idx_` + s.table + `_expires_at ON ` + tableQ + ` (expires_at);
+		CREATE INDEX IF NOT EXISTS idx_` + s.table + `_processed_at ON ` + tableQ + ` (processed_at);
+	`
 
 	_, err := s.db.ExecContext(ctx, query)
 	if err != nil {
@@ -119,12 +120,13 @@ func (s *IdempotencyStore) Initialize(ctx context.Context) error {
 
 // Exists checks if a record with the given key exists and is not expired.
 func (s *IdempotencyStore) Exists(ctx context.Context, key string) (bool, error) {
-	query := fmt.Sprintf(`
+	tableQ := s.fullTableName()
+	query := `
 		SELECT EXISTS(
-			SELECT 1 FROM %s 
+			SELECT 1 FROM ` + tableQ + ` 
 			WHERE key = $1 AND expires_at > NOW()
 		)
-	`, s.fullTableName())
+	`
 
 	var exists bool
 	err := s.db.QueryRowContext(ctx, query, key).Scan(&exists)
@@ -148,8 +150,9 @@ func (s *IdempotencyStore) Store(ctx context.Context, record *adapters.Idempoten
 		}
 	}
 
-	query := fmt.Sprintf(`
-		INSERT INTO %s (
+	tableQ := s.fullTableName()
+	query := `
+		INSERT INTO ` + tableQ + ` (
 			key, command_type, aggregate_id, version, response, error, success, processed_at, expires_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (key) DO UPDATE SET
@@ -161,7 +164,7 @@ func (s *IdempotencyStore) Store(ctx context.Context, record *adapters.Idempoten
 			success = EXCLUDED.success,
 			processed_at = EXCLUDED.processed_at,
 			expires_at = EXCLUDED.expires_at
-	`, s.fullTableName())
+	`
 
 	var nullableResponse interface{}
 	if responseJSON != nil {
@@ -204,11 +207,12 @@ func (s *IdempotencyStore) Store(ctx context.Context, record *adapters.Idempoten
 // Get retrieves an idempotency record by key.
 // Returns nil, nil if the record doesn't exist or is expired.
 func (s *IdempotencyStore) Get(ctx context.Context, key string) (*adapters.IdempotencyRecord, error) {
-	query := fmt.Sprintf(`
+	tableQ := s.fullTableName()
+	query := `
 		SELECT key, command_type, aggregate_id, version, response, error, success, processed_at, expires_at
-		FROM %s
+		FROM ` + tableQ + `
 		WHERE key = $1 AND expires_at > NOW()
-	`, s.fullTableName())
+	`
 
 	var record adapters.IdempotencyRecord
 	var aggregateID sql.NullString
@@ -257,7 +261,8 @@ func (s *IdempotencyStore) Get(ctx context.Context, key string) (*adapters.Idemp
 
 // Delete removes an idempotency record by key.
 func (s *IdempotencyStore) Delete(ctx context.Context, key string) error {
-	query := fmt.Sprintf(`DELETE FROM %s WHERE key = $1`, s.fullTableName())
+	tableQ := s.fullTableName()
+	query := `DELETE FROM ` + tableQ + ` WHERE key = $1`
 
 	_, err := s.db.ExecContext(ctx, query, key)
 	if err != nil {
@@ -272,10 +277,11 @@ func (s *IdempotencyStore) Delete(ctx context.Context, key string) error {
 func (s *IdempotencyStore) Cleanup(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)
 
-	query := fmt.Sprintf(`
-		DELETE FROM %s 
+	tableQ := s.fullTableName()
+	query := `
+		DELETE FROM ` + tableQ + ` 
 		WHERE processed_at < $1 OR expires_at < NOW()
-	`, s.fullTableName())
+	`
 
 	result, err := s.db.ExecContext(ctx, query, cutoff)
 	if err != nil {
@@ -293,7 +299,8 @@ func (s *IdempotencyStore) Cleanup(ctx context.Context, olderThan time.Duration)
 // Count returns the total number of records in the store.
 // Useful for testing and monitoring.
 func (s *IdempotencyStore) Count(ctx context.Context) (int64, error) {
-	query := fmt.Sprintf(`SELECT COUNT(*) FROM %s`, s.fullTableName())
+	tableQ := s.fullTableName()
+	query := `SELECT COUNT(*) FROM ` + tableQ
 
 	var count int64
 	err := s.db.QueryRowContext(ctx, query).Scan(&count)
@@ -307,7 +314,8 @@ func (s *IdempotencyStore) Count(ctx context.Context) (int64, error) {
 // Clear removes all records from the store.
 // Useful for testing.
 func (s *IdempotencyStore) Clear(ctx context.Context) error {
-	query := fmt.Sprintf(`TRUNCATE TABLE %s`, s.fullTableName())
+	tableQ := s.fullTableName()
+	query := `TRUNCATE TABLE ` + tableQ
 
 	_, err := s.db.ExecContext(ctx, query)
 	if err != nil {

--- a/adapters/postgres/idempotency_test.go
+++ b/adapters/postgres/idempotency_test.go
@@ -70,7 +70,7 @@ func TestIdempotencyStore_WithOptions(t *testing.T) {
 		store := NewIdempotencyStore(adapter.db,
 			WithIdempotencySchema("mink"),
 			WithIdempotencyTable("custom_idempotency"))
-		assert.Equal(t, "mink.custom_idempotency", store.fullTableName())
+		assert.Equal(t, `"mink"."custom_idempotency"`, store.fullTableName())
 	})
 }
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -239,11 +239,13 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 	}
 
 	// Create indexes
+	streamsTableQ := quoteQualifiedTable(a.schema, "streams")
+	eventsTableQ := quoteQualifiedTable(a.schema, "events")
 	indexes := []string{
-		`CREATE INDEX IF NOT EXISTS idx_streams_category ON ` + schemaQ + `.streams(category)`,
-		`CREATE INDEX IF NOT EXISTS idx_events_stream ON ` + schemaQ + `.events(stream_id, version)`,
-		`CREATE INDEX IF NOT EXISTS idx_events_type ON ` + schemaQ + `.events(event_type)`,
-		`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON ` + schemaQ + `.events(timestamp)`,
+		`CREATE INDEX IF NOT EXISTS idx_streams_category ON ` + streamsTableQ + `(category)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_stream ON ` + eventsTableQ + `(stream_id, version)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_type ON ` + eventsTableQ + `(event_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON ` + eventsTableQ + `(timestamp)`,
 	}
 
 	for _, idx := range indexes {

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -19,6 +19,19 @@ import (
 // alphanumeric characters and underscores.
 var schemaNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+// quoteIdentifier quotes a PostgreSQL identifier (schema, table, column name)
+// using double quotes. This prevents SQL injection by ensuring the identifier
+// is treated as a literal name, not as SQL syntax.
+// PostgreSQL identifier quoting: wrap in double quotes, escape internal quotes by doubling.
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// quoteQualifiedTable returns a properly quoted schema.table identifier.
+func quoteQualifiedTable(schema, table string) string {
+	return quoteIdentifier(schema) + "." + quoteIdentifier(table)
+}
+
 // validateSchemaName checks if the schema name is a valid PostgreSQL identifier.
 func validateSchemaName(schema string) error {
 	if schema == "" {
@@ -182,22 +195,24 @@ func (a *PostgresAdapter) Initialize(ctx context.Context) error {
 
 // Migrate runs database migrations.
 func (a *PostgresAdapter) Migrate(ctx context.Context) error {
+	schemaQ := quoteIdentifier(a.schema)
+
 	// Create schema
-	_, err := a.db.ExecContext(ctx, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, a.schema))
+	_, err := a.db.ExecContext(ctx, `CREATE SCHEMA IF NOT EXISTS `+schemaQ)
 	if err != nil {
 		return fmt.Errorf("mink/postgres: failed to create schema: %w", err)
 	}
 
 	// Create streams table
-	streamsSQL := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s.streams (
+	streamsSQL := `
+		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.streams (
 			id              BIGSERIAL PRIMARY KEY,
 			stream_id       VARCHAR(500) NOT NULL UNIQUE,
 			category        VARCHAR(250) NOT NULL,
 			version         BIGINT NOT NULL DEFAULT 0,
 			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`, a.schema)
+		)`
 
 	_, err = a.db.ExecContext(ctx, streamsSQL)
 	if err != nil {
@@ -205,8 +220,8 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 	}
 
 	// Create events table
-	eventsSQL := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s.events (
+	eventsSQL := `
+		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.events (
 			global_position BIGSERIAL PRIMARY KEY,
 			stream_id       VARCHAR(500) NOT NULL,
 			version         BIGINT NOT NULL,
@@ -216,7 +231,7 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 			metadata        JSONB,
 			timestamp       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			UNIQUE(stream_id, version)
-		)`, a.schema)
+		)`
 
 	_, err = a.db.ExecContext(ctx, eventsSQL)
 	if err != nil {
@@ -225,10 +240,10 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 
 	// Create indexes
 	indexes := []string{
-		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_streams_category ON %s.streams(category)`, a.schema),
-		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_events_stream ON %s.events(stream_id, version)`, a.schema),
-		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_events_type ON %s.events(event_type)`, a.schema),
-		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON %s.events(timestamp)`, a.schema),
+		`CREATE INDEX IF NOT EXISTS idx_streams_category ON ` + schemaQ + `.streams(category)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_stream ON ` + schemaQ + `.events(stream_id, version)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_type ON ` + schemaQ + `.events(event_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON ` + schemaQ + `.events(timestamp)`,
 	}
 
 	for _, idx := range indexes {
@@ -239,13 +254,13 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 	}
 
 	// Create snapshots table
-	snapshotsSQL := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s.snapshots (
+	snapshotsSQL := `
+		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.snapshots (
 			stream_id       VARCHAR(500) PRIMARY KEY,
 			version         BIGINT NOT NULL,
 			data            BYTEA NOT NULL,
 			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`, a.schema)
+		)`
 
 	_, err = a.db.ExecContext(ctx, snapshotsSQL)
 	if err != nil {
@@ -253,12 +268,12 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 	}
 
 	// Create checkpoints table
-	checkpointsSQL := fmt.Sprintf(`
-		CREATE TABLE IF NOT EXISTS %s.checkpoints (
+	checkpointsSQL := `
+		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.checkpoints (
 			projection_name VARCHAR(500) PRIMARY KEY,
 			position        BIGINT NOT NULL DEFAULT 0,
 			updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`, a.schema)
+		)`
 
 	_, err = a.db.ExecContext(ctx, checkpointsSQL)
 	if err != nil {
@@ -272,11 +287,11 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 func (a *PostgresAdapter) MigrationVersion(ctx context.Context) (int, error) {
 	// For now, return 1 if tables exist
 	var exists bool
-	err := a.db.QueryRowContext(ctx, fmt.Sprintf(`
+	err := a.db.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT FROM information_schema.tables 
-			WHERE table_schema = '%s' AND table_name = 'events'
-		)`, a.schema)).Scan(&exists)
+			WHERE table_schema = $1 AND table_name = 'events'
+		)`, a.schema).Scan(&exists)
 
 	if err != nil {
 		return 0, err
@@ -311,11 +326,12 @@ func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []
 	// Get current stream version with lock
 	var currentVersion int64
 	var streamExists bool
+	schemaQ := quoteIdentifier(a.schema)
 
-	err = tx.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT version FROM %s.streams 
+	err = tx.QueryRowContext(ctx, `
+		SELECT version FROM `+schemaQ+`.streams 
 		WHERE stream_id = $1 
-		FOR UPDATE`, a.schema), streamID).Scan(&currentVersion)
+		FOR UPDATE`, streamID).Scan(&currentVersion)
 
 	if err == sql.ErrNoRows {
 		streamExists = false
@@ -334,9 +350,9 @@ func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []
 	// Create stream if it doesn't exist
 	category := extractCategory(streamID)
 	if !streamExists {
-		_, err = tx.ExecContext(ctx, fmt.Sprintf(`
-			INSERT INTO %s.streams (stream_id, category, version)
-			VALUES ($1, $2, 0)`, a.schema), streamID, category)
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO `+schemaQ+`.streams (stream_id, category, version)
+			VALUES ($1, $2, 0)`, streamID, category)
 		if err != nil {
 			return nil, fmt.Errorf("mink/postgres: failed to create stream: %w", err)
 		}
@@ -356,10 +372,10 @@ func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []
 		var eventID string
 		var timestamp time.Time
 
-		err = tx.QueryRowContext(ctx, fmt.Sprintf(`
-			INSERT INTO %s.events (stream_id, version, event_type, data, metadata)
+		err = tx.QueryRowContext(ctx, `
+			INSERT INTO `+schemaQ+`.events (stream_id, version, event_type, data, metadata)
 			VALUES ($1, $2, $3, $4, $5)
-			RETURNING global_position, event_id, timestamp`, a.schema),
+			RETURNING global_position, event_id, timestamp`,
 			streamID, currentVersion, event.Type, event.Data, metadataJSON,
 		).Scan(&globalPosition, &eventID, &timestamp)
 
@@ -380,10 +396,10 @@ func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []
 	}
 
 	// Update stream version
-	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
-		UPDATE %s.streams 
+	_, err = tx.ExecContext(ctx, `
+		UPDATE `+schemaQ+`.streams 
 		SET version = $1, updated_at = NOW()
-		WHERE stream_id = $2`, a.schema), currentVersion, streamID)
+		WHERE stream_id = $2`, currentVersion, streamID)
 	if err != nil {
 		return nil, fmt.Errorf("mink/postgres: failed to update stream version: %w", err)
 	}
@@ -405,11 +421,12 @@ func (a *PostgresAdapter) Load(ctx context.Context, streamID string, fromVersion
 		return nil, ErrEmptyStreamID
 	}
 
-	rows, err := a.db.QueryContext(ctx, fmt.Sprintf(`
+	schemaQ := quoteIdentifier(a.schema)
+	rows, err := a.db.QueryContext(ctx, `
 		SELECT global_position, event_id, stream_id, version, event_type, data, metadata, timestamp
-		FROM %s.events
+		FROM `+schemaQ+`.events
 		WHERE stream_id = $1 AND version > $2
-		ORDER BY version`, a.schema), streamID, fromVersion)
+		ORDER BY version`, streamID, fromVersion)
 	if err != nil {
 		return nil, fmt.Errorf("mink/postgres: failed to load events: %w", err)
 	}
@@ -456,13 +473,14 @@ func (a *PostgresAdapter) GetStreamInfo(ctx context.Context, streamID string) (*
 		return nil, ErrAdapterClosed
 	}
 
+	schemaQ := quoteIdentifier(a.schema)
 	var info adapters.StreamInfo
 	// Query stream info and count events in one query using a subquery
-	err := a.db.QueryRowContext(ctx, fmt.Sprintf(`
+	err := a.db.QueryRowContext(ctx, `
 		SELECT s.stream_id, s.category, s.version, s.created_at, s.updated_at,
-		       (SELECT COUNT(*) FROM %s.events e WHERE e.stream_id = s.stream_id) as event_count
-		FROM %s.streams s
-		WHERE s.stream_id = $1`, a.schema, a.schema), streamID).Scan(
+		       (SELECT COUNT(*) FROM `+schemaQ+`.events e WHERE e.stream_id = s.stream_id) as event_count
+		FROM `+schemaQ+`.streams s
+		WHERE s.stream_id = $1`, streamID).Scan(
 		&info.StreamID,
 		&info.Category,
 		&info.Version,
@@ -487,9 +505,10 @@ func (a *PostgresAdapter) GetLastPosition(ctx context.Context) (uint64, error) {
 		return 0, ErrAdapterClosed
 	}
 
+	schemaQ := quoteIdentifier(a.schema)
 	var pos sql.NullInt64
-	err := a.db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT MAX(global_position) FROM %s.events`, a.schema)).Scan(&pos)
+	err := a.db.QueryRowContext(ctx, `
+		SELECT MAX(global_position) FROM `+schemaQ+`.events`).Scan(&pos)
 	if err != nil {
 		return 0, fmt.Errorf("mink/postgres: failed to get last position: %w", err)
 	}
@@ -520,13 +539,14 @@ func (a *PostgresAdapter) SaveSnapshot(ctx context.Context, streamID string, ver
 		return ErrAdapterClosed
 	}
 
-	_, err := a.db.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s.snapshots (stream_id, version, data)
+	schemaQ := quoteIdentifier(a.schema)
+	_, err := a.db.ExecContext(ctx, `
+		INSERT INTO `+schemaQ+`.snapshots (stream_id, version, data)
 		VALUES ($1, $2, $3)
 		ON CONFLICT (stream_id) DO UPDATE SET
 			version = EXCLUDED.version,
 			data = EXCLUDED.data,
-			created_at = NOW()`, a.schema), streamID, version, data)
+			created_at = NOW()`, streamID, version, data)
 	if err != nil {
 		return fmt.Errorf("mink/postgres: failed to save snapshot: %w", err)
 	}
@@ -540,11 +560,12 @@ func (a *PostgresAdapter) LoadSnapshot(ctx context.Context, streamID string) (*a
 		return nil, ErrAdapterClosed
 	}
 
+	schemaQ := quoteIdentifier(a.schema)
 	var snapshot adapters.SnapshotRecord
-	err := a.db.QueryRowContext(ctx, fmt.Sprintf(`
+	err := a.db.QueryRowContext(ctx, `
 		SELECT stream_id, version, data
-		FROM %s.snapshots
-		WHERE stream_id = $1`, a.schema), streamID).Scan(
+		FROM `+schemaQ+`.snapshots
+		WHERE stream_id = $1`, streamID).Scan(
 		&snapshot.StreamID,
 		&snapshot.Version,
 		&snapshot.Data,
@@ -566,8 +587,9 @@ func (a *PostgresAdapter) DeleteSnapshot(ctx context.Context, streamID string) e
 		return ErrAdapterClosed
 	}
 
-	_, err := a.db.ExecContext(ctx, fmt.Sprintf(`
-		DELETE FROM %s.snapshots WHERE stream_id = $1`, a.schema), streamID)
+	schemaQ := quoteIdentifier(a.schema)
+	_, err := a.db.ExecContext(ctx, `
+		DELETE FROM `+schemaQ+`.snapshots WHERE stream_id = $1`, streamID)
 	if err != nil {
 		return fmt.Errorf("mink/postgres: failed to delete snapshot: %w", err)
 	}
@@ -581,10 +603,11 @@ func (a *PostgresAdapter) GetCheckpoint(ctx context.Context, projectionName stri
 		return 0, ErrAdapterClosed
 	}
 
+	schemaQ := quoteIdentifier(a.schema)
 	var pos sql.NullInt64
-	err := a.db.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT position FROM %s.checkpoints
-		WHERE projection_name = $1`, a.schema), projectionName).Scan(&pos)
+	err := a.db.QueryRowContext(ctx, `
+		SELECT position FROM `+schemaQ+`.checkpoints
+		WHERE projection_name = $1`, projectionName).Scan(&pos)
 
 	if err == sql.ErrNoRows {
 		return 0, nil
@@ -610,12 +633,13 @@ func (a *PostgresAdapter) SetCheckpoint(ctx context.Context, projectionName stri
 		return ErrAdapterClosed
 	}
 
-	_, err := a.db.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s.checkpoints (projection_name, position)
+	schemaQ := quoteIdentifier(a.schema)
+	_, err := a.db.ExecContext(ctx, `
+		INSERT INTO `+schemaQ+`.checkpoints (projection_name, position)
 		VALUES ($1, $2)
 		ON CONFLICT (projection_name) DO UPDATE SET
 			position = EXCLUDED.position,
-			updated_at = NOW()`, a.schema), projectionName, position)
+			updated_at = NOW()`, projectionName, position)
 	if err != nil {
 		return fmt.Errorf("mink/postgres: failed to set checkpoint: %w", err)
 	}

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1152,7 +1152,10 @@ func BenchmarkPostgresAdapter_Load(b *testing.B) {
 
 	schema := newTestSchema()
 	defer func() {
-		schemaQ := quoteIdentifier(schema)
+		schemaQ, err := safeSchemaIdentifier(schema)
+		if err != nil {
+			return
+		}
 		_, _ = db.Exec(`DROP SCHEMA IF EXISTS ` + schemaQ + ` CASCADE`)
 	}()
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -56,11 +56,14 @@ func newTestAdapter(t *testing.T, db *sql.DB, opts ...Option) *PostgresAdapter {
 
 // cleanupSchema drops the test schema.
 func cleanupSchema(t *testing.T, db *sql.DB, schema string) {
-	_, err := db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+	schemaQ := quoteIdentifier(schema)
+	_, err := db.Exec(`DROP SCHEMA IF EXISTS ` + schemaQ + ` CASCADE`)
 	require.NoError(t, err)
 }
 
 // newTestSchema creates a unique test schema name.
+// The generated names contain only alphanumeric characters and underscores,
+// making them safe for use in SQL queries.
 func newTestSchema() string {
 	return fmt.Sprintf("test_%d", time.Now().UnixNano())
 }
@@ -895,7 +898,8 @@ func BenchmarkPostgresAdapter_Append(b *testing.B) {
 
 	schema := newTestSchema()
 	defer func() {
-		_, _ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+		schemaQ := quoteIdentifier(schema)
+		_, _ = db.Exec(`DROP SCHEMA IF EXISTS ` + schemaQ + ` CASCADE`)
 	}()
 
 	adapter, err := NewAdapterWithDB(db, WithSchema(schema))
@@ -925,7 +929,8 @@ func BenchmarkPostgresAdapter_Load(b *testing.B) {
 
 	schema := newTestSchema()
 	defer func() {
-		_, _ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+		schemaQ := quoteIdentifier(schema)
+		_, _ = db.Exec(`DROP SCHEMA IF EXISTS ` + schemaQ + ` CASCADE`)
 	}()
 
 	adapter, err := NewAdapterWithDB(db, WithSchema(schema))

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1118,7 +1118,10 @@ func BenchmarkPostgresAdapter_Append(b *testing.B) {
 
 	schema := newTestSchema()
 	defer func() {
-		schemaQ := quoteIdentifier(schema)
+		schemaQ, err := safeSchemaIdentifier(schema)
+		if err != nil {
+			return
+		}
 		_, _ = db.Exec(`DROP SCHEMA IF EXISTS ` + schemaQ + ` CASCADE`)
 	}()
 

--- a/adapters/postgres/subscription.go
+++ b/adapters/postgres/subscription.go
@@ -68,12 +68,13 @@ func (a *PostgresAdapter) LoadFromPosition(ctx context.Context, fromPosition uin
 		limit = 1000
 	}
 
-	query := fmt.Sprintf(`
+	schemaQ := quoteIdentifier(a.schema)
+	query := `
 		SELECT event_id, stream_id, version, event_type, data, metadata, global_position, timestamp
-		FROM %s.events
+		FROM ` + schemaQ + `.events
 		WHERE global_position > $1
 		ORDER BY global_position ASC
-		LIMIT $2`, a.schema)
+		LIMIT $2`
 
 	rows, err := a.db.QueryContext(ctx, query, fromPosition, limit)
 	if err != nil {
@@ -297,12 +298,13 @@ func (a *PostgresAdapter) SubscribeCategory(ctx context.Context, category string
 
 // loadCategoryEvents loads events for a specific category from a position.
 func (a *PostgresAdapter) loadCategoryEvents(ctx context.Context, category string, fromPosition uint64, limit int) ([]adapters.StoredEvent, error) {
-	query := fmt.Sprintf(`
+	schemaQ := quoteIdentifier(a.schema)
+	query := `
 		SELECT event_id, stream_id, version, event_type, data, metadata, global_position, timestamp
-		FROM %s.events
+		FROM ` + schemaQ + `.events
 		WHERE global_position > $1 AND stream_id LIKE $2
 		ORDER BY global_position ASC
-		LIMIT $3`, a.schema)
+		LIMIT $3`
 
 	rows, err := a.db.QueryContext(ctx, query, fromPosition, category+"-%", limit)
 	if err != nil {

--- a/adapters/postgres/subscription.go
+++ b/adapters/postgres/subscription.go
@@ -68,7 +68,10 @@ func (a *PostgresAdapter) LoadFromPosition(ctx context.Context, fromPosition uin
 		limit = 1000
 	}
 
-	schemaQ := quoteIdentifier(a.schema)
+	schemaQ, err := safeSchemaIdentifier(a.schema)
+	if err != nil {
+		return nil, fmt.Errorf("mink/postgres: invalid schema: %w", err)
+	}
 	query := `
 		SELECT event_id, stream_id, version, event_type, data, metadata, global_position, timestamp
 		FROM ` + schemaQ + `.events
@@ -298,7 +301,10 @@ func (a *PostgresAdapter) SubscribeCategory(ctx context.Context, category string
 
 // loadCategoryEvents loads events for a specific category from a position.
 func (a *PostgresAdapter) loadCategoryEvents(ctx context.Context, category string, fromPosition uint64, limit int) ([]adapters.StoredEvent, error) {
-	schemaQ := quoteIdentifier(a.schema)
+	schemaQ, err := safeSchemaIdentifier(a.schema)
+	if err != nil {
+		return nil, fmt.Errorf("mink/postgres: invalid schema: %w", err)
+	}
 	query := `
 		SELECT event_id, stream_id, version, event_type, data, metadata, global_position, timestamp
 		FROM ` + schemaQ + `.events


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request focuses on improving SQL safety and maintainability in the Postgres adapter by introducing proper quoting for schema and table identifiers, reducing SQL injection risks, and refactoring SQL statement construction. It also updates GitHub Actions workflow steps to use pinned commit SHAs for third-party actions, enhancing CI security and reproducibility.

**Postgres Adapter: SQL Safety and Refactoring**

* Added `quoteIdentifier` and `quoteQualifiedTable` helper functions to safely quote schema and table names, preventing SQL injection and syntax errors. (`adapters/postgres/postgres.go`)
* Refactored all raw SQL statements in the Postgres adapter and idempotency store to use these quoting helpers, replacing most `fmt.Sprintf` usages and string interpolation for schema/table names with safe, quoted identifiers. [[1]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L80-R82) [[2]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L95-R97) [[3]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L108-R111) [[4]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L122-R129) [[5]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L151-R155) [[6]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L164-R167) [[7]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L207-R215) [[8]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L260-R265) [[9]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L275-R284) [[10]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L296-R303) [[11]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L310-R318) [[12]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79R198-R224) [[13]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L219-R234) [[14]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L228-R246) [[15]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L242-R276) [[16]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L275-R294) [[17]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79R329-R334) [[18]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L337-R355) [[19]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L359-R378) [[20]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L383-R402) [[21]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L408-R429) [[22]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79R476-R483) [[23]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79R508-R511)

**CI/CD Workflow Security Improvements**

* Updated GitHub Actions workflow files to pin third-party actions (`ruby/setup-ruby`, `softprops/action-gh-release`, `codecov/codecov-action`, `golangci/golangci-lint-action`) to specific commit SHAs, ensuring builds use known, trusted versions and improving CI security. (`.github/workflows/docs.yml`, `.github/workflows/release.yml`, `.github/workflows/test.yml`) [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL30-R30) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L99-R99) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L59-R59) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L93-R93)

## Changes
<!-- List of changes -->
- 
- 

## Testing
<!-- How did you test this? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [ ] Code comments added
- [ ] README updated (if applicable)
- [ ] API docs updated

## Checklist
- [ ] Code follows project style guidelines
- [ ] All tests pass
- [ ] No breaking changes (or documented if intentional)
