### PR TITLE
feat(aggregate): add VersionSetter interface for automatic version management

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -125,3 +125,13 @@ type EventApplier func(aggregate interface{}, event interface{}) error
 
 // AggregateFactory creates new aggregate instances.
 type AggregateFactory func(id string) Aggregate
+
+// VersionSetter is an optional interface that aggregates can implement
+// to allow the event store to set their version after loading events.
+// If an aggregate implements this interface, LoadAggregate will automatically
+// set the version based on the number of events loaded.
+//
+// Note: AggregateBase already implements this interface.
+type VersionSetter interface {
+	SetVersion(v int64)
+}

--- a/mink.go
+++ b/mink.go
@@ -79,7 +79,8 @@
 //	    case ItemAdded:
 //	        o.Items = append(o.Items, OrderItem{SKU: e.SKU, Quantity: e.Quantity, Price: e.Price})
 //	    }
-//	    o.IncrementVersion()
+//	    // NOTE: Version is managed automatically by LoadAggregate and SaveAggregate.
+//	    // You do NOT need to call IncrementVersion() here.
 //	    return nil
 //	}
 //
@@ -99,6 +100,7 @@
 //	err := store.LoadAggregate(ctx, loaded)
 //	// loaded.Status == "Created"
 //	// loaded.Items contains the added item
+//	// loaded.Version() returns the number of events in the stream
 //
 // # Low-Level Event Operations
 //


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request introduces automatic version management for aggregates in the event store, ensuring that aggregate versions are set and updated correctly during load and save operations. This change removes the need for manual version incrementing within aggregates, fixes concurrency issues, and adds comprehensive tests to verify the new behavior.

## Changes
<!-- List of changes -->

**Automatic version management for aggregates:**

* Introduced the `VersionSetter` interface, which allows the event store to set an aggregate's version after loading or saving events. Aggregates embedding `AggregateBase` automatically support this. (`aggregate.go` [aggregate.goR128-R137](diffhunk://#diff-7c7a029dfc7e224e0f0f822054316bf2562143a529805096fe7eee8e0799b96aR128-R137))
* Updated `EventStore.LoadAggregate` and `EventStore.SaveAggregate` to automatically set the aggregate's version if it implements `VersionSetter`, ensuring correct optimistic concurrency control without manual intervention. (`store.go` [[1]](diffhunk://#diff-ed648181f98484bd12541509e0ae7b5ad1d1de7674ab1721814b47ddd5c95de4R193-R196) [[2]](diffhunk://#diff-ed648181f98484bd12541509e0ae7b5ad1d1de7674ab1721814b47ddd5c95de4R246-R252) [[3]](diffhunk://#diff-ed648181f98484bd12541509e0ae7b5ad1d1de7674ab1721814b47ddd5c95de4R232-R237) [[4]](diffhunk://#diff-ed648181f98484bd12541509e0ae7b5ad1d1de7674ab1721814b47ddd5c95de4R279-R284)

**Documentation and code comments:**

* Updated documentation in `mink.go` and function comments to clarify that version management is now handled automatically by the event store and manual calls to `IncrementVersion()` are no longer needed. (`mink.go` [[1]](diffhunk://#diff-98698cd4d317efe71f19beb626c690056f0e23343d7d8abe3f88c86f5fa5d2fbL82-R83) [[2]](diffhunk://#diff-98698cd4d317efe71f19beb626c690056f0e23343d7d8abe3f88c86f5fa5d2fbR103)

**Testing and bug fixes:**

* Added extensive tests (including the new `SimpleOrder` aggregate) to verify that version management works correctly across load, save, and concurrent modification scenarios, and that manual version management is not required. (`store_test.go` [store_test.goR408-R602](diffhunk://#diff-d9c85caa78c66977ce7cda19343eb7c1b40daa7994d98b70b960ec363654cbeeR408-R602))
* Refactored existing handler tests to remove outdated comments about version handling limitations and to verify that the new version management eliminates concurrency conflicts. (`handler_test.go` [[1]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL535-R536) [[2]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL555-R570)


## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
