### PR TITLE
refactor: replace local error definitions with adapters package aliases for consistency and maintainability

### DIFF
--- a/adapters/common.go
+++ b/adapters/common.go
@@ -1,0 +1,151 @@
+// Package adapters provides interfaces and shared utilities for event store backends.
+package adapters
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Version constants for optimistic concurrency control.
+// These constants define special version values used in Append operations.
+const (
+	// AnyVersion skips version checking. Use when you don't care about concurrent modifications.
+	AnyVersion int64 = -1
+
+	// NoStream requires the stream to not exist. Use for creating new streams.
+	NoStream int64 = 0
+
+	// StreamExists requires the stream to exist. Use when you expect to append to an existing stream.
+	StreamExists int64 = -2
+)
+
+// ExtractCategory extracts the category from a stream ID.
+// Stream IDs are expected to follow the format "Category-ID" (e.g., "Order-123").
+// The category is the portion before the first hyphen.
+//
+// Behavior:
+//   - "Order-123" returns "Order"
+//   - "User-abc-def" returns "User" (only splits on first hyphen)
+//   - "NoHyphen" returns "NoHyphen" (entire ID if no hyphen)
+//   - "" returns "" (empty string for empty input)
+func ExtractCategory(streamID string) string {
+	if streamID == "" {
+		return ""
+	}
+	parts := strings.SplitN(streamID, "-", 2)
+	return parts[0]
+}
+
+// ConcurrencyError provides details about a concurrency conflict.
+// It is returned when an optimistic concurrency check fails during Append operations.
+type ConcurrencyError struct {
+	StreamID        string
+	ExpectedVersion int64
+	ActualVersion   int64
+}
+
+// NewConcurrencyError creates a new ConcurrencyError.
+func NewConcurrencyError(streamID string, expected, actual int64) *ConcurrencyError {
+	return &ConcurrencyError{
+		StreamID:        streamID,
+		ExpectedVersion: expected,
+		ActualVersion:   actual,
+	}
+}
+
+// Error implements the error interface.
+func (e *ConcurrencyError) Error() string {
+	return fmt.Sprintf("mink: concurrency conflict on stream %q: expected version %d, got %d",
+		e.StreamID, e.ExpectedVersion, e.ActualVersion)
+}
+
+// Is implements errors.Is compatibility.
+// Returns true when compared with ErrConcurrencyConflict.
+func (e *ConcurrencyError) Is(target error) bool {
+	return target == ErrConcurrencyConflict
+}
+
+// StreamNotFoundError provides details about a missing stream.
+// It is returned when an operation requires an existing stream that doesn't exist.
+type StreamNotFoundError struct {
+	StreamID string
+}
+
+// NewStreamNotFoundError creates a new StreamNotFoundError.
+func NewStreamNotFoundError(streamID string) *StreamNotFoundError {
+	return &StreamNotFoundError{StreamID: streamID}
+}
+
+// Error implements the error interface.
+func (e *StreamNotFoundError) Error() string {
+	return fmt.Sprintf("mink: stream %q not found", e.StreamID)
+}
+
+// Is implements errors.Is compatibility.
+// Returns true when compared with ErrStreamNotFound.
+func (e *StreamNotFoundError) Is(target error) bool {
+	return target == ErrStreamNotFound
+}
+
+// CheckVersion validates the expected version against the current version.
+// This implements the optimistic concurrency control logic shared by all adapters.
+//
+// Parameters:
+//   - streamID: The stream identifier (used for error messages)
+//   - expected: The expected version (can be AnyVersion, NoStream, StreamExists, or a positive version)
+//   - current: The current version of the stream
+//   - exists: Whether the stream currently exists
+//
+// Returns nil if the version check passes, or an appropriate error otherwise.
+func CheckVersion(streamID string, expected, current int64, exists bool) error {
+	switch expected {
+	case AnyVersion:
+		return nil
+	case NoStream:
+		if exists {
+			return NewConcurrencyError(streamID, expected, current)
+		}
+		return nil
+	case StreamExists:
+		if !exists {
+			return NewStreamNotFoundError(streamID)
+		}
+		return nil
+	default:
+		if expected < 0 {
+			return ErrInvalidVersion
+		}
+		if current != expected {
+			return NewConcurrencyError(streamID, expected, current)
+		}
+		return nil
+	}
+}
+
+// CopyIdempotencyRecord creates a deep copy of an IdempotencyRecord.
+// This is useful to avoid external mutations of stored records.
+func CopyIdempotencyRecord(record *IdempotencyRecord) *IdempotencyRecord {
+	if record == nil {
+		return nil
+	}
+	return &IdempotencyRecord{
+		Key:         record.Key,
+		CommandType: record.CommandType,
+		AggregateID: record.AggregateID,
+		Version:     record.Version,
+		Response:    record.Response,
+		Success:     record.Success,
+		Error:       record.Error,
+		ProcessedAt: record.ProcessedAt,
+		ExpiresAt:   record.ExpiresAt,
+	}
+}
+
+// DefaultLimit returns a default limit value if the provided limit is invalid.
+// Used for pagination in LoadFromPosition and similar methods.
+func DefaultLimit(limit, defaultValue int) int {
+	if limit <= 0 {
+		return defaultValue
+	}
+	return limit
+}

--- a/adapters/common_test.go
+++ b/adapters/common_test.go
@@ -1,0 +1,384 @@
+package adapters
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionConstants(t *testing.T) {
+	t.Run("version constants have expected values", func(t *testing.T) {
+		assert.Equal(t, int64(-1), AnyVersion)
+		assert.Equal(t, int64(0), NoStream)
+		assert.Equal(t, int64(-2), StreamExists)
+	})
+}
+
+func TestExtractCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		streamID string
+		expected string
+	}{
+		{
+			name:     "standard format Order-123",
+			streamID: "Order-123",
+			expected: "Order",
+		},
+		{
+			name:     "standard format User-abc",
+			streamID: "User-abc",
+			expected: "User",
+		},
+		{
+			name:     "multiple hyphens takes first part",
+			streamID: "User-abc-def-ghi",
+			expected: "User",
+		},
+		{
+			name:     "no hyphen returns entire ID",
+			streamID: "SingleWord",
+			expected: "SingleWord",
+		},
+		{
+			name:     "empty string returns empty",
+			streamID: "",
+			expected: "",
+		},
+		{
+			name:     "starts with hyphen returns empty",
+			streamID: "-StartsWithHyphen",
+			expected: "",
+		},
+		{
+			name:     "ends with hyphen",
+			streamID: "EndsWithHyphen-",
+			expected: "EndsWithHyphen",
+		},
+		{
+			name:     "only hyphen",
+			streamID: "-",
+			expected: "",
+		},
+		{
+			name:     "numeric category",
+			streamID: "123-456",
+			expected: "123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractCategory(tt.streamID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConcurrencyError(t *testing.T) {
+	t.Run("NewConcurrencyError creates error with correct fields", func(t *testing.T) {
+		err := NewConcurrencyError("Order-123", 5, 3)
+
+		assert.Equal(t, "Order-123", err.StreamID)
+		assert.Equal(t, int64(5), err.ExpectedVersion)
+		assert.Equal(t, int64(3), err.ActualVersion)
+	})
+
+	t.Run("Error method returns formatted message", func(t *testing.T) {
+		err := NewConcurrencyError("Order-123", 5, 3)
+
+		expected := `mink: concurrency conflict on stream "Order-123": expected version 5, got 3`
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("Is returns true for ErrConcurrencyConflict", func(t *testing.T) {
+		err := NewConcurrencyError("Order-123", 5, 3)
+
+		assert.True(t, errors.Is(err, ErrConcurrencyConflict))
+	})
+
+	t.Run("Is returns false for other errors", func(t *testing.T) {
+		err := NewConcurrencyError("Order-123", 5, 3)
+
+		assert.False(t, errors.Is(err, ErrStreamNotFound))
+		assert.False(t, errors.Is(err, ErrEmptyStreamID))
+		assert.False(t, errors.Is(err, ErrNoEvents))
+	})
+
+	t.Run("works with NoStream expected version", func(t *testing.T) {
+		err := NewConcurrencyError("Order-123", NoStream, 1)
+
+		assert.Contains(t, err.Error(), "expected version 0")
+	})
+
+	t.Run("works with StreamExists expected version", func(t *testing.T) {
+		err := NewConcurrencyError("Order-123", StreamExists, 0)
+
+		assert.Contains(t, err.Error(), "expected version -2")
+	})
+}
+
+func TestStreamNotFoundError(t *testing.T) {
+	t.Run("NewStreamNotFoundError creates error with correct field", func(t *testing.T) {
+		err := NewStreamNotFoundError("Order-123")
+
+		assert.Equal(t, "Order-123", err.StreamID)
+	})
+
+	t.Run("Error method returns formatted message", func(t *testing.T) {
+		err := NewStreamNotFoundError("Order-123")
+
+		expected := `mink: stream "Order-123" not found`
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("Is returns true for ErrStreamNotFound", func(t *testing.T) {
+		err := NewStreamNotFoundError("Order-123")
+
+		assert.True(t, errors.Is(err, ErrStreamNotFound))
+	})
+
+	t.Run("Is returns false for other errors", func(t *testing.T) {
+		err := NewStreamNotFoundError("Order-123")
+
+		assert.False(t, errors.Is(err, ErrConcurrencyConflict))
+		assert.False(t, errors.Is(err, ErrEmptyStreamID))
+		assert.False(t, errors.Is(err, ErrNoEvents))
+	})
+
+	t.Run("handles empty stream ID", func(t *testing.T) {
+		err := NewStreamNotFoundError("")
+
+		assert.Contains(t, err.Error(), `stream ""`)
+	})
+}
+
+func TestCheckVersion(t *testing.T) {
+	t.Run("AnyVersion always succeeds", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			current int64
+			exists  bool
+		}{
+			{"stream exists with version 0", 0, true},
+			{"stream exists with version 5", 5, true},
+			{"stream does not exist", 0, false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := CheckVersion("Order-123", AnyVersion, tt.current, tt.exists)
+				assert.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("NoStream succeeds when stream does not exist", func(t *testing.T) {
+		err := CheckVersion("Order-123", NoStream, 0, false)
+		assert.NoError(t, err)
+	})
+
+	t.Run("NoStream fails when stream exists", func(t *testing.T) {
+		err := CheckVersion("Order-123", NoStream, 5, true)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrConcurrencyConflict))
+
+		var concErr *ConcurrencyError
+		require.True(t, errors.As(err, &concErr))
+		assert.Equal(t, "Order-123", concErr.StreamID)
+		assert.Equal(t, NoStream, concErr.ExpectedVersion)
+		assert.Equal(t, int64(5), concErr.ActualVersion)
+	})
+
+	t.Run("StreamExists succeeds when stream exists", func(t *testing.T) {
+		err := CheckVersion("Order-123", StreamExists, 5, true)
+		assert.NoError(t, err)
+	})
+
+	t.Run("StreamExists fails when stream does not exist", func(t *testing.T) {
+		err := CheckVersion("Order-123", StreamExists, 0, false)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrStreamNotFound))
+
+		var notFoundErr *StreamNotFoundError
+		require.True(t, errors.As(err, &notFoundErr))
+		assert.Equal(t, "Order-123", notFoundErr.StreamID)
+	})
+
+	t.Run("positive version succeeds when current matches expected", func(t *testing.T) {
+		err := CheckVersion("Order-123", 5, 5, true)
+		assert.NoError(t, err)
+	})
+
+	t.Run("positive version fails when current differs from expected", func(t *testing.T) {
+		err := CheckVersion("Order-123", 5, 3, true)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrConcurrencyConflict))
+
+		var concErr *ConcurrencyError
+		require.True(t, errors.As(err, &concErr))
+		assert.Equal(t, int64(5), concErr.ExpectedVersion)
+		assert.Equal(t, int64(3), concErr.ActualVersion)
+	})
+
+	t.Run("negative version other than AnyVersion/NoStream/StreamExists returns ErrInvalidVersion", func(t *testing.T) {
+		invalidVersions := []int64{-3, -4, -10, -100}
+
+		for _, v := range invalidVersions {
+			err := CheckVersion("Order-123", v, 5, true)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidVersion))
+		}
+	})
+
+	t.Run("version 1 succeeds when stream has version 1", func(t *testing.T) {
+		err := CheckVersion("Order-123", 1, 1, true)
+		assert.NoError(t, err)
+	})
+
+	t.Run("version 1 fails when stream has version 0", func(t *testing.T) {
+		err := CheckVersion("Order-123", 1, 0, true)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrConcurrencyConflict))
+	})
+}
+
+func TestCopyIdempotencyRecord(t *testing.T) {
+	t.Run("returns nil for nil input", func(t *testing.T) {
+		result := CopyIdempotencyRecord(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("creates deep copy of record", func(t *testing.T) {
+		original := &IdempotencyRecord{
+			Key:         "test-key",
+			CommandType: "CreateOrder",
+			AggregateID: "Order-123",
+			Version:     5,
+			Response:    []byte(`{"result":"success"}`),
+			Success:     true,
+			Error:       "",
+			ProcessedAt: time.Now(),
+			ExpiresAt:   time.Now().Add(time.Hour),
+		}
+
+		copied := CopyIdempotencyRecord(original)
+
+		// Verify all fields are copied
+		assert.Equal(t, original.Key, copied.Key)
+		assert.Equal(t, original.CommandType, copied.CommandType)
+		assert.Equal(t, original.AggregateID, copied.AggregateID)
+		assert.Equal(t, original.Version, copied.Version)
+		assert.Equal(t, original.Response, copied.Response)
+		assert.Equal(t, original.Success, copied.Success)
+		assert.Equal(t, original.Error, copied.Error)
+		assert.Equal(t, original.ProcessedAt, copied.ProcessedAt)
+		assert.Equal(t, original.ExpiresAt, copied.ExpiresAt)
+
+		// Verify it's a different pointer
+		assert.NotSame(t, original, copied)
+	})
+
+	t.Run("modifications to copy do not affect original", func(t *testing.T) {
+		original := &IdempotencyRecord{
+			Key:     "test-key",
+			Version: 5,
+		}
+
+		copied := CopyIdempotencyRecord(original)
+		copied.Key = "modified-key"
+		copied.Version = 10
+
+		assert.Equal(t, "test-key", original.Key)
+		assert.Equal(t, int64(5), original.Version)
+	})
+
+	t.Run("copies record with error", func(t *testing.T) {
+		original := &IdempotencyRecord{
+			Key:     "test-key",
+			Success: false,
+			Error:   "something went wrong",
+		}
+
+		copied := CopyIdempotencyRecord(original)
+
+		assert.False(t, copied.Success)
+		assert.Equal(t, "something went wrong", copied.Error)
+	})
+
+	t.Run("copies record with empty fields", func(t *testing.T) {
+		original := &IdempotencyRecord{
+			Key: "minimal-key",
+		}
+
+		copied := CopyIdempotencyRecord(original)
+
+		assert.Equal(t, "minimal-key", copied.Key)
+		assert.Empty(t, copied.CommandType)
+		assert.Empty(t, copied.AggregateID)
+		assert.Equal(t, int64(0), copied.Version)
+		assert.Nil(t, copied.Response)
+	})
+}
+
+func TestDefaultLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		limit        int
+		defaultValue int
+		expected     int
+	}{
+		{
+			name:         "zero limit returns default",
+			limit:        0,
+			defaultValue: 100,
+			expected:     100,
+		},
+		{
+			name:         "negative limit returns default",
+			limit:        -1,
+			defaultValue: 100,
+			expected:     100,
+		},
+		{
+			name:         "very negative limit returns default",
+			limit:        -1000,
+			defaultValue: 50,
+			expected:     50,
+		},
+		{
+			name:         "positive limit is used",
+			limit:        50,
+			defaultValue: 100,
+			expected:     50,
+		},
+		{
+			name:         "limit of 1 is used",
+			limit:        1,
+			defaultValue: 100,
+			expected:     1,
+		},
+		{
+			name:         "large limit is used",
+			limit:        10000,
+			defaultValue: 100,
+			expected:     10000,
+		},
+		{
+			name:         "zero default with zero limit returns zero",
+			limit:        0,
+			defaultValue: 0,
+			expected:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DefaultLimit(tt.limit, tt.defaultValue)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/adapters/memory/errors.go
+++ b/adapters/memory/errors.go
@@ -1,79 +1,39 @@
 package memory
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/AshkanYarmoradi/go-mink/adapters"
 )
 
 // Sentinel errors for the memory adapter.
-// These are local errors that are compatible with the adapters package errors via errors.Is().
+// These are aliases to the adapters package errors for compatibility with errors.Is().
 var (
 	// ErrAdapterClosed is returned when an operation is attempted on a closed adapter.
-	ErrAdapterClosed = errors.New("mink/memory: adapter is closed")
+	ErrAdapterClosed = adapters.ErrAdapterClosed
 
 	// ErrEmptyStreamID is returned when an empty stream ID is provided.
-	ErrEmptyStreamID = errors.New("mink/memory: stream ID is required")
+	ErrEmptyStreamID = adapters.ErrEmptyStreamID
 
 	// ErrNoEvents is returned when attempting to append zero events.
-	ErrNoEvents = errors.New("mink/memory: no events to append")
+	ErrNoEvents = adapters.ErrNoEvents
 
 	// ErrConcurrencyConflict is returned when optimistic concurrency check fails.
-	ErrConcurrencyConflict = errors.New("mink/memory: concurrency conflict")
+	ErrConcurrencyConflict = adapters.ErrConcurrencyConflict
 
 	// ErrStreamNotFound is returned when a stream does not exist.
-	ErrStreamNotFound = errors.New("mink/memory: stream not found")
+	ErrStreamNotFound = adapters.ErrStreamNotFound
 
 	// ErrInvalidVersion is returned when an invalid version is specified.
-	ErrInvalidVersion = errors.New("mink/memory: invalid version")
+	ErrInvalidVersion = adapters.ErrInvalidVersion
 )
 
-// ConcurrencyError provides details about a concurrency conflict.
-type ConcurrencyError struct {
-	StreamID        string
-	ExpectedVersion int64
-	ActualVersion   int64
-}
+// ConcurrencyError is an alias for adapters.ConcurrencyError for backward compatibility.
+type ConcurrencyError = adapters.ConcurrencyError
 
-// NewConcurrencyError creates a new ConcurrencyError.
-func NewConcurrencyError(streamID string, expected, actual int64) *ConcurrencyError {
-	return &ConcurrencyError{
-		StreamID:        streamID,
-		ExpectedVersion: expected,
-		ActualVersion:   actual,
-	}
-}
+// StreamNotFoundError is an alias for adapters.StreamNotFoundError for backward compatibility.
+type StreamNotFoundError = adapters.StreamNotFoundError
 
-// Error implements the error interface.
-func (e *ConcurrencyError) Error() string {
-	return fmt.Sprintf("mink/memory: concurrency conflict on stream %q: expected version %d, got %d",
-		e.StreamID, e.ExpectedVersion, e.ActualVersion)
-}
+// NewConcurrencyError is an alias for adapters.NewConcurrencyError for backward compatibility.
+var NewConcurrencyError = adapters.NewConcurrencyError
 
-// Is implements errors.Is compatibility.
-// Returns true for both local ErrConcurrencyConflict and adapters.ErrConcurrencyConflict.
-func (e *ConcurrencyError) Is(target error) bool {
-	return target == ErrConcurrencyConflict || target == adapters.ErrConcurrencyConflict
-}
-
-// StreamNotFoundError provides details about a missing stream.
-type StreamNotFoundError struct {
-	StreamID string
-}
-
-// NewStreamNotFoundError creates a new StreamNotFoundError.
-func NewStreamNotFoundError(streamID string) *StreamNotFoundError {
-	return &StreamNotFoundError{StreamID: streamID}
-}
-
-// Error implements the error interface.
-func (e *StreamNotFoundError) Error() string {
-	return fmt.Sprintf("mink/memory: stream %q not found", e.StreamID)
-}
-
-// Is implements errors.Is compatibility.
-// Returns true for both local ErrStreamNotFound and adapters.ErrStreamNotFound.
-func (e *StreamNotFoundError) Is(target error) bool {
-	return target == ErrStreamNotFound || target == adapters.ErrStreamNotFound
-}
+// NewStreamNotFoundError is an alias for adapters.NewStreamNotFoundError for backward compatibility.
+var NewStreamNotFoundError = adapters.NewStreamNotFoundError

--- a/adapters/memory/idempotency.go
+++ b/adapters/memory/idempotency.go
@@ -126,19 +126,7 @@ func (s *IdempotencyStore) Store(ctx context.Context, record *adapters.Idempoten
 	defer s.mu.Unlock()
 
 	// Make a copy to avoid external modifications
-	recordCopy := &adapters.IdempotencyRecord{
-		Key:         record.Key,
-		CommandType: record.CommandType,
-		AggregateID: record.AggregateID,
-		Version:     record.Version,
-		Response:    record.Response,
-		Success:     record.Success,
-		Error:       record.Error,
-		ProcessedAt: record.ProcessedAt,
-		ExpiresAt:   record.ExpiresAt,
-	}
-
-	s.records[record.Key] = recordCopy
+	s.records[record.Key] = adapters.CopyIdempotencyRecord(record)
 	return nil
 }
 
@@ -159,19 +147,7 @@ func (s *IdempotencyStore) Get(ctx context.Context, key string) (*adapters.Idemp
 	}
 
 	// Return a copy to avoid external modifications
-	recordCopy := &adapters.IdempotencyRecord{
-		Key:         record.Key,
-		CommandType: record.CommandType,
-		AggregateID: record.AggregateID,
-		Version:     record.Version,
-		Response:    record.Response,
-		Success:     record.Success,
-		Error:       record.Error,
-		ProcessedAt: record.ProcessedAt,
-		ExpiresAt:   record.ExpiresAt,
-	}
-
-	return recordCopy, nil
+	return adapters.CopyIdempotencyRecord(record), nil
 }
 
 // Delete removes an idempotency record by key.

--- a/adapters/memory/memory_test.go
+++ b/adapters/memory/memory_test.go
@@ -647,7 +647,7 @@ func TestExtractCategory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.streamID, func(t *testing.T) {
-			result := extractCategory(tt.streamID)
+			result := adapters.ExtractCategory(tt.streamID)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/adapters/postgres/idempotency.go
+++ b/adapters/postgres/idempotency.go
@@ -62,21 +62,6 @@ func NewIdempotencyStoreFromAdapter(adapter *PostgresAdapter, opts ...Idempotenc
 	return NewIdempotencyStore(adapter.db, allOpts...)
 }
 
-// validateIdentifier checks if a name is a valid PostgreSQL identifier.
-// This helps prevent SQL injection when using identifiers in queries.
-func validateIdentifier(name, kind string) error {
-	if name == "" {
-		return fmt.Errorf("mink/postgres/idempotency: %s name cannot be empty", kind)
-	}
-	if len(name) > 63 {
-		return fmt.Errorf("mink/postgres/idempotency: %s name exceeds 63 characters", kind)
-	}
-	if !schemaNamePattern.MatchString(name) {
-		return fmt.Errorf("mink/postgres/idempotency: %s name contains invalid characters", kind)
-	}
-	return nil
-}
-
 // fullTableName returns the fully qualified and quoted table name.
 func (s *IdempotencyStore) fullTableName() string {
 	return quoteQualifiedTable(s.schema, s.table)

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -57,10 +57,11 @@ func validateSchemaName(schema string) error {
 }
 
 // Version constants for optimistic concurrency control.
+// These are re-exported from the adapters package for convenience.
 const (
-	AnyVersion   int64 = -1
-	NoStream     int64 = 0
-	StreamExists int64 = -2
+	AnyVersion   = adapters.AnyVersion
+	NoStream     = adapters.NoStream
+	StreamExists = adapters.StreamExists
 )
 
 // Sentinel errors for the postgres adapter.
@@ -363,12 +364,12 @@ func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []
 	}
 
 	// Check expected version
-	if err := a.checkVersion(streamID, expectedVersion, currentVersion, streamExists); err != nil {
+	if err := adapters.CheckVersion(streamID, expectedVersion, currentVersion, streamExists); err != nil {
 		return nil, err
 	}
 
 	// Create stream if it doesn't exist
-	category := extractCategory(streamID)
+	category := adapters.ExtractCategory(streamID)
 	if !streamExists {
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO `+schemaQ+`.streams (stream_id, category, version)
@@ -446,7 +447,7 @@ func (a *PostgresAdapter) Load(ctx context.Context, streamID string, fromVersion
 		return nil, fmt.Errorf("mink/postgres: invalid schema: %w", err)
 	}
 	rows, err := a.db.QueryContext(ctx, `
-		SELECT global_position, event_id, stream_id, version, event_type, data, metadata, timestamp
+		SELECT event_id, stream_id, version, event_type, data, metadata, global_position, timestamp
 		FROM `+schemaQ+`.events
 		WHERE stream_id = $1 AND version > $2
 		ORDER BY version`, streamID, fromVersion)
@@ -455,39 +456,7 @@ func (a *PostgresAdapter) Load(ctx context.Context, streamID string, fromVersion
 	}
 	defer rows.Close()
 
-	events := make([]adapters.StoredEvent, 0)
-	for rows.Next() {
-		var event adapters.StoredEvent
-		var metadataJSON []byte
-
-		err := rows.Scan(
-			&event.GlobalPosition,
-			&event.ID,
-			&event.StreamID,
-			&event.Version,
-			&event.Type,
-			&event.Data,
-			&metadataJSON,
-			&event.Timestamp,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("mink/postgres: failed to scan event: %w", err)
-		}
-
-		if len(metadataJSON) > 0 {
-			if err := json.Unmarshal(metadataJSON, &event.Metadata); err != nil {
-				return nil, fmt.Errorf("mink/postgres: failed to unmarshal metadata: %w", err)
-			}
-		}
-
-		events = append(events, event)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("mink/postgres: error iterating events: %w", err)
-	}
-
-	return events, nil
+	return a.scanEvents(rows)
 }
 
 // GetStreamInfo returns metadata about a stream.
@@ -516,7 +485,7 @@ func (a *PostgresAdapter) GetStreamInfo(ctx context.Context, streamID string) (*
 	)
 
 	if err == sql.ErrNoRows {
-		return nil, NewStreamNotFoundError(streamID)
+		return nil, adapters.NewStreamNotFoundError(streamID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("mink/postgres: failed to get stream info: %w", err)
@@ -733,92 +702,14 @@ func (a *PostgresAdapter) Schema() string {
 	return a.schema
 }
 
-// ConcurrencyError provides details about a concurrency conflict.
-type ConcurrencyError struct {
-	StreamID        string
-	ExpectedVersion int64
-	ActualVersion   int64
-}
+// ConcurrencyError is an alias for adapters.ConcurrencyError for backward compatibility.
+type ConcurrencyError = adapters.ConcurrencyError
 
-// NewConcurrencyError creates a new ConcurrencyError.
-func NewConcurrencyError(streamID string, expected, actual int64) *ConcurrencyError {
-	return &ConcurrencyError{
-		StreamID:        streamID,
-		ExpectedVersion: expected,
-		ActualVersion:   actual,
-	}
-}
+// StreamNotFoundError is an alias for adapters.StreamNotFoundError for backward compatibility.
+type StreamNotFoundError = adapters.StreamNotFoundError
 
-// Error implements the error interface.
-func (e *ConcurrencyError) Error() string {
-	return fmt.Sprintf("mink/postgres: concurrency conflict on stream %q: expected version %d, got %d",
-		e.StreamID, e.ExpectedVersion, e.ActualVersion)
-}
+// NewConcurrencyError is an alias for adapters.NewConcurrencyError for backward compatibility.
+var NewConcurrencyError = adapters.NewConcurrencyError
 
-// Is implements errors.Is compatibility.
-func (e *ConcurrencyError) Is(target error) bool {
-	return target == ErrConcurrencyConflict
-}
-
-// StreamNotFoundError provides details about a missing stream.
-type StreamNotFoundError struct {
-	StreamID string
-}
-
-// NewStreamNotFoundError creates a new StreamNotFoundError.
-func NewStreamNotFoundError(streamID string) *StreamNotFoundError {
-	return &StreamNotFoundError{StreamID: streamID}
-}
-
-// Error implements the error interface.
-func (e *StreamNotFoundError) Error() string {
-	return fmt.Sprintf("mink/postgres: stream %q not found", e.StreamID)
-}
-
-// Is implements errors.Is compatibility.
-func (e *StreamNotFoundError) Is(target error) bool {
-	return target == ErrStreamNotFound
-}
-
-// checkVersion validates the expected version against the current version.
-func (a *PostgresAdapter) checkVersion(streamID string, expected, current int64, exists bool) error {
-	switch expected {
-	case AnyVersion:
-		return nil
-	case NoStream:
-		if exists {
-			return NewConcurrencyError(streamID, expected, current)
-		}
-		return nil
-	case StreamExists:
-		if !exists {
-			return NewStreamNotFoundError(streamID)
-		}
-		return nil
-	default:
-		if expected < 0 {
-			return ErrInvalidVersion
-		}
-		if current != expected {
-			return NewConcurrencyError(streamID, expected, current)
-		}
-		return nil
-	}
-}
-
-// extractCategory extracts the category from a stream ID.
-// Stream IDs are expected to follow the format "Category-ID" (e.g., "Order-123").
-// The category is the portion before the first hyphen.
-//
-// Behavior:
-//   - "Order-123" returns "Order"
-//   - "User-abc-def" returns "User" (only splits on first hyphen)
-//   - "NoHyphen" returns "NoHyphen" (entire ID if no hyphen)
-//   - "" returns "" (empty string for empty input)
-func extractCategory(streamID string) string {
-	if streamID == "" {
-		return ""
-	}
-	parts := strings.SplitN(streamID, "-", 2)
-	return parts[0]
-}
+// NewStreamNotFoundError is an alias for adapters.NewStreamNotFoundError for backward compatibility.
+var NewStreamNotFoundError = adapters.NewStreamNotFoundError

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1099,7 +1099,7 @@ func TestExtractCategory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.streamID, func(t *testing.T) {
-			result := extractCategory(tc.streamID)
+			result := adapters.ExtractCategory(tc.streamID)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/adapters/postgres/subscription.go
+++ b/adapters/postgres/subscription.go
@@ -57,6 +57,75 @@ func (c *subscriptionConfig) handleError(err error, context string) {
 	}
 }
 
+// eventLoader is a function that loads events and returns the new position.
+// The position type is generic to support both uint64 (global position) and int64 (version).
+type eventLoader[P any] func(ctx context.Context, position P) ([]adapters.StoredEvent, P, error)
+
+// runPollingLoop runs a generic polling loop for subscriptions.
+// It handles error retries, context cancellation, and event delivery.
+func runPollingLoop[P any](
+	ctx context.Context,
+	cfg subscriptionConfig,
+	ch chan adapters.StoredEvent,
+	errorContext string,
+	initialPosition P,
+	loader eventLoader[P],
+) {
+	defer close(ch)
+	ticker := time.NewTicker(cfg.pollInterval)
+	defer ticker.Stop()
+
+	currentPosition := initialPosition
+	consecutiveErrors := 0
+
+	for {
+		// Check for shutdown before polling
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Load events from current position
+		events, newPosition, err := loader(ctx, currentPosition)
+		if err != nil {
+			consecutiveErrors++
+			if consecutiveErrors >= cfg.maxRetries {
+				cfg.handleError(err, errorContext)
+				consecutiveErrors = 0 // Reset after logging
+			}
+			// On error, wait and retry (unless context is cancelled)
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				continue
+			}
+		}
+		consecutiveErrors = 0
+
+		// Send events to channel and update position
+		for _, event := range events {
+			select {
+			case ch <- event:
+				currentPosition = newPosition
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		// Wait for next poll cycle if no events
+		if len(events) == 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// Continue polling
+			}
+		}
+	}
+}
+
 // LoadFromPosition loads events starting from a global position.
 // This is used by projection engines to catch up on historical events.
 func (a *PostgresAdapter) LoadFromPosition(ctx context.Context, fromPosition uint64, limit int) ([]adapters.StoredEvent, error) {
@@ -100,61 +169,19 @@ func (a *PostgresAdapter) SubscribeAll(ctx context.Context, fromPosition uint64,
 	cfg := newSubscriptionConfig(opts)
 	ch := make(chan adapters.StoredEvent, cfg.bufferSize)
 
-	go func() {
-		defer close(ch)
-		ticker := time.NewTicker(cfg.pollInterval)
-		defer ticker.Stop()
-
-		currentPosition := fromPosition
-		consecutiveErrors := 0
-
-		for {
-			// Check for shutdown before polling
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			// Load events from current position
-			events, err := a.LoadFromPosition(ctx, currentPosition, cfg.bufferSize)
-			if err != nil {
-				consecutiveErrors++
-				if consecutiveErrors >= cfg.maxRetries {
-					cfg.handleError(err, "SubscribeAll")
-					consecutiveErrors = 0 // Reset after logging
-				}
-				// On error, wait and retry (unless context is cancelled)
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					continue
-				}
-			}
-			consecutiveErrors = 0
-
-			// Send events to channel
-			for _, event := range events {
-				select {
-				case ch <- event:
-					currentPosition = event.GlobalPosition
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			// Wait for next poll cycle if no events, otherwise continue immediately
-			if len(events) == 0 {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					// Continue polling
-				}
-			}
+	loader := func(ctx context.Context, position uint64) ([]adapters.StoredEvent, uint64, error) {
+		events, err := a.LoadFromPosition(ctx, position, cfg.bufferSize)
+		if err != nil {
+			return nil, position, err
 		}
-	}()
+		newPosition := position
+		if len(events) > 0 {
+			newPosition = events[len(events)-1].GlobalPosition
+		}
+		return events, newPosition, nil
+	}
+
+	go runPollingLoop(ctx, cfg, ch, "SubscribeAll", fromPosition, loader)
 
 	return ch, nil
 }
@@ -170,61 +197,19 @@ func (a *PostgresAdapter) SubscribeStream(ctx context.Context, streamID string, 
 	cfg := newSubscriptionConfig(opts)
 	ch := make(chan adapters.StoredEvent, cfg.bufferSize)
 
-	go func() {
-		defer close(ch)
-		ticker := time.NewTicker(cfg.pollInterval)
-		defer ticker.Stop()
-
-		currentVersion := fromVersion
-		consecutiveErrors := 0
-
-		for {
-			// Check for shutdown before polling
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			// Load events from current version
-			events, err := a.Load(ctx, streamID, currentVersion)
-			if err != nil {
-				consecutiveErrors++
-				if consecutiveErrors >= cfg.maxRetries {
-					cfg.handleError(err, fmt.Sprintf("SubscribeStream(%s)", streamID))
-					consecutiveErrors = 0
-				}
-				// On error, wait and retry (unless context is cancelled)
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					continue
-				}
-			}
-			consecutiveErrors = 0
-
-			// Send events to channel
-			for _, event := range events {
-				select {
-				case ch <- event:
-					currentVersion = event.Version + 1
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			// Wait for next poll cycle if no events
-			if len(events) == 0 {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					// Continue polling
-				}
-			}
+	loader := func(ctx context.Context, version int64) ([]adapters.StoredEvent, int64, error) {
+		events, err := a.Load(ctx, streamID, version)
+		if err != nil {
+			return nil, version, err
 		}
-	}()
+		newVersion := version
+		if len(events) > 0 {
+			newVersion = events[len(events)-1].Version
+		}
+		return events, newVersion, nil
+	}
+
+	go runPollingLoop(ctx, cfg, ch, fmt.Sprintf("SubscribeStream(%s)", streamID), fromVersion, loader)
 
 	return ch, nil
 }
@@ -240,61 +225,19 @@ func (a *PostgresAdapter) SubscribeCategory(ctx context.Context, category string
 	cfg := newSubscriptionConfig(opts)
 	ch := make(chan adapters.StoredEvent, cfg.bufferSize)
 
-	go func() {
-		defer close(ch)
-		ticker := time.NewTicker(cfg.pollInterval)
-		defer ticker.Stop()
-
-		currentPosition := fromPosition
-		consecutiveErrors := 0
-
-		for {
-			// Check for shutdown before polling
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			// Load events for this category
-			events, err := a.loadCategoryEvents(ctx, category, currentPosition, cfg.bufferSize)
-			if err != nil {
-				consecutiveErrors++
-				if consecutiveErrors >= cfg.maxRetries {
-					cfg.handleError(err, fmt.Sprintf("SubscribeCategory(%s)", category))
-					consecutiveErrors = 0
-				}
-				// On error, wait and retry (unless context is cancelled)
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					continue
-				}
-			}
-			consecutiveErrors = 0
-
-			// Send events to channel
-			for _, event := range events {
-				select {
-				case ch <- event:
-					currentPosition = event.GlobalPosition
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			// Wait for next poll cycle if no events
-			if len(events) == 0 {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					// Continue polling
-				}
-			}
+	loader := func(ctx context.Context, position uint64) ([]adapters.StoredEvent, uint64, error) {
+		events, err := a.loadCategoryEvents(ctx, category, position, cfg.bufferSize)
+		if err != nil {
+			return nil, position, err
 		}
-	}()
+		newPosition := position
+		if len(events) > 0 {
+			newPosition = events[len(events)-1].GlobalPosition
+		}
+		return events, newPosition, nil
+	}
+
+	go runPollingLoop(ctx, cfg, ch, fmt.Sprintf("SubscribeCategory(%s)", category), fromPosition, loader)
 
 	return ch, nil
 }

--- a/projection_engine.go
+++ b/projection_engine.go
@@ -197,14 +197,23 @@ func (r *noRetry) Delay(attempt int) time.Duration {
 	return 0
 }
 
-// RegisterInline registers an inline projection.
-// Inline projections are processed synchronously with event appends.
-func (e *ProjectionEngine) RegisterInline(projection InlineProjection) error {
+// validateProjection checks if a projection is valid for registration.
+// Returns an error if the projection is nil or has an empty name.
+func validateProjection(projection Projection) error {
 	if projection == nil {
 		return ErrNilProjection
 	}
 	if projection.Name() == "" {
 		return ErrEmptyProjectionName
+	}
+	return nil
+}
+
+// RegisterInline registers an inline projection.
+// Inline projections are processed synchronously with event appends.
+func (e *ProjectionEngine) RegisterInline(projection InlineProjection) error {
+	if err := validateProjection(projection); err != nil {
+		return err
 	}
 
 	e.inlineMu.Lock()
@@ -225,11 +234,8 @@ func (e *ProjectionEngine) RegisterInline(projection InlineProjection) error {
 // RegisterAsync registers an async projection with the given options.
 // Async projections are processed in background workers.
 func (e *ProjectionEngine) RegisterAsync(projection AsyncProjection, opts ...AsyncOptions) error {
-	if projection == nil {
-		return ErrNilProjection
-	}
-	if projection.Name() == "" {
-		return ErrEmptyProjectionName
+	if err := validateProjection(projection); err != nil {
+		return err
 	}
 
 	options := DefaultAsyncOptions()
@@ -262,11 +268,8 @@ func (e *ProjectionEngine) RegisterAsync(projection AsyncProjection, opts ...Asy
 // RegisterLive registers a live projection with optional configuration.
 // Live projections receive events in real-time.
 func (e *ProjectionEngine) RegisterLive(projection LiveProjection, opts ...LiveOptions) error {
-	if projection == nil {
-		return ErrNilProjection
-	}
-	if projection.Name() == "" {
-		return ErrEmptyProjectionName
+	if err := validateProjection(projection); err != nil {
+		return err
 	}
 
 	options := DefaultLiveOptions()

--- a/store_test.go
+++ b/store_test.go
@@ -929,3 +929,32 @@ func (s *failingSerializer) Register(eventType string, example interface{}) {
 
 func (s *failingSerializer) RegisterAll(examples ...interface{}) {
 }
+
+// TestNoopLogger tests that noopLogger methods don't panic
+func TestNoopLogger(t *testing.T) {
+	logger := &noopLogger{}
+
+	t.Run("Debug does nothing", func(t *testing.T) {
+		// Should not panic
+		logger.Debug("test message")
+		logger.Debug("test with args", "key", "value")
+	})
+
+	t.Run("Info does nothing", func(t *testing.T) {
+		// Should not panic
+		logger.Info("test message")
+		logger.Info("test with args", "key", "value", "num", 42)
+	})
+
+	t.Run("Warn does nothing", func(t *testing.T) {
+		// Should not panic
+		logger.Warn("test message")
+		logger.Warn("test with args", "key", "value")
+	})
+
+	t.Run("Error does nothing", func(t *testing.T) {
+		// Should not panic
+		logger.Error("test message")
+		logger.Error("test with args", "error", assert.AnError)
+	})
+}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -675,3 +675,52 @@ func TestPollingSubscription_Integration(t *testing.T) {
 		}
 	})
 }
+
+// testMinkSubscriptionAdapter implements SubscriptionAdapter for testing minkSubscriptionAdapter
+type testMinkSubscriptionAdapter struct {
+	events []StoredEvent
+}
+
+func (m *testMinkSubscriptionAdapter) LoadFromPosition(ctx context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
+	var result []StoredEvent
+	for _, e := range m.events {
+		if e.GlobalPosition > fromPosition {
+			result = append(result, e)
+			if len(result) >= limit {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *testMinkSubscriptionAdapter) SubscribeAll(ctx context.Context, fromPosition uint64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func (m *testMinkSubscriptionAdapter) SubscribeStream(ctx context.Context, streamID string, fromVersion int64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func (m *testMinkSubscriptionAdapter) SubscribeCategory(ctx context.Context, category string, fromPosition uint64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+// TestMinkSubscriptionAdapter tests the minkSubscriptionAdapter wrapper
+func TestMinkSubscriptionAdapter(t *testing.T) {
+	t.Run("LoadFromPosition delegates to underlying adapter", func(t *testing.T) {
+		ctx := context.Background()
+
+		mockAdapter := &testMinkSubscriptionAdapter{
+			events: []StoredEvent{
+				{ID: "1", StreamID: "Order-1", Type: "CatchupTestEvent", GlobalPosition: 1},
+				{ID: "2", StreamID: "Order-2", Type: "CatchupTestEvent", GlobalPosition: 2},
+			},
+		}
+
+		wrapper := &minkSubscriptionAdapter{adapter: mockAdapter}
+		events, err := wrapper.LoadFromPosition(ctx, 0, 10)
+		require.NoError(t, err)
+		assert.Len(t, events, 2)
+	})
+}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -724,3 +724,4 @@ func TestMinkSubscriptionAdapter(t *testing.T) {
 		assert.Len(t, events, 2)
 	})
 }
+


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request refactors and centralizes shared logic for event store adapters, moving common utilities and error types to the `adapters` package. It eliminates code duplication across the `memory` and `postgres` adapters by re-exporting constants, error types, and helper functions, and updating their usages throughout the codebase. The changes improve maintainability and consistency, especially around optimistic concurrency control and stream category extraction.

### Centralization of shared logic

* Added `adapters/common.go` with shared constants (`AnyVersion`, `NoStream`, `StreamExists`), error types (`ConcurrencyError`, `StreamNotFoundError`), helper functions (`ExtractCategory`, `CheckVersion`, `CopyIdempotencyRecord`, `DefaultLimit`), and error constructors. This file is now the single source of truth for these utilities.

### Refactoring adapters to use shared logic

* Updated the `memory` adapter to remove local implementations of version constants, error types, and helper functions, replacing them with re-exports and direct usage from the `adapters` package. This includes updating all usages of `extractCategory`, `checkVersion`, and error constructors. [[1]](diffhunk://#diff-efb594fd48dee5296b987b8c514deb56656b45e757d45d5207a82e8f1eb29333L4-R39) [[2]](diffhunk://#diff-b453dc4119e65fb2127a3253d10701346e444cacb5a5b310f9310366ed329cefR15-R19) [[3]](diffhunk://#diff-b453dc4119e65fb2127a3253d10701346e444cacb5a5b310f9310366ed329cefL106-R112) [[4]](diffhunk://#diff-b453dc4119e65fb2127a3253d10701346e444cacb5a5b310f9310366ed329cefL388-R388) [[5]](diffhunk://#diff-b453dc4119e65fb2127a3253d10701346e444cacb5a5b310f9310366ed329cefL541-L566) [[6]](diffhunk://#diff-b453dc4119e65fb2127a3253d10701346e444cacb5a5b310f9310366ed329cefL598-L606)
* Updated the `postgres` adapter similarly, removing local implementations and using the centralized utilities and error types from the `adapters` package. [[1]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79R60-R64) [[2]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L366-R372) [[3]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L519-R488) [[4]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L736-R715)

### Code deduplication and simplification

* Replaced manual deep copies of `IdempotencyRecord` in the memory adapter with the new `CopyIdempotencyRecord` helper from the shared package, reducing boilerplate and risk of errors. [[1]](diffhunk://#diff-d4af9c38a0616bbe25513331bf6f1463d9e5e3e84341ba4b6ac7111fe616a317L129-R129) [[2]](diffhunk://#diff-d4af9c38a0616bbe25513331bf6f1463d9e5e3e84341ba4b6ac7111fe616a317L162-R150)
* Updated tests in both adapters to use the shared `ExtractCategory` function, ensuring consistency in test coverage. [[1]](diffhunk://#diff-8830e4174a0b6d224827b3e8630197c08a70e50219e2db274b4522689864dac2L650-R650) [[2]](diffhunk://#diff-5d14bb73944e3125a78f96cb4c731103e93f38b6752310164fb3dad771d98b8cL1102-R1102)

### Minor improvements

* Changed the order of columns in the `SELECT` statement for events in the `postgres` adapter for consistency with the shared event struct, and delegated row scanning to a helper. [[1]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L449-R450) [[2]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L458-R459)
* Removed unnecessary imports and local functions that are now handled by the shared package.

---

These changes make the codebase easier to maintain and extend, ensuring that all adapters use the same logic for concurrency checks, error handling, and stream category extraction. [[1]](diffhunk://#diff-41663219516a90c5b24e33a9992d5764704c5562f46af3a88d070e3746db4c12R1-R151) [[2]](diffhunk://#diff-efb594fd48dee5296b987b8c514deb56656b45e757d45d5207a82e8f1eb29333L4-R39) [[3]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79R60-R64) [[4]](diffhunk://#diff-b453dc4119e65fb2127a3253d10701346e444cacb5a5b310f9310366ed329cefR15-R19) [[5]](diffhunk://#diff-d4af9c38a0616bbe25513331bf6f1463d9e5e3e84341ba4b6ac7111fe616a317L129-R129)

## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
