### PR TITLE
feat(postgres): implement DeleteCheckpoint and GetAllCheckpoints methods

### DIFF
--- a/adapters/memory/checkpoint.go
+++ b/adapters/memory/checkpoint.go
@@ -9,6 +9,8 @@ import (
 )
 
 // Ensure interface compliance at compile time.
+// Note: CheckpointStore also implements mink.CheckpointStore but we cannot
+// verify it here due to import cycle. The interface is verified in tests.
 var _ adapters.CheckpointAdapter = (*CheckpointStore)(nil)
 
 // Checkpoint represents a stored checkpoint.


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request enhances the Postgres adapter's checkpoint management capabilities by implementing the full `mink.CheckpointStore` interface. It introduces methods to delete checkpoints and retrieve all checkpoints, updates interface compliance, and adds comprehensive tests for these new features and edge cases.

## Changes
<!-- List of changes -->

**CheckpointStore interface implementation:**

* Added implementation of `DeleteCheckpoint` and `GetAllCheckpoints` methods to the `PostgresAdapter`, enabling deletion of individual checkpoints and retrieval of all checkpoints for projections.
* Registered `PostgresAdapter` as implementing the `mink.CheckpointStore` interface for compile-time verification.
* Updated imports to include the `mink` package, required for interface implementation.

**Testing and interface compliance:**

* Added extensive tests for deleting checkpoints, handling non-existent checkpoints, retrieving all checkpoints, and verifying correct behavior when the adapter is closed. [[1]](diffhunk://#diff-5d14bb73944e3125a78f96cb4c731103e93f38b6752310164fb3dad771d98b8cR938-R992) [[2]](diffhunk://#diff-5d14bb73944e3125a78f96cb4c731103e93f38b6752310164fb3dad771d98b8cR1051-R1056)
* Clarified interface compliance for `CheckpointStore` in the memory adapter with a comment, noting that compliance is verified in tests due to import cycles.

- 
- 

## Testing
<!-- How did you test this? -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [x] Code comments added
- [x] README updated (if applicable)
- [x] API docs updated

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] No breaking changes (or documented if intentional)
