### PR TITLE
Idempotency tracking in Saga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WithSagaWorkers()` - Configure number of worker goroutines
 - `WithSagaLogger()` - Configure logger for saga operations
 
+#### Saga Idempotency
+- `SagaState.ProcessedEvents` - Tracks processed event IDs for at-least-once delivery
+- Automatic deduplication of duplicate events (e.g., from pg_notify + polling)
+- Transparent handling by `SagaManager` - no user code changes required
+- Persisted to PostgreSQL `processed_events JSONB` column
+
 #### Saga Store Implementations
 - `memory.NewSagaStore()` - In-memory saga store for testing
 - `memory.SagaStore.Save()` - Persist saga state with optimistic concurrency

--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -656,6 +656,12 @@ type SagaState struct {
 	// Data contains the saga's internal state.
 	Data map[string]interface{} `json:"data,omitempty"`
 
+	// ProcessedEvents contains event keys that have been processed by this saga.
+	// This is used internally by the SagaManager for idempotency tracking and
+	// should not be modified directly by saga implementations.
+	// Each entry is formatted as "eventID:globalPosition".
+	ProcessedEvents []string `json:"processedEvents,omitempty"`
+
 	// Steps contains the history of executed steps.
 	Steps []SagaStep `json:"steps,omitempty"`
 

--- a/adapters/memory/saga_store.go
+++ b/adapters/memory/saga_store.go
@@ -94,6 +94,12 @@ func (s *SagaStore) Save(ctx context.Context, state *adapters.SagaState) error {
 		savedState.Data = deepCopyMap(state.Data)
 	}
 
+	// Deep copy ProcessedEvents
+	if state.ProcessedEvents != nil {
+		savedState.ProcessedEvents = make([]string, len(state.ProcessedEvents))
+		copy(savedState.ProcessedEvents, state.ProcessedEvents)
+	}
+
 	// Deep copy Steps
 	if state.Steps != nil {
 		savedState.Steps = make([]adapters.SagaStep, len(state.Steps))
@@ -301,6 +307,12 @@ func (s *SagaStore) copyState(state *adapters.SagaState) *adapters.SagaState {
 	// Deep copy Data (handles nested maps and slices)
 	if state.Data != nil {
 		copied.Data = deepCopyMap(state.Data)
+	}
+
+	// Deep copy ProcessedEvents
+	if state.ProcessedEvents != nil {
+		copied.ProcessedEvents = make([]string, len(state.ProcessedEvents))
+		copy(copied.ProcessedEvents, state.ProcessedEvents)
 	}
 
 	// Deep copy Steps

--- a/adapters/postgres/saga_store.go
+++ b/adapters/postgres/saga_store.go
@@ -115,11 +115,13 @@ func (s *SagaStore) Initialize(ctx context.Context) error {
 // Save persists a saga state with optimistic concurrency control.
 //
 // Version semantics:
-//   - Version 0: Creates a new saga. Uses INSERT.
+//   - Version 0: Creates a new saga. Uses INSERT with version=1.
 //   - Version > 0: Updates an existing saga. Uses UPDATE with version check.
 //     If the version doesn't match, returns ErrConcurrencyConflict.
 //
-// After a successful save, state.Version is incremented to reflect the new version.
+// The version is incremented atomically by the database (version = version + 1)
+// and returned via RETURNING clause. After a successful save, state.Version is
+// updated with the new version from the database.
 func (s *SagaStore) Save(ctx context.Context, state *mink.SagaState) error {
 	if state == nil {
 		return errors.New("mink/postgres/saga: state is nil")

--- a/adapters/postgres/saga_store.go
+++ b/adapters/postgres/saga_store.go
@@ -87,7 +87,7 @@ func (s *SagaStore) Initialize(ctx context.Context) error {
 			status INT NOT NULL DEFAULT 0,
 			current_step INT NOT NULL DEFAULT 0,
 			data JSONB,
-			processed_events JSONB,
+			processed_events JSONB NOT NULL DEFAULT '[]'::jsonb,
 			steps JSONB,
 			failure_reason TEXT,
 			started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/saga_manager.go
+++ b/saga_manager.go
@@ -511,12 +511,11 @@ func (m *SagaManager) attemptProcessSagaEvent(
 				return fmt.Errorf("mink: failed to find saga: %w", err)
 			}
 			if state != nil {
-				m.logger.Debug("[SAGA-DEBUG] Loaded fresh state from store",
+				m.logger.Debug("Loaded saga state from store",
 					"correlationID", correlationID,
 					"sagaID", state.ID,
 					"version", state.Version,
-					"status", state.Status,
-					"processedEventsCount", len(state.ProcessedEvents))
+					"status", state.Status)
 			}
 		}
 
@@ -776,27 +775,14 @@ func (m *SagaManager) saveSaga(ctx context.Context, saga Saga) error {
 		Version:         saga.Version(),
 	}
 
-	m.logger.Debug("[SAGA-DEBUG] Saving saga state",
-		"sagaID", sagaID,
-		"status", state.Status,
-		"versionBeforeSave", state.Version,
-		"processedEventsCount", len(processedEvents))
-
 	err := m.store.Save(ctx, state)
 	if err != nil {
-		m.logger.Error("Save failed",
-			"sagaID", sagaID,
-			"error", err)
 		return err
 	}
 
 	// Update saga's version with the new version from the database
 	// This is important for any subsequent operations on the same saga instance
 	saga.SetVersion(state.Version)
-
-	m.logger.Info("[SAGA-DEBUG] Save succeeded",
-		"sagaID", sagaID,
-		"versionAfterSave", state.Version)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request introduces built-in idempotency support for sagas by tracking processed events in a new `ProcessedEvents` field on `SagaState`. This ensures that duplicate events (such as those caused by retries or concurrent delivery) are automatically deduplicated by the `SagaManager`, with no changes required in user saga code. The implementation includes changes to both in-memory and PostgreSQL saga stores, as well as documentation updates.

## Changes
<!-- List of changes -->

**Idempotency and Event Deduplication:**

- Added a `ProcessedEvents` field to `SagaState` to record event IDs that have already been handled, enabling at-least-once delivery semantics and preventing duplicate event processing. This is managed internally by the `SagaManager` and persisted in the database. [[1]](diffhunk://#diff-91ed6cb6f65eab3ef590590633635d99bba0328f1d37c430386e3ad7b55c26c9R659-R664) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR43-R48) [[3]](diffhunk://#diff-d8211123f735a615ee391eeb41377f1a118d63fcf3537b20b4f5f23a9b76971cL89-R92) [[4]](diffhunk://#diff-d8211123f735a615ee391eeb41377f1a118d63fcf3537b20b4f5f23a9b76971cR147-R151)
- Updated the `SagaManager` to always reload saga state after acquiring locks, ensuring the latest `ProcessedEvents` are used and avoiding race conditions that could lead to duplicate processing. [[1]](diffhunk://#diff-d8211123f735a615ee391eeb41377f1a118d63fcf3537b20b4f5f23a9b76971cL352-R364) [[2]](diffhunk://#diff-d8211123f735a615ee391eeb41377f1a118d63fcf3537b20b4f5f23a9b76971cL400-R412)

**Persistence Layer Updates:**

- Modified the in-memory saga store to deep copy the new `ProcessedEvents` field when saving and copying state. [[1]](diffhunk://#diff-d30576e4cb724c974cbab9f47b77a82dc696238d0ee7f088a742f6d5b5748f5dR97-R102) [[2]](diffhunk://#diff-d30576e4cb724c974cbab9f47b77a82dc696238d0ee7f088a742f6d5b5748f5dR312-R317)
- Updated the PostgreSQL saga store to persist the `ProcessedEvents` field as a JSONB column, including all necessary SQL, marshaling, and unmarshaling logic for save/load/find operations. [[1]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR90) [[2]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR138-R142) [[3]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfL146-R171) [[4]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR183) [[5]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfL206-R214) [[6]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR224) [[7]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR238) [[8]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR268-R273) [[9]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfL276-R292) [[10]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR304) [[11]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR318) [[12]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR348-R353) [[13]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfL352-R376) [[14]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfL370-R394) [[15]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR415) [[16]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR429) [[17]](diffhunk://#diff-2caa3eddda0c4468508c6fa547a62888fde647b20735de5e8374c96170c645bfR454-R459)

**Documentation and Schema:**

- Updated documentation to describe the new idempotency mechanism, including the role of `ProcessedEvents` and its handling by the `SagaManager`. [[1]](diffhunk://#diff-835a9b9d912b506a3c4a28c5c69ea0de36bd9ade14fa66807f0e66e90c46a40cR463) [[2]](diffhunk://#diff-835a9b9d912b506a3c4a28c5c69ea0de36bd9ade14fa66807f0e66e90c46a40cL624-R629)
- Added `processed_events` to the example PostgreSQL schema in the documentation.

## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
