### PR TITLE
Implement upcasting serializer and versioning system with documentation updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,87 +11,62 @@ go-mink is an Event Sourcing and CQRS library for Go (inspired by MartenDB for .
 ```bash
 # Preferred: use Makefile targets (infrastructure managed via docker-compose.test.yml)
 make test-unit                          # Unit tests only (no infra needed, uses -short -race)
-make test                               # All tests (auto-starts PostgreSQL via docker-compose)
-make lint                               # golangci-lint run ./...
+make test                               # All tests (auto-starts PostgreSQL + Kafka via docker-compose)
+make lint                               # golangci-lint run ./... (uses defaults, no .golangci.yml)
 make fmt                                # go fmt ./...
 make test-coverage                      # Coverage report (excludes examples/ and testing/)
 
 # Infrastructure management
-make infra-up                           # Start test PostgreSQL (docker-compose.test.yml)
+make infra-up                           # Start test PostgreSQL + Kafka (docker-compose.test.yml)
 make infra-down                         # Stop test infrastructure
 make clean                              # Stop infra + remove coverage artifacts + clear caches
 
 # Running a single test (infra must be up for integration tests)
 TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
+  TEST_KAFKA_BROKERS="localhost:9092" \
   go test -v -run TestName ./path/to/pkg/...
 
 # Integration tests skip themselves when:
 #   - testing.Short() is true (via -short flag)
-#   - TEST_DATABASE_URL env var is not set
+#   - TEST_DATABASE_URL env var is not set (for Postgres tests)
+#   - TEST_KAFKA_BROKERS env var is not set (for Kafka tests)
 ```
+
+**CI enforces 90% code coverage** (excludes `examples/` and `testing/`). Go version compatibility: go.mod targets 1.25, CI tests Go 1.22–1.26 on Linux, macOS, Windows.
 
 ## Architecture
 
 ```
 Commands --> Command Bus (middleware pipeline) --> Handler --> Aggregate --> Events --> Event Store
                                                                                           |
-                                                                              Projection Engine
-                                                                                          |
-                                                                                    Read Models
-                                                                          |
-                                                                     Saga Manager
-                                                                    (compensation)
-                                                                          |
-                                                                   Outbox Processor
-                                                                          |
-                                                              External Systems (Kafka, Webhooks, SNS)
+                                                                                +---------+---------+
+                                                                                |                   |
+                                                                      Projection Engine       Saga Manager
+                                                                                |            (compensation)
+                                                                          Read Models               |
+                                                                                            Outbox Processor
+                                                                                                    |
+                                                                                     External Systems (Kafka, Webhooks, SNS)
 ```
 
 **Data flow**: Commands are dispatched through the bus with middleware (validation, idempotency, correlation, recovery). Handlers load aggregates from the event store, execute domain logic, and persist uncommitted events. The projection engine subscribes to stored events and updates read models. Sagas orchestrate long-running workflows with compensation. The outbox processor reliably publishes events to external systems (Kafka, webhooks, SNS) with retry and dead-letter support.
 
 ## Key File Locations
 
-Root package (all core types are in the root `mink` package):
-- `event.go` - Event types, StreamID, Metadata
-- `aggregate.go` - Aggregate interface and AggregateBase
-- `store.go` - EventStore (main entry point: Append, Load, SaveAggregate, LoadAggregate)
-- `command.go` - Command interface, CommandBase, AggregateCommand, IdempotentCommand
-- `bus.go` - CommandBus with middleware pipeline
-- `handler.go` - CommandHandler and handler registry
-- `middleware.go` - Middleware implementations (Validation, Recovery, Idempotency, Correlation, Causation, Tenant)
-- `idempotency.go` - IdempotencyConfig and middleware setup
-- `projection.go` - Projection interfaces (Inline, Async, Live), ProjectionBase helpers
-- `projection_engine.go` - ProjectionEngine with worker pool, checkpoints, resilience
-- `rebuilder.go` - ProjectionRebuilder for rebuilding from scratch
-- `subscription.go` - Event subscription management
-- `saga.go` - Saga interface, SagaBase, SagaCorrelation
-- `saga_manager.go` - SagaManager orchestration with compensation and retry
-- `outbox.go` - OutboxRoute, Publisher interface, EventStoreWithOutbox wrapper, OutboxMetrics
-- `outbox_processor.go` - OutboxProcessor background worker with polling, retry, dead-letter
-- `repository.go` - Repository pattern for aggregates
-- `serializer.go` - Serializer interface and JSON implementation
-- `errors.go` - All sentinel errors and typed errors
+All core types live in the root `mink` package. Key entry points: `store.go` (EventStore), `bus.go` (CommandBus), `projection_engine.go` (ProjectionEngine), `saga_manager.go` (SagaManager), `outbox_processor.go` (OutboxProcessor), `errors.go` (all sentinel/typed errors).
 
 Adapters:
-- `adapters/adapter.go` - All adapter interfaces and shared types (EventStoreAdapter, SubscriptionAdapter, SagaStore, OutboxStore, OutboxAppender, etc.)
-- `adapters/postgres/` - PostgreSQL adapter (postgres.go, subscription.go, idempotency.go, saga_store.go, outbox_store.go, readmodel.go)
-- `adapters/memory/` - In-memory adapter for testing (memory.go, checkpoint.go, idempotency.go, saga_store.go, outbox_store.go)
+- `adapters/adapter.go` - All adapter interfaces and shared types (EventStoreAdapter, SubscriptionAdapter, SagaStore, OutboxStore, OutboxAppender, HealthChecker, Migrator, plus CLI adapters: StreamQueryAdapter, DiagnosticAdapter, SchemaProvider)
+- `adapters/postgres/` - PostgreSQL adapter (production)
+- `adapters/memory/` - In-memory adapter (testing)
 
 Other packages:
-- `outbox/webhook/` - HTTP webhook publisher for outbox
-- `outbox/kafka/` - Apache Kafka publisher for outbox
-- `outbox/sns/` - AWS SNS publisher for outbox
-- `middleware/metrics/` - Prometheus metrics middleware (includes outbox metrics)
-- `middleware/tracing/` - OpenTelemetry tracing middleware
-- `serializer/msgpack/` - MessagePack serializer
-- `serializer/protobuf/` - Protocol Buffers serializer
-- `testing/bdd/` - BDD-style aggregate testing (Given/When/Then)
-- `testing/assertions/` - Event assertion helpers
-- `testing/projections/` - Projection testing utilities
-- `testing/sagas/` - Saga testing utilities
-- `testing/containers/` - PostgreSQL Docker test containers
+- `outbox/{webhook,kafka,sns}/` - Outbox publishers
+- `middleware/{metrics,tracing}/` - Prometheus metrics, OpenTelemetry tracing
+- `serializer/{msgpack,protobuf}/` - Alternative serializers
+- `testing/{bdd,assertions,projections,sagas,containers}/` - Test utilities
 - `cli/commands/` - CLI tool (init, generate, migrate, projection, stream, diagnose, schema)
-- `examples/` - 13 example projects
+- `examples/` - Example projects
 
 ## Core Interfaces
 
@@ -157,6 +132,7 @@ StreamExists = -2  // Stream must exist
 4. **Sentinel errors**: `var ErrXxx = errors.New("mink: ...")` prefixed with "mink:"
 5. **Typed errors**: Implement `Is()` and `Unwrap()` for `errors.Is()` compatibility
 6. **Compile-time interface checks**: `var _ mink.EventStoreAdapter = (*MyAdapter)(nil)`
+7. **Naming**: Interfaces with single method use `-er` suffix (`Serializer`, `Subscriber`). Constructors use `NewXxx()`. Test functions: `TestXxx_Method_Scenario`.
 
 ## Testing Patterns
 
@@ -196,6 +172,23 @@ db := container.MustDB(ctx)
 - Completed: Saga / Process Manager, CLI tool, Outbox pattern (stores, processor, publishers, metrics)
 - Remaining: Event versioning & upcasting, field-level encryption, GDPR compliance
 
+## PostgreSQL Schema
+
+Events table (auto-created by adapter):
+```sql
+CREATE TABLE mink_events (
+    id UUID PRIMARY KEY,
+    stream_id VARCHAR(255) NOT NULL,
+    version BIGINT NOT NULL,
+    type VARCHAR(255) NOT NULL,
+    data JSONB NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    global_position BIGSERIAL,
+    timestamp TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(stream_id, version)
+);
+```
+
 ## Don't Do
 
 - Don't mutate events after storage
@@ -203,3 +196,4 @@ db := container.MustDB(ctx)
 - Don't skip context propagation
 - Don't use global state
 - Don't break public API without version bump
+- Don't add dependencies without discussion

--- a/e2e_versioning_test.go
+++ b/e2e_versioning_test.go
@@ -460,3 +460,151 @@ func TestE2E_Versioning_SchemaRegistry(t *testing.T) {
 	types := registry.RegisteredEventTypes()
 	assert.Equal(t, []string{productAddedEventType}, types)
 }
+
+// =============================================================================
+// Test: Upcast error during Load propagates correctly
+// =============================================================================
+
+// failingUpcaster always returns an error.
+type failingUpcaster struct{}
+
+func (u *failingUpcaster) EventType() string { return productAddedEventType }
+func (u *failingUpcaster) FromVersion() int  { return 1 }
+func (u *failingUpcaster) ToVersion() int    { return 2 }
+func (u *failingUpcaster) Upcast(data []byte, metadata mink.Metadata) ([]byte, error) {
+	return nil, fmt.Errorf("upcast deliberately failed")
+}
+
+func TestE2E_Versioning_UpcastError_Load(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Store a v1 event
+	storeV1Events(ctx, t, adapter, "ProductCatalog-err-1",
+		[]map[string]interface{}{{"product_id": "p1", "name": "Widget", "price": 9.99}},
+		mink.Metadata{}, mink.NoStream)
+
+	// Create store with a failing upcaster
+	chain := mink.NewUpcasterChain()
+	require.NoError(t, chain.Register(&failingUpcaster{}))
+	store := mink.New(adapter, mink.WithUpcasters(chain))
+	store.RegisterEvents(ProductAdded{})
+
+	// Load should propagate the upcast error
+	_, err := store.Load(ctx, "ProductCatalog-err-1")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "upcast deliberately failed")
+}
+
+func TestE2E_Versioning_UpcastError_LoadAggregate(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Store a v1 event
+	storeV1Events(ctx, t, adapter, "ProductCatalog-err-agg-1",
+		[]map[string]interface{}{{"product_id": "p1", "name": "Widget", "price": 9.99}},
+		mink.Metadata{}, mink.NoStream)
+
+	// Create store with a failing upcaster
+	chain := mink.NewUpcasterChain()
+	require.NoError(t, chain.Register(&failingUpcaster{}))
+	store := mink.New(adapter, mink.WithUpcasters(chain))
+	store.RegisterEvents(ProductAdded{})
+
+	// LoadAggregate should propagate the upcast error
+	catalog := newProductCatalog("err-agg-1")
+	err := store.LoadAggregate(ctx, catalog)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "upcast deliberately failed")
+}
+
+// =============================================================================
+// Test: RegisterUpcasters error path
+// =============================================================================
+
+func TestE2E_Versioning_RegisterUpcasters_Error(t *testing.T) {
+	store := mink.New(memory.NewAdapter())
+
+	// Register valid upcaster, then attempt a duplicate
+	err := store.RegisterUpcasters(&paV1ToV2{})
+	require.NoError(t, err)
+
+	// Second registration with same version range should fail
+	err = store.RegisterUpcasters(&paV1ToV2{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "duplicate")
+}
+
+// =============================================================================
+// Test: SaveAggregate stamps schema version
+// =============================================================================
+
+func TestE2E_Versioning_SaveAggregate_StampsVersion(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	chain := mink.NewUpcasterChain()
+	require.NoError(t, chain.Register(&paV1ToV2{}))
+	require.NoError(t, chain.Register(&paV2ToV3{}))
+
+	store := mink.New(adapter, mink.WithUpcasters(chain))
+	store.RegisterEvents(ProductAdded{})
+
+	// Create and save aggregate
+	catalog := newProductCatalog("save-stamp-1")
+	catalog.Apply(ProductAdded{ProductID: "p1", Name: "Test", Price: 5.0, Currency: "USD", Tax: 0})
+	catalog.Products = append(catalog.Products, catalogProduct{ProductID: "p1", Name: "Test", Price: 5.0, Currency: "USD"})
+
+	err := store.SaveAggregate(ctx, catalog)
+	require.NoError(t, err)
+
+	// Verify schema version was stamped
+	raw, err := store.LoadRaw(ctx, "ProductCatalog-save-stamp-1", 0)
+	require.NoError(t, err)
+	require.Len(t, raw, 1)
+	assert.Equal(t, 3, mink.GetSchemaVersion(raw[0].Metadata))
+}
+
+// =============================================================================
+// Test: CheckCompatibility error for unknown event type
+// =============================================================================
+
+func TestE2E_Versioning_SchemaRegistry_CheckCompatibility_Error(t *testing.T) {
+	registry := mink.NewSchemaRegistry()
+
+	// Unknown event type
+	_, err := registry.CheckCompatibility("Unknown", 1, 2)
+	require.Error(t, err)
+}
+
+// =============================================================================
+// Test: Deserialization error after successful upcast
+// =============================================================================
+
+// corruptingUpcaster produces invalid JSON so deserialization fails.
+type corruptingUpcaster struct{}
+
+func (u *corruptingUpcaster) EventType() string { return productAddedEventType }
+func (u *corruptingUpcaster) FromVersion() int  { return 1 }
+func (u *corruptingUpcaster) ToVersion() int    { return 2 }
+func (u *corruptingUpcaster) Upcast(_ []byte, _ mink.Metadata) ([]byte, error) {
+	return []byte(`{invalid json`), nil // Upcast succeeds but produces bad data
+}
+
+func TestE2E_Versioning_DeserializeError_AfterUpcast(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	storeV1Events(ctx, t, adapter, "ProductCatalog-deserr-1",
+		[]map[string]interface{}{{"product_id": "p1", "name": "Widget", "price": 9.99}},
+		mink.Metadata{}, mink.NoStream)
+
+	chain := mink.NewUpcasterChain()
+	require.NoError(t, chain.Register(&corruptingUpcaster{}))
+	store := mink.New(adapter, mink.WithUpcasters(chain))
+	store.RegisterEvents(ProductAdded{})
+
+	_, err := store.Load(ctx, "ProductCatalog-deserr-1")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "deserialize")
+}

--- a/e2e_versioning_test.go
+++ b/e2e_versioning_test.go
@@ -1,0 +1,462 @@
+package mink_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/AshkanYarmoradi/go-mink"
+	"github.com/AshkanYarmoradi/go-mink/adapters"
+	"github.com/AshkanYarmoradi/go-mink/adapters/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// E2E Test: Event Versioning & Upcasting
+// =============================================================================
+
+// --- Test Domain Events (versioned) ---
+// In a real application all schema versions share the same Go struct name,
+// since only the latest version exists in the codebase at any time.
+// In tests we need both old and new schemas simultaneously, so we use
+// separate struct names but a single logical event type name.
+
+// ProductAdded is the latest event schema (v3).
+// This is the struct the application code uses.
+type ProductAdded struct {
+	ProductID string  `json:"product_id"`
+	Name      string  `json:"name"`
+	Price     float64 `json:"price"`
+	Currency  string  `json:"currency"`
+	Tax       float64 `json:"tax"`
+}
+
+// productAddedEventType is the logical event type name — matches GetEventType(ProductAdded{}).
+const productAddedEventType = "ProductAdded"
+
+// --- Test Aggregate ---
+
+type productCatalog struct {
+	mink.AggregateBase
+	Products []catalogProduct
+}
+
+type catalogProduct struct {
+	ProductID string
+	Name      string
+	Price     float64
+	Currency  string
+	Tax       float64
+}
+
+func newProductCatalog(id string) *productCatalog {
+	return &productCatalog{
+		AggregateBase: mink.NewAggregateBase(id, "ProductCatalog"),
+	}
+}
+
+func (c *productCatalog) ApplyEvent(event interface{}) error {
+	switch e := event.(type) {
+	case ProductAdded:
+		c.Products = append(c.Products, catalogProduct(e))
+	default:
+		return fmt.Errorf("unknown event type: %T", event)
+	}
+	c.IncrementVersion()
+	return nil
+}
+
+// --- Test Upcasters ---
+
+// paV1ToV2 adds a default Currency field.
+type paV1ToV2 struct{}
+
+func (u *paV1ToV2) EventType() string { return productAddedEventType }
+func (u *paV1ToV2) FromVersion() int  { return 1 }
+func (u *paV1ToV2) ToVersion() int    { return 2 }
+func (u *paV1ToV2) Upcast(data []byte, metadata mink.Metadata) ([]byte, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	if metadata.TenantID == "eu-store" {
+		obj["currency"] = "EUR"
+	} else {
+		obj["currency"] = "USD"
+	}
+	return json.Marshal(obj)
+}
+
+// paV2ToV3 adds a default Tax field.
+type paV2ToV3 struct{}
+
+func (u *paV2ToV3) EventType() string { return productAddedEventType }
+func (u *paV2ToV3) FromVersion() int  { return 2 }
+func (u *paV2ToV3) ToVersion() int    { return 3 }
+func (u *paV2ToV3) Upcast(data []byte, metadata mink.Metadata) ([]byte, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	obj["tax"] = 0.0
+	return json.Marshal(obj)
+}
+
+// --- Test Helpers ---
+
+// storeV1Events stores events with the v1 schema (no currency, no tax) directly
+// through the adapter, using the consistent event type name "ProductAdded".
+// This simulates events stored before schema evolution was introduced.
+func storeV1Events(ctx context.Context, t *testing.T, adapter adapters.EventStoreAdapter, streamID string, events []map[string]interface{}, metadata mink.Metadata, expectedVersion int64) {
+	t.Helper()
+	records := make([]adapters.EventRecord, len(events))
+	for i, e := range events {
+		data, err := json.Marshal(e)
+		require.NoError(t, err)
+		records[i] = adapters.EventRecord{
+			Type: productAddedEventType,
+			Data: data,
+			Metadata: adapters.Metadata{
+				CorrelationID: metadata.CorrelationID,
+				CausationID:   metadata.CausationID,
+				UserID:        metadata.UserID,
+				TenantID:      metadata.TenantID,
+				Custom:        metadata.Custom,
+			},
+		}
+	}
+	_, err := adapter.Append(ctx, streamID, records, expectedVersion)
+	require.NoError(t, err)
+}
+
+// newV3Store creates a store with upcasters that deserializes into the latest ProductAdded struct.
+func newV3Store(adapter adapters.EventStoreAdapter) *mink.EventStore {
+	chain := mink.NewUpcasterChain()
+	_ = chain.Register(&paV1ToV2{})
+	_ = chain.Register(&paV2ToV3{})
+
+	store := mink.New(adapter, mink.WithUpcasters(chain))
+	store.RegisterEvents(ProductAdded{})
+	return store
+}
+
+// =============================================================================
+// Test: Full round-trip with memory adapter
+// =============================================================================
+
+func TestE2E_Versioning_FullRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Step 1: Store v1 events (no currency, no tax) via adapter.
+	// These simulate events stored before schema evolution was introduced.
+	storeV1Events(ctx, t, adapter, "ProductCatalog-catalog-1", []map[string]interface{}{
+		{"product_id": "prod-1", "name": "Widget", "price": 9.99},
+		{"product_id": "prod-2", "name": "Gadget", "price": 19.99},
+	}, mink.Metadata{}, mink.NoStream)
+
+	// Step 2: Create a store with upcasters and the latest event type.
+	storeV3 := newV3Store(adapter)
+
+	// Step 3: Load events — they should be transparently upcasted v1 → v2 → v3.
+	events, err := storeV3.Load(ctx, "ProductCatalog-catalog-1")
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	// Verify first event was upcasted
+	e1, ok := events[0].Data.(ProductAdded)
+	require.True(t, ok, "expected ProductAdded, got %T", events[0].Data)
+	assert.Equal(t, "prod-1", e1.ProductID)
+	assert.Equal(t, "Widget", e1.Name)
+	assert.Equal(t, 9.99, e1.Price)
+	assert.Equal(t, "USD", e1.Currency) // Added by v1→v2 upcaster
+	assert.Equal(t, 0.0, e1.Tax)        // Added by v2→v3 upcaster
+
+	// Verify second event
+	e2, ok := events[1].Data.(ProductAdded)
+	require.True(t, ok)
+	assert.Equal(t, "prod-2", e2.ProductID)
+	assert.Equal(t, "USD", e2.Currency)
+}
+
+// =============================================================================
+// Test: Upcaster uses metadata context (tenant-specific defaults)
+// =============================================================================
+
+func TestE2E_Versioning_MetadataContext(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Store v1 events with different tenant metadata
+	storeV1Events(ctx, t, adapter, "ProductCatalog-eu-1",
+		[]map[string]interface{}{{"product_id": "eu-prod", "name": "Euro Widget", "price": 8.99}},
+		mink.Metadata{TenantID: "eu-store"}, mink.NoStream)
+
+	storeV1Events(ctx, t, adapter, "ProductCatalog-us-1",
+		[]map[string]interface{}{{"product_id": "us-prod", "name": "Dollar Widget", "price": 9.99}},
+		mink.Metadata{TenantID: "us-store"}, mink.NoStream)
+
+	// Create store with upcasters — the v1→v2 upcaster reads TenantID
+	storeV3 := newV3Store(adapter)
+
+	// Load EU stream — should get EUR currency
+	euEvents, err := storeV3.Load(ctx, "ProductCatalog-eu-1")
+	require.NoError(t, err)
+	require.Len(t, euEvents, 1)
+	assert.Equal(t, "EUR", euEvents[0].Data.(ProductAdded).Currency, "EU tenant should get EUR")
+
+	// Load US stream — should get USD currency
+	usEvents, err := storeV3.Load(ctx, "ProductCatalog-us-1")
+	require.NoError(t, err)
+	require.Len(t, usEvents, 1)
+	assert.Equal(t, "USD", usEvents[0].Data.(ProductAdded).Currency, "US tenant should get USD")
+}
+
+// =============================================================================
+// Test: Schema version stamped on new events
+// =============================================================================
+
+func TestE2E_Versioning_SchemaVersionStamped(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	storeV3 := newV3Store(adapter)
+
+	// Append v3 event — should stamp schema version 3 in metadata
+	err := storeV3.Append(ctx, "ProductCatalog-stamped-1",
+		[]interface{}{ProductAdded{ProductID: "prod-new", Name: "New", Price: 5.0, Currency: "USD", Tax: 1.0}},
+	)
+	require.NoError(t, err)
+
+	// Load raw to inspect metadata
+	raw, err := storeV3.LoadRaw(ctx, "ProductCatalog-stamped-1", 0)
+	require.NoError(t, err)
+	require.Len(t, raw, 1)
+
+	schemaVersion := mink.GetSchemaVersion(raw[0].Metadata)
+	assert.Equal(t, 3, schemaVersion, "new events should be stamped with latest schema version")
+}
+
+// =============================================================================
+// Test: No upcasters — zero overhead, identical to current behavior
+// =============================================================================
+
+func TestE2E_Versioning_NoUpcasters_ZeroOverhead(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Store without upcasters — standard behavior
+	store := mink.New(adapter)
+	store.RegisterEvents(ProductAdded{})
+
+	err := store.Append(ctx, "ProductCatalog-noop-1",
+		[]interface{}{ProductAdded{ProductID: "prod-1", Name: "Widget", Price: 9.99, Currency: "USD", Tax: 0}},
+	)
+	require.NoError(t, err)
+
+	events, err := store.Load(ctx, "ProductCatalog-noop-1")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	e, ok := events[0].Data.(ProductAdded)
+	require.True(t, ok, "expected ProductAdded, got %T", events[0].Data)
+	assert.Equal(t, "prod-1", e.ProductID)
+	assert.Equal(t, 9.99, e.Price)
+
+	// No schema version stamped (no upcasters configured)
+	raw, err := store.LoadRaw(ctx, "ProductCatalog-noop-1", 0)
+	require.NoError(t, err)
+	assert.Equal(t, mink.DefaultSchemaVersion, mink.GetSchemaVersion(raw[0].Metadata),
+		"events without upcasters should default to version 1")
+}
+
+// =============================================================================
+// Test: Mixed-version events in same stream
+// =============================================================================
+
+func TestE2E_Versioning_MixedVersions(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Step 1: Store a v1 event (before upcasters were added)
+	storeV1Events(ctx, t, adapter, "ProductCatalog-mixed-1",
+		[]map[string]interface{}{{"product_id": "old-prod", "name": "Legacy", "price": 5.0}},
+		mink.Metadata{}, mink.NoStream)
+
+	// Step 2: Create store with upcasters and append a v3 event to same stream
+	storeV3 := newV3Store(adapter)
+	err := storeV3.Append(ctx, "ProductCatalog-mixed-1",
+		[]interface{}{ProductAdded{ProductID: "new-prod", Name: "Modern", Price: 15.0, Currency: "GBP", Tax: 3.0}},
+		mink.ExpectVersion(1),
+	)
+	require.NoError(t, err)
+
+	// Step 3: Load — stream has mixed versions:
+	//   event 1: stored as v1 (no $schema_version) → upcasted to v3
+	//   event 2: stored as v3 ($schema_version=3) → no upcasting needed
+	events, err := storeV3.Load(ctx, "ProductCatalog-mixed-1")
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	// Event 1: old v1, upcasted to v3
+	e1 := events[0].Data.(ProductAdded)
+	assert.Equal(t, "old-prod", e1.ProductID)
+	assert.Equal(t, "USD", e1.Currency, "v1 event should be upcasted with default currency")
+	assert.Equal(t, 0.0, e1.Tax, "v1 event should be upcasted with zero tax")
+
+	// Event 2: native v3, unchanged
+	e2 := events[1].Data.(ProductAdded)
+	assert.Equal(t, "new-prod", e2.ProductID)
+	assert.Equal(t, "GBP", e2.Currency, "v3 event currency should be preserved")
+	assert.Equal(t, 3.0, e2.Tax, "v3 event tax should be preserved")
+}
+
+// =============================================================================
+// Test: LoadAggregate with upcasting rebuilds correct state
+// =============================================================================
+
+func TestE2E_Versioning_LoadAggregate_Rebuild(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Store v1 events without upcasters
+	storeV1Events(ctx, t, adapter, "ProductCatalog-rebuild-1", []map[string]interface{}{
+		{"product_id": "prod-a", "name": "Alpha", "price": 10.0},
+		{"product_id": "prod-b", "name": "Beta", "price": 20.0},
+	}, mink.Metadata{}, mink.NoStream)
+
+	// Create store with upcasters
+	storeV3 := newV3Store(adapter)
+
+	// Load aggregate — events should be upcasted before ApplyEvent
+	catalog := newProductCatalog("rebuild-1")
+	err := storeV3.LoadAggregate(ctx, catalog)
+	require.NoError(t, err)
+
+	// Verify aggregate state was rebuilt from upcasted events
+	require.Len(t, catalog.Products, 2)
+	assert.Equal(t, "prod-a", catalog.Products[0].ProductID)
+	assert.Equal(t, "USD", catalog.Products[0].Currency, "upcasted currency")
+	assert.Equal(t, 0.0, catalog.Products[0].Tax, "upcasted tax")
+	assert.Equal(t, "prod-b", catalog.Products[1].ProductID)
+	assert.Equal(t, "USD", catalog.Products[1].Currency)
+}
+
+// =============================================================================
+// Test: RegisterUpcasters convenience method
+// =============================================================================
+
+func TestE2E_Versioning_RegisterUpcasters(t *testing.T) {
+	ctx := context.Background()
+	adapter := memory.NewAdapter()
+
+	// Store v1 events
+	storeV1Events(ctx, t, adapter, "ProductCatalog-convenience-1",
+		[]map[string]interface{}{{"product_id": "prod-c", "name": "Charlie", "price": 30.0}},
+		mink.Metadata{}, mink.AnyVersion)
+
+	// Use RegisterUpcasters convenience method (auto-creates chain)
+	store := mink.New(adapter)
+	store.RegisterEvents(ProductAdded{})
+	err := store.RegisterUpcasters(&paV1ToV2{}, &paV2ToV3{})
+	require.NoError(t, err)
+
+	events, err := store.Load(ctx, "ProductCatalog-convenience-1")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	e := events[0].Data.(ProductAdded)
+	assert.Equal(t, "prod-c", e.ProductID)
+	assert.Equal(t, "USD", e.Currency)
+	assert.Equal(t, 0.0, e.Tax)
+}
+
+// =============================================================================
+// Test: UpcastingSerializer standalone (without EventStore)
+// =============================================================================
+
+func TestE2E_Versioning_UpcastingSerializer_Standalone(t *testing.T) {
+	inner := mink.NewJSONSerializer()
+	inner.Register(productAddedEventType, ProductAdded{})
+
+	chain := mink.NewUpcasterChain()
+	require.NoError(t, chain.Register(&paV1ToV2{}))
+	require.NoError(t, chain.Register(&paV2ToV3{}))
+
+	s := mink.NewUpcastingSerializer(inner, chain)
+
+	// Deserialize v1 data through the upcasting serializer (version 1 → 3)
+	v1Data, _ := json.Marshal(map[string]interface{}{"product_id": "p2", "name": "Old", "price": 3.0})
+	result, err := s.DeserializeWithVersion(v1Data, productAddedEventType, 1, mink.Metadata{})
+	require.NoError(t, err)
+
+	event := result.(ProductAdded)
+	assert.Equal(t, "p2", event.ProductID)
+	assert.Equal(t, "USD", event.Currency)
+	assert.Equal(t, 0.0, event.Tax)
+
+	// Deserialize v3 data at version 3 — no upcasting should occur
+	v3Data, _ := json.Marshal(ProductAdded{ProductID: "p1", Name: "Test", Price: 5.0, Currency: "GBP", Tax: 1.0})
+	result2, err := s.DeserializeWithVersion(v3Data, productAddedEventType, 3, mink.Metadata{})
+	require.NoError(t, err)
+
+	event2 := result2.(ProductAdded)
+	assert.Equal(t, "p1", event2.ProductID)
+	assert.Equal(t, "GBP", event2.Currency, "v3 data at version 3 should not be upcasted")
+	assert.Equal(t, 1.0, event2.Tax)
+}
+
+// =============================================================================
+// Test: SchemaRegistry compatibility checks
+// =============================================================================
+
+func TestE2E_Versioning_SchemaRegistry(t *testing.T) {
+	registry := mink.NewSchemaRegistry()
+
+	require.NoError(t, registry.Register(productAddedEventType, mink.SchemaDefinition{
+		Version: 1,
+		Fields: []mink.FieldDefinition{
+			{Name: "product_id", Type: "string", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "price", Type: "float64", Required: true},
+		},
+	}))
+
+	require.NoError(t, registry.Register(productAddedEventType, mink.SchemaDefinition{
+		Version: 2,
+		Fields: []mink.FieldDefinition{
+			{Name: "product_id", Type: "string", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "price", Type: "float64", Required: true},
+			{Name: "currency", Type: "string", Required: false},
+		},
+	}))
+
+	require.NoError(t, registry.Register(productAddedEventType, mink.SchemaDefinition{
+		Version: 3,
+		Fields: []mink.FieldDefinition{
+			{Name: "product_id", Type: "string", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "price", Type: "float64", Required: true},
+			{Name: "currency", Type: "string", Required: false},
+			{Name: "tax", Type: "float64", Required: false},
+		},
+	}))
+
+	compat12, err := registry.CheckCompatibility(productAddedEventType, 1, 2)
+	require.NoError(t, err)
+	assert.Equal(t, mink.SchemaBackwardCompatible, compat12, "v1→v2 should be backward compatible")
+
+	compat23, err := registry.CheckCompatibility(productAddedEventType, 2, 3)
+	require.NoError(t, err)
+	assert.Equal(t, mink.SchemaBackwardCompatible, compat23, "v2→v3 should be backward compatible")
+
+	latest, err := registry.GetLatestVersion(productAddedEventType)
+	require.NoError(t, err)
+	assert.Equal(t, 3, latest)
+
+	types := registry.RegisteredEventTypes()
+	assert.Equal(t, []string{productAddedEventType}, types)
+}

--- a/examples/versioning/main.go
+++ b/examples/versioning/main.go
@@ -1,0 +1,283 @@
+// Package main demonstrates event versioning and upcasting in go-mink.
+//
+// This example shows:
+// - Storing events with an initial schema (v1)
+// - Defining upcasters for schema evolution (v1 → v2 → v3)
+// - Transparently loading old events as the latest schema version
+// - Schema version stamping on newly appended events
+// - Using the SchemaRegistry for compatibility checking
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/AshkanYarmoradi/go-mink"
+	"github.com/AshkanYarmoradi/go-mink/adapters/memory"
+)
+
+// ---------------------------------------------------------------------------
+// Event definitions — all schema versions share the same Go struct name so
+// the event type stored in the database ("ProductAdded") stays consistent.
+// Older events are transformed to the latest shape by upcasters at read time.
+// ---------------------------------------------------------------------------
+
+// ProductAdded is the latest (v3) schema for the "product added" event.
+// v1 had only Name and Price.
+// v2 added Currency (default "USD").
+// v3 added TaxRate  (default 0.0).
+type ProductAdded struct {
+	ProductID string  `json:"product_id"`
+	Name      string  `json:"name"`
+	Price     float64 `json:"price"`
+	Currency  string  `json:"currency"` // added in v2
+	TaxRate   float64 `json:"tax_rate"` // added in v3
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate
+// ---------------------------------------------------------------------------
+
+// Product is an aggregate that tracks catalog products.
+type Product struct {
+	mink.AggregateBase
+
+	Name     string
+	Price    float64
+	Currency string
+	TaxRate  float64
+}
+
+// NewProduct creates a new Product aggregate.
+func NewProduct(id string) *Product {
+	return &Product{
+		AggregateBase: mink.NewAggregateBase(id, "Product"),
+	}
+}
+
+// Add records a new product in the catalog.
+func (p *Product) Add(name string, price float64, currency string, taxRate float64) {
+	p.Apply(ProductAdded{
+		ProductID: p.AggregateID(),
+		Name:      name,
+		Price:     price,
+		Currency:  currency,
+		TaxRate:   taxRate,
+	})
+	p.Name = name
+	p.Price = price
+	p.Currency = currency
+	p.TaxRate = taxRate
+}
+
+// ApplyEvent replays a historical event to rebuild state.
+func (p *Product) ApplyEvent(event interface{}) error {
+	switch e := event.(type) {
+	case ProductAdded:
+		p.Name = e.Name
+		p.Price = e.Price
+		p.Currency = e.Currency
+		p.TaxRate = e.TaxRate
+	default:
+		return fmt.Errorf("unknown event type: %T", event)
+	}
+	p.IncrementVersion()
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Upcasters — pure data transformations on raw JSON bytes
+// ---------------------------------------------------------------------------
+
+// productAddedV1ToV2 adds the Currency field (default "USD").
+type productAddedV1ToV2 struct{}
+
+func (u productAddedV1ToV2) EventType() string { return "ProductAdded" }
+func (u productAddedV1ToV2) FromVersion() int  { return 1 }
+func (u productAddedV1ToV2) ToVersion() int    { return 2 }
+
+func (u productAddedV1ToV2) Upcast(data []byte, metadata mink.Metadata) ([]byte, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	m["currency"] = "USD" // default for all pre-v2 events
+	return json.Marshal(m)
+}
+
+// productAddedV2ToV3 adds the TaxRate field (default 0.0).
+type productAddedV2ToV3 struct{}
+
+func (u productAddedV2ToV3) EventType() string { return "ProductAdded" }
+func (u productAddedV2ToV3) FromVersion() int  { return 2 }
+func (u productAddedV2ToV3) ToVersion() int    { return 3 }
+
+func (u productAddedV2ToV3) Upcast(data []byte, metadata mink.Metadata) ([]byte, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	m["tax_rate"] = 0.0
+	return json.Marshal(m)
+}
+
+func main() {
+	ctx := context.Background()
+
+	fmt.Println("=== go-mink Event Versioning Example ===")
+	fmt.Println()
+
+	// ------------------------------------------------------------------
+	// Step 1: Store a v1 event (no upcasters, no schema version stamp)
+	// ------------------------------------------------------------------
+	fmt.Println("1. Storing a v1 ProductAdded event (old schema)...")
+
+	adapter := memory.NewAdapter()
+	storeV1 := mink.New(adapter)
+	storeV1.RegisterEvents(ProductAdded{})
+
+	// Simulate storing a v1 event — only Name and Price, no Currency or TaxRate.
+	v1Event := ProductAdded{
+		ProductID: "prod-001",
+		Name:      "Wireless Mouse",
+		Price:     29.99,
+		// Currency and TaxRate are zero-valued, representing the old schema.
+	}
+	err := storeV1.Append(ctx, "Product-prod-001", []interface{}{v1Event})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("   Stored: {Name: Wireless Mouse, Price: 29.99}")
+	fmt.Println("   (no Currency or TaxRate — this is a v1 event)")
+	fmt.Println()
+
+	// ------------------------------------------------------------------
+	// Step 2: Set up upcasters and create a new store
+	// ------------------------------------------------------------------
+	fmt.Println("2. Registering upcasters (v1 → v2 → v3)...")
+
+	chain := mink.NewUpcasterChain()
+	if err := chain.Register(productAddedV1ToV2{}); err != nil {
+		log.Fatal(err)
+	}
+	if err := chain.Register(productAddedV2ToV3{}); err != nil {
+		log.Fatal(err)
+	}
+	if err := chain.Validate(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("   Registered upcasters for: %v\n", chain.RegisteredEventTypes())
+	fmt.Printf("   Latest version for ProductAdded: v%d\n", chain.LatestVersion("ProductAdded"))
+	fmt.Println()
+
+	// Create a new store pointing at the same adapter, now with upcasters
+	storeV3 := mink.New(adapter, mink.WithUpcasters(chain))
+	storeV3.RegisterEvents(ProductAdded{})
+
+	// ------------------------------------------------------------------
+	// Step 3: Load the old event — it gets upcasted transparently
+	// ------------------------------------------------------------------
+	fmt.Println("3. Loading the old event through the new store...")
+
+	events, err := storeV3.Load(ctx, "Product-prod-001")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	loaded := events[0].Data.(ProductAdded)
+	fmt.Printf("   Loaded event (after upcasting):\n")
+	fmt.Printf("      Name:     %s\n", loaded.Name)
+	fmt.Printf("      Price:    $%.2f\n", loaded.Price)
+	fmt.Printf("      Currency: %s  (added by v1→v2 upcaster)\n", loaded.Currency)
+	fmt.Printf("      TaxRate:  %.1f%% (added by v2→v3 upcaster)\n", loaded.TaxRate*100)
+	fmt.Println()
+
+	// ------------------------------------------------------------------
+	// Step 4: Rebuild aggregate from old events
+	// ------------------------------------------------------------------
+	fmt.Println("4. Loading aggregate (rebuilds state from upcasted events)...")
+
+	product := NewProduct("prod-001")
+	if err := storeV3.LoadAggregate(ctx, product); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("   Product state:\n")
+	fmt.Printf("      Name:     %s\n", product.Name)
+	fmt.Printf("      Price:    $%.2f\n", product.Price)
+	fmt.Printf("      Currency: %s\n", product.Currency)
+	fmt.Printf("      TaxRate:  %.1f%%\n", product.TaxRate*100)
+	fmt.Printf("      Version:  %d\n", product.Version())
+	fmt.Println()
+
+	// ------------------------------------------------------------------
+	// Step 5: Save a new v3 event — schema version is stamped automatically
+	// ------------------------------------------------------------------
+	fmt.Println("5. Saving a new product (v3 schema, version stamped)...")
+
+	product2 := NewProduct("prod-002")
+	product2.Add("Mechanical Keyboard", 149.99, "EUR", 0.19)
+
+	if err := storeV3.SaveAggregate(ctx, product2); err != nil {
+		log.Fatal(err)
+	}
+
+	// Verify the schema version was stamped in metadata
+	rawEvents, err := storeV3.LoadRaw(ctx, "Product-prod-002", 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	schemaVersion := mink.GetSchemaVersion(rawEvents[0].Metadata)
+	fmt.Printf("   Stored event type: %s\n", rawEvents[0].Type)
+	fmt.Printf("   Schema version in metadata: v%d\n", schemaVersion)
+	fmt.Println()
+
+	// ------------------------------------------------------------------
+	// Step 6: SchemaRegistry — track and compare schemas
+	// ------------------------------------------------------------------
+	fmt.Println("6. Using SchemaRegistry for compatibility checking...")
+
+	registry := mink.NewSchemaRegistry()
+
+	_ = registry.Register("ProductAdded", mink.SchemaDefinition{
+		Version: 1,
+		Fields: []mink.FieldDefinition{
+			{Name: "product_id", Type: "string", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "price", Type: "float64", Required: true},
+		},
+	})
+	_ = registry.Register("ProductAdded", mink.SchemaDefinition{
+		Version: 2,
+		Fields: []mink.FieldDefinition{
+			{Name: "product_id", Type: "string", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "price", Type: "float64", Required: true},
+			{Name: "currency", Type: "string", Required: false},
+		},
+	})
+	_ = registry.Register("ProductAdded", mink.SchemaDefinition{
+		Version: 3,
+		Fields: []mink.FieldDefinition{
+			{Name: "product_id", Type: "string", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "price", Type: "float64", Required: true},
+			{Name: "currency", Type: "string", Required: false},
+			{Name: "tax_rate", Type: "float64", Required: false},
+		},
+	})
+
+	latestVer, _ := registry.GetLatestVersion("ProductAdded")
+	fmt.Printf("   Latest registered schema version: v%d\n", latestVer)
+
+	compat12, _ := registry.CheckCompatibility("ProductAdded", 1, 2)
+	compat23, _ := registry.CheckCompatibility("ProductAdded", 2, 3)
+	fmt.Printf("   v1 → v2: %s (Currency field added)\n", compat12)
+	fmt.Printf("   v2 → v3: %s (TaxRate field added)\n", compat23)
+	fmt.Println()
+
+	fmt.Println("=== Example Complete ===")
+}

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -1,0 +1,222 @@
+package mink
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// SchemaCompatibility represents the level of backward compatibility between schema versions.
+type SchemaCompatibility int
+
+const (
+	// SchemaFullyCompatible indicates the schema change is fully backward and forward compatible.
+	// No fields were added, removed, or changed — only documentation or ordering changes.
+	SchemaFullyCompatible SchemaCompatibility = iota
+
+	// SchemaBackwardCompatible indicates old data can be read by new code.
+	// Fields may have been added (with defaults) but none removed or changed.
+	SchemaBackwardCompatible
+
+	// SchemaForwardCompatible indicates new data can be read by old code.
+	// Fields may have been removed but none added or changed.
+	SchemaForwardCompatible
+
+	// SchemaBreaking indicates the schema change breaks compatibility.
+	// Fields were changed, renamed, or removed without migration support.
+	SchemaBreaking
+)
+
+// String returns a human-readable name for the compatibility level.
+func (c SchemaCompatibility) String() string {
+	switch c {
+	case SchemaFullyCompatible:
+		return "fully-compatible"
+	case SchemaBackwardCompatible:
+		return "backward-compatible"
+	case SchemaForwardCompatible:
+		return "forward-compatible"
+	case SchemaBreaking:
+		return "breaking"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(c))
+	}
+}
+
+// FieldDefinition describes a single field in an event schema.
+type FieldDefinition struct {
+	// Name is the field name.
+	Name string
+
+	// Type is the field type (e.g., "string", "int", "bool").
+	Type string
+
+	// Required indicates whether the field must be present.
+	Required bool
+}
+
+// SchemaDefinition describes the schema for a specific version of an event type.
+type SchemaDefinition struct {
+	// Version is the schema version number.
+	Version int
+
+	// Fields describes the fields in this schema version.
+	Fields []FieldDefinition
+
+	// JSONSchema is an optional JSON Schema document for validation.
+	JSONSchema json.RawMessage
+
+	// RegisteredAt is when this schema version was registered.
+	RegisteredAt time.Time
+}
+
+// SchemaRegistry is an in-memory registry that tracks event schemas and their versions.
+// It provides compatibility checking between schema versions.
+type SchemaRegistry struct {
+	mu      sync.RWMutex
+	schemas map[string]map[int]*SchemaDefinition // eventType → version → schema
+}
+
+// NewSchemaRegistry creates a new empty SchemaRegistry.
+func NewSchemaRegistry() *SchemaRegistry {
+	return &SchemaRegistry{
+		schemas: make(map[string]map[int]*SchemaDefinition),
+	}
+}
+
+// Register adds a schema definition for an event type.
+// Returns an error if the version is < 1 or already registered.
+func (r *SchemaRegistry) Register(eventType string, schema SchemaDefinition) error {
+	if schema.Version < 1 {
+		return fmt.Errorf("mink: schema version must be >= 1, got %d", schema.Version)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	versions, ok := r.schemas[eventType]
+	if !ok {
+		versions = make(map[int]*SchemaDefinition)
+		r.schemas[eventType] = versions
+	}
+
+	if _, exists := versions[schema.Version]; exists {
+		return fmt.Errorf("mink: schema version %d already registered for event type %q",
+			schema.Version, eventType)
+	}
+
+	s := schema
+	if s.RegisteredAt.IsZero() {
+		s.RegisteredAt = time.Now()
+	}
+	versions[schema.Version] = &s
+	return nil
+}
+
+// GetSchema retrieves a specific schema version for an event type.
+func (r *SchemaRegistry) GetSchema(eventType string, version int) (*SchemaDefinition, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	versions, ok := r.schemas[eventType]
+	if !ok {
+		return nil, fmt.Errorf("%w: event type %q", ErrSchemaNotFound, eventType)
+	}
+
+	schema, ok := versions[version]
+	if !ok {
+		return nil, fmt.Errorf("%w: event type %q version %d", ErrSchemaNotFound, eventType, version)
+	}
+
+	return schema, nil
+}
+
+// GetLatestVersion returns the highest registered schema version for an event type.
+func (r *SchemaRegistry) GetLatestVersion(eventType string) (int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	versions, ok := r.schemas[eventType]
+	if !ok {
+		return 0, fmt.Errorf("%w: event type %q", ErrSchemaNotFound, eventType)
+	}
+
+	latest := 0
+	for v := range versions {
+		if v > latest {
+			latest = v
+		}
+	}
+	return latest, nil
+}
+
+// CheckCompatibility determines the compatibility level between two schema versions.
+// It compares the field definitions to classify the change.
+func (r *SchemaRegistry) CheckCompatibility(eventType string, oldVersion, newVersion int) (SchemaCompatibility, error) {
+	oldSchema, err := r.GetSchema(eventType, oldVersion)
+	if err != nil {
+		return SchemaBreaking, err
+	}
+	newSchema, err := r.GetSchema(eventType, newVersion)
+	if err != nil {
+		return SchemaBreaking, err
+	}
+
+	oldFields := make(map[string]FieldDefinition, len(oldSchema.Fields))
+	for _, f := range oldSchema.Fields {
+		oldFields[f.Name] = f
+	}
+	newFields := make(map[string]FieldDefinition, len(newSchema.Fields))
+	for _, f := range newSchema.Fields {
+		newFields[f.Name] = f
+	}
+
+	hasAddedFields := false
+	hasRemovedFields := false
+	hasChangedFields := false
+
+	// Check for removed or changed fields
+	for name, oldField := range oldFields {
+		if newField, ok := newFields[name]; !ok {
+			hasRemovedFields = true
+		} else if oldField.Type != newField.Type {
+			hasChangedFields = true
+		}
+	}
+
+	// Check for added fields
+	for name := range newFields {
+		if _, ok := oldFields[name]; !ok {
+			hasAddedFields = true
+		}
+	}
+
+	if hasChangedFields {
+		return SchemaBreaking, nil
+	}
+	if hasRemovedFields && hasAddedFields {
+		return SchemaBreaking, nil
+	}
+	if hasRemovedFields {
+		return SchemaForwardCompatible, nil
+	}
+	if hasAddedFields {
+		return SchemaBackwardCompatible, nil
+	}
+	return SchemaFullyCompatible, nil
+}
+
+// RegisteredEventTypes returns a sorted list of event types that have schemas registered.
+func (r *SchemaRegistry) RegisteredEventTypes() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	types := make([]string, 0, len(r.schemas))
+	for t := range r.schemas {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
+}

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -1,0 +1,321 @@
+package mink
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestSchemaRegistry_Register(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(r *SchemaRegistry) error
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "register valid schema",
+			setup: func(r *SchemaRegistry) error {
+				return r.Register("OrderCreated", SchemaDefinition{
+					Version: 1,
+					Fields: []FieldDefinition{
+						{Name: "order_id", Type: "string", Required: true},
+						{Name: "amount", Type: "float64", Required: true},
+					},
+				})
+			},
+		},
+		{
+			name: "register multiple versions",
+			setup: func(r *SchemaRegistry) error {
+				if err := r.Register("OrderCreated", SchemaDefinition{
+					Version: 1,
+					Fields:  []FieldDefinition{{Name: "order_id", Type: "string", Required: true}},
+				}); err != nil {
+					return err
+				}
+				return r.Register("OrderCreated", SchemaDefinition{
+					Version: 2,
+					Fields: []FieldDefinition{
+						{Name: "order_id", Type: "string", Required: true},
+						{Name: "currency", Type: "string", Required: false},
+					},
+				})
+			},
+		},
+		{
+			name: "reject duplicate version",
+			setup: func(r *SchemaRegistry) error {
+				if err := r.Register("OrderCreated", SchemaDefinition{
+					Version: 1,
+					Fields:  []FieldDefinition{{Name: "order_id", Type: "string", Required: true}},
+				}); err != nil {
+					return err
+				}
+				return r.Register("OrderCreated", SchemaDefinition{
+					Version: 1,
+					Fields:  []FieldDefinition{{Name: "order_id", Type: "string", Required: true}},
+				})
+			},
+			wantErr: true,
+			errMsg:  "already registered",
+		},
+		{
+			name: "reject version less than 1",
+			setup: func(r *SchemaRegistry) error {
+				return r.Register("OrderCreated", SchemaDefinition{Version: 0})
+			},
+			wantErr: true,
+			errMsg:  "must be >= 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSchemaRegistry()
+			err := tt.setup(r)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSchemaRegistry_GetSchema(t *testing.T) {
+	r := NewSchemaRegistry()
+	_ = r.Register("OrderCreated", SchemaDefinition{
+		Version: 1,
+		Fields:  []FieldDefinition{{Name: "order_id", Type: "string", Required: true}},
+	})
+
+	t.Run("get existing schema", func(t *testing.T) {
+		schema, err := r.GetSchema("OrderCreated", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if schema.Version != 1 {
+			t.Errorf("expected version 1, got %d", schema.Version)
+		}
+		if len(schema.Fields) != 1 {
+			t.Errorf("expected 1 field, got %d", len(schema.Fields))
+		}
+	})
+
+	t.Run("schema not found for unknown event type", func(t *testing.T) {
+		_, err := r.GetSchema("Unknown", 1)
+		if !errors.Is(err, ErrSchemaNotFound) {
+			t.Errorf("expected ErrSchemaNotFound, got %v", err)
+		}
+	})
+
+	t.Run("schema not found for unknown version", func(t *testing.T) {
+		_, err := r.GetSchema("OrderCreated", 99)
+		if !errors.Is(err, ErrSchemaNotFound) {
+			t.Errorf("expected ErrSchemaNotFound, got %v", err)
+		}
+	})
+}
+
+func TestSchemaRegistry_GetLatestVersion(t *testing.T) {
+	r := NewSchemaRegistry()
+
+	t.Run("not found for unknown event type", func(t *testing.T) {
+		_, err := r.GetLatestVersion("Unknown")
+		if !errors.Is(err, ErrSchemaNotFound) {
+			t.Errorf("expected ErrSchemaNotFound, got %v", err)
+		}
+	})
+
+	t.Run("returns highest version", func(t *testing.T) {
+		_ = r.Register("OrderCreated", SchemaDefinition{Version: 1})
+		_ = r.Register("OrderCreated", SchemaDefinition{Version: 3})
+		_ = r.Register("OrderCreated", SchemaDefinition{Version: 2})
+
+		v, err := r.GetLatestVersion("OrderCreated")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v != 3 {
+			t.Errorf("expected 3, got %d", v)
+		}
+	})
+}
+
+func TestSchemaRegistry_CheckCompatibility(t *testing.T) {
+	tests := []struct {
+		name   string
+		v1     SchemaDefinition
+		v2     SchemaDefinition
+		expect SchemaCompatibility
+	}{
+		{
+			name: "fully compatible - same fields",
+			v1: SchemaDefinition{
+				Version: 1,
+				Fields: []FieldDefinition{
+					{Name: "order_id", Type: "string", Required: true},
+					{Name: "amount", Type: "float64", Required: true},
+				},
+			},
+			v2: SchemaDefinition{
+				Version: 2,
+				Fields: []FieldDefinition{
+					{Name: "order_id", Type: "string", Required: true},
+					{Name: "amount", Type: "float64", Required: true},
+				},
+			},
+			expect: SchemaFullyCompatible,
+		},
+		{
+			name: "backward compatible - field added",
+			v1: SchemaDefinition{
+				Version: 1,
+				Fields: []FieldDefinition{
+					{Name: "order_id", Type: "string", Required: true},
+				},
+			},
+			v2: SchemaDefinition{
+				Version: 2,
+				Fields: []FieldDefinition{
+					{Name: "order_id", Type: "string", Required: true},
+					{Name: "currency", Type: "string", Required: false},
+				},
+			},
+			expect: SchemaBackwardCompatible,
+		},
+		{
+			name: "forward compatible - field removed",
+			v1: SchemaDefinition{
+				Version: 1,
+				Fields: []FieldDefinition{
+					{Name: "order_id", Type: "string", Required: true},
+					{Name: "legacy", Type: "string", Required: false},
+				},
+			},
+			v2: SchemaDefinition{
+				Version: 2,
+				Fields: []FieldDefinition{
+					{Name: "order_id", Type: "string", Required: true},
+				},
+			},
+			expect: SchemaForwardCompatible,
+		},
+		{
+			name: "breaking - field type changed",
+			v1: SchemaDefinition{
+				Version: 1,
+				Fields: []FieldDefinition{
+					{Name: "amount", Type: "float64", Required: true},
+				},
+			},
+			v2: SchemaDefinition{
+				Version: 2,
+				Fields: []FieldDefinition{
+					{Name: "amount", Type: "string", Required: true},
+				},
+			},
+			expect: SchemaBreaking,
+		},
+		{
+			name: "breaking - field added and removed",
+			v1: SchemaDefinition{
+				Version: 1,
+				Fields: []FieldDefinition{
+					{Name: "old_field", Type: "string", Required: true},
+				},
+			},
+			v2: SchemaDefinition{
+				Version: 2,
+				Fields: []FieldDefinition{
+					{Name: "new_field", Type: "string", Required: true},
+				},
+			},
+			expect: SchemaBreaking,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSchemaRegistry()
+			_ = r.Register("TestEvent", tt.v1)
+			_ = r.Register("TestEvent", tt.v2)
+
+			compat, err := r.CheckCompatibility("TestEvent", tt.v1.Version, tt.v2.Version)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if compat != tt.expect {
+				t.Errorf("expected %s, got %s", tt.expect, compat)
+			}
+		})
+	}
+}
+
+func TestSchemaRegistry_RegisteredEventTypes(t *testing.T) {
+	r := NewSchemaRegistry()
+
+	types := r.RegisteredEventTypes()
+	if len(types) != 0 {
+		t.Errorf("expected empty, got %v", types)
+	}
+
+	_ = r.Register("OrderCreated", SchemaDefinition{Version: 1})
+	_ = r.Register("OrderShipped", SchemaDefinition{Version: 1})
+
+	types = r.RegisteredEventTypes()
+	if len(types) != 2 {
+		t.Fatalf("expected 2 types, got %d", len(types))
+	}
+	if types[0] != "OrderCreated" || types[1] != "OrderShipped" {
+		t.Errorf("expected [OrderCreated, OrderShipped], got %v", types)
+	}
+}
+
+func TestSchemaCompatibility_String(t *testing.T) {
+	tests := []struct {
+		compat SchemaCompatibility
+		want   string
+	}{
+		{SchemaFullyCompatible, "fully-compatible"},
+		{SchemaBackwardCompatible, "backward-compatible"},
+		{SchemaForwardCompatible, "forward-compatible"},
+		{SchemaBreaking, "breaking"},
+		{SchemaCompatibility(99), "unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.compat.String(); got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSchemaDefinition_WithJSONSchema(t *testing.T) {
+	r := NewSchemaRegistry()
+	jsonSchema := json.RawMessage(`{"type": "object", "properties": {"order_id": {"type": "string"}}}`)
+	err := r.Register("OrderCreated", SchemaDefinition{
+		Version:    1,
+		Fields:     []FieldDefinition{{Name: "order_id", Type: "string", Required: true}},
+		JSONSchema: jsonSchema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	schema, err := r.GetSchema("OrderCreated", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema.JSONSchema == nil {
+		t.Error("expected JSONSchema to be set")
+	}
+}

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -3,6 +3,7 @@ package mink
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -78,7 +79,7 @@ func TestSchemaRegistry_Register(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error, got nil")
 				}
-				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
 					t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
 				}
 			} else if err != nil {

--- a/serializer.go
+++ b/serializer.go
@@ -203,6 +203,17 @@ func SerializeEvent(serializer Serializer, event interface{}, metadata Metadata)
 	}, nil
 }
 
+// SerializeEventWithVersion is a convenience function that serializes an event and
+// stamps the metadata with the given schema version.
+func SerializeEventWithVersion(serializer Serializer, event interface{}, metadata Metadata, schemaVersion int) (EventData, error) {
+	eventData, err := SerializeEvent(serializer, event, metadata)
+	if err != nil {
+		return EventData{}, err
+	}
+	eventData.Metadata = SetSchemaVersion(eventData.Metadata, schemaVersion)
+	return eventData, nil
+}
+
 // DeserializeEvent is a convenience function that deserializes a StoredEvent to an Event.
 func DeserializeEvent(serializer Serializer, stored StoredEvent) (Event, error) {
 	data, err := serializer.Deserialize(stored.Data, stored.Type)

--- a/store.go
+++ b/store.go
@@ -13,6 +13,7 @@ type EventStore struct {
 	adapter    adapters.EventStoreAdapter
 	serializer Serializer
 	logger     Logger
+	upcasters  *UpcasterChain // nil by default — zero overhead when unused
 }
 
 // Logger defines the logging interface for the event store.
@@ -45,6 +46,16 @@ func WithSerializer(s Serializer) Option {
 func WithLogger(l Logger) Option {
 	return func(es *EventStore) {
 		es.logger = l
+	}
+}
+
+// WithUpcasters configures the event store with an upcaster chain for
+// transparent schema evolution. When set, events are automatically upcasted
+// to the latest schema version during loading and stamped with the latest
+// version during appending.
+func WithUpcasters(chain *UpcasterChain) Option {
+	return func(es *EventStore) {
+		es.upcasters = chain
 	}
 }
 
@@ -130,6 +141,11 @@ func (s *EventStore) Append(ctx context.Context, streamID string, events []inter
 			return fmt.Errorf("mink: failed to serialize event %d: %w", i, err)
 		}
 
+		// Stamp schema version if upcasters are configured
+		if s.upcasters != nil {
+			eventData.Metadata = SetSchemaVersion(eventData.Metadata, s.upcasters.LatestVersion(eventData.Type))
+		}
+
 		records[i] = adapters.EventRecord{
 			Type:     eventData.Type,
 			Data:     eventData.Data,
@@ -160,7 +176,7 @@ func (s *EventStore) LoadFrom(ctx context.Context, streamID string, fromVersion 
 	events := make([]Event, len(storedEvents))
 	for i, stored := range storedEvents {
 		minkStored := convertStoredEventFromAdapter(stored)
-		event, err := DeserializeEvent(s.serializer, minkStored)
+		event, err := s.deserializeWithUpcast(minkStored)
 		if err != nil {
 			return nil, fmt.Errorf("mink: failed to deserialize event %d: %w", i, err)
 		}
@@ -212,6 +228,11 @@ func (s *EventStore) SaveAggregate(ctx context.Context, agg Aggregate) error {
 		eventData, err := SerializeEvent(s.serializer, event, Metadata{})
 		if err != nil {
 			return fmt.Errorf("mink: failed to serialize aggregate event %d: %w", i, err)
+		}
+
+		// Stamp schema version if upcasters are configured
+		if s.upcasters != nil {
+			eventData.Metadata = SetSchemaVersion(eventData.Metadata, s.upcasters.LatestVersion(eventData.Type))
 		}
 
 		records[i] = adapters.EventRecord{
@@ -267,8 +288,19 @@ func (s *EventStore) LoadAggregate(ctx context.Context, agg Aggregate) error {
 
 	// Apply each event to rebuild state
 	for i, stored := range storedEvents {
-		// Deserialize event data
-		data, err := s.serializer.Deserialize(stored.Data, stored.Type)
+		// Deserialize event data with optional upcasting
+		eventData := stored.Data
+		if s.upcasters != nil && s.upcasters.HasUpcasters(stored.Type) {
+			minkStored := convertStoredEventFromAdapter(stored)
+			schemaVersion := GetSchemaVersion(minkStored.Metadata)
+			upcasted, _, err := s.upcasters.Upcast(stored.Type, schemaVersion, stored.Data, minkStored.Metadata)
+			if err != nil {
+				return fmt.Errorf("mink: failed to upcast event %d: %w", i, err)
+			}
+			eventData = upcasted
+		}
+
+		data, err := s.serializer.Deserialize(eventData, stored.Type)
 		if err != nil {
 			return fmt.Errorf("mink: failed to deserialize event %d: %w", i, err)
 		}
@@ -368,6 +400,42 @@ func convertStoredEventFromAdapter(s adapters.StoredEvent) StoredEvent {
 		GlobalPosition: s.GlobalPosition,
 		Timestamp:      s.Timestamp,
 	}
+}
+
+// deserializeWithUpcast deserializes a stored event, applying upcasting if configured.
+// If no upcasters are registered or none exist for the event type, it falls back
+// to the standard DeserializeEvent path with zero overhead.
+func (s *EventStore) deserializeWithUpcast(stored StoredEvent) (Event, error) {
+	if s.upcasters == nil || !s.upcasters.HasUpcasters(stored.Type) {
+		return DeserializeEvent(s.serializer, stored)
+	}
+
+	schemaVersion := GetSchemaVersion(stored.Metadata)
+	upcasted, _, err := s.upcasters.Upcast(stored.Type, schemaVersion, stored.Data, stored.Metadata)
+	if err != nil {
+		return Event{}, err
+	}
+
+	data, err := s.serializer.Deserialize(upcasted, stored.Type)
+	if err != nil {
+		return Event{}, err
+	}
+
+	return EventFromStored(stored, data), nil
+}
+
+// RegisterUpcasters is a convenience method that registers upcasters with the event store.
+// If no UpcasterChain has been configured, a new one is created automatically.
+func (s *EventStore) RegisterUpcasters(upcasters ...Upcaster) error {
+	if s.upcasters == nil {
+		s.upcasters = NewUpcasterChain()
+	}
+	for _, u := range upcasters {
+		if err := s.upcasters.Register(u); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // LoadEventsFromPosition loads events starting from a global position.

--- a/upcasting_serializer.go
+++ b/upcasting_serializer.go
@@ -1,0 +1,54 @@
+package mink
+
+// Compile-time interface check.
+var _ Serializer = (*UpcastingSerializer)(nil)
+
+// UpcastingSerializer is a decorator that wraps any Serializer and applies
+// upcasting during deserialization. Serialization passes through unchanged.
+type UpcastingSerializer struct {
+	inner Serializer
+	chain *UpcasterChain
+}
+
+// NewUpcastingSerializer creates a new UpcastingSerializer wrapping the given serializer.
+func NewUpcastingSerializer(inner Serializer, chain *UpcasterChain) *UpcastingSerializer {
+	return &UpcastingSerializer{
+		inner: inner,
+		chain: chain,
+	}
+}
+
+// Serialize converts an event to bytes. Pass-through to the inner serializer.
+func (s *UpcastingSerializer) Serialize(event interface{}) ([]byte, error) {
+	return s.inner.Serialize(event)
+}
+
+// Deserialize converts bytes back to an event.
+// If upcasters are registered for the event type, the data is upcasted from
+// DefaultSchemaVersion before deserialization.
+func (s *UpcastingSerializer) Deserialize(data []byte, eventType string) (interface{}, error) {
+	return s.DeserializeWithVersion(data, eventType, DefaultSchemaVersion, Metadata{})
+}
+
+// DeserializeWithVersion converts bytes back to an event, upcasting from the
+// specified schema version. Metadata is provided as read-only context to upcasters.
+func (s *UpcastingSerializer) DeserializeWithVersion(data []byte, eventType string, schemaVersion int, metadata Metadata) (interface{}, error) {
+	if s.chain != nil && s.chain.HasUpcasters(eventType) {
+		upcasted, _, err := s.chain.Upcast(eventType, schemaVersion, data, metadata)
+		if err != nil {
+			return nil, err
+		}
+		data = upcasted
+	}
+	return s.inner.Deserialize(data, eventType)
+}
+
+// Inner returns the wrapped serializer.
+func (s *UpcastingSerializer) Inner() Serializer {
+	return s.inner
+}
+
+// Chain returns the upcaster chain.
+func (s *UpcastingSerializer) Chain() *UpcasterChain {
+	return s.chain
+}

--- a/upcasting_serializer_test.go
+++ b/upcasting_serializer_test.go
@@ -1,0 +1,236 @@
+package mink
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type OrderCreatedV1 struct {
+	OrderID string  `json:"order_id"`
+	Amount  float64 `json:"amount"`
+}
+
+type OrderCreatedV2 struct {
+	OrderID  string  `json:"order_id"`
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
+}
+
+type OrderCreatedV3 struct {
+	OrderID  string  `json:"order_id"`
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
+	Tax      float64 `json:"tax"`
+}
+
+func TestUpcastingSerializer_Serialize(t *testing.T) {
+	inner := NewJSONSerializer()
+	chain := NewUpcasterChain()
+	s := NewUpcastingSerializer(inner, chain)
+
+	event := OrderCreatedV2{OrderID: "order-1", Amount: 100, Currency: "USD"}
+	data, err := s.Serialize(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify it produces the same output as the inner serializer
+	expected, _ := inner.Serialize(event)
+	if string(data) != string(expected) {
+		t.Errorf("expected %s, got %s", expected, data)
+	}
+}
+
+func TestUpcastingSerializer_Deserialize_NoUpcasters(t *testing.T) {
+	inner := NewJSONSerializer()
+	inner.Register("OrderCreatedV2", OrderCreatedV2{})
+	chain := NewUpcasterChain()
+	s := NewUpcastingSerializer(inner, chain)
+
+	data, _ := json.Marshal(OrderCreatedV2{OrderID: "order-1", Amount: 100, Currency: "USD"})
+	result, err := s.Deserialize(data, "OrderCreatedV2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	event, ok := result.(OrderCreatedV2)
+	if !ok {
+		t.Fatalf("expected OrderCreatedV2, got %T", result)
+	}
+	if event.OrderID != "order-1" {
+		t.Errorf("expected order-1, got %s", event.OrderID)
+	}
+	if event.Currency != "USD" {
+		t.Errorf("expected USD, got %s", event.Currency)
+	}
+}
+
+func TestUpcastingSerializer_Deserialize_WithUpcasting(t *testing.T) {
+	inner := NewJSONSerializer()
+	inner.Register("OrderCreated", OrderCreatedV2{})
+
+	chain := NewUpcasterChain()
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+		var obj map[string]interface{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, err
+		}
+		obj["currency"] = "USD"
+		return json.Marshal(obj)
+	}))
+
+	s := NewUpcastingSerializer(inner, chain)
+
+	// Serialize a v1 event (no currency field)
+	v1Data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
+
+	// Deserialize should upcast from v1 to v2
+	result, err := s.Deserialize(v1Data, "OrderCreated")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	event, ok := result.(OrderCreatedV2)
+	if !ok {
+		t.Fatalf("expected OrderCreatedV2, got %T", result)
+	}
+	if event.Currency != "USD" {
+		t.Errorf("expected USD after upcast, got %s", event.Currency)
+	}
+	if event.Amount != 100 {
+		t.Errorf("expected amount 100, got %f", event.Amount)
+	}
+}
+
+func TestUpcastingSerializer_DeserializeWithVersion(t *testing.T) {
+	inner := NewJSONSerializer()
+	inner.Register("OrderCreated", OrderCreatedV3{})
+
+	chain := NewUpcasterChain()
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+		var obj map[string]interface{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, err
+		}
+		obj["currency"] = "USD"
+		return json.Marshal(obj)
+	}))
+	_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
+		var obj map[string]interface{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, err
+		}
+		obj["tax"] = 10.0
+		return json.Marshal(obj)
+	}))
+
+	s := NewUpcastingSerializer(inner, chain)
+
+	t.Run("upcast from v1 to v3", func(t *testing.T) {
+		v1Data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
+		result, err := s.DeserializeWithVersion(v1Data, "OrderCreated", 1, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		event := result.(OrderCreatedV3)
+		if event.Currency != "USD" {
+			t.Errorf("expected USD, got %s", event.Currency)
+		}
+		if event.Tax != 10.0 {
+			t.Errorf("expected tax 10.0, got %f", event.Tax)
+		}
+	})
+
+	t.Run("upcast from v2 to v3", func(t *testing.T) {
+		v2Data, _ := json.Marshal(OrderCreatedV2{OrderID: "order-1", Amount: 100, Currency: "EUR"})
+		result, err := s.DeserializeWithVersion(v2Data, "OrderCreated", 2, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		event := result.(OrderCreatedV3)
+		if event.Currency != "EUR" {
+			t.Errorf("expected EUR (preserved), got %s", event.Currency)
+		}
+		if event.Tax != 10.0 {
+			t.Errorf("expected tax 10.0, got %f", event.Tax)
+		}
+	})
+
+	t.Run("v3 data no upcasting needed", func(t *testing.T) {
+		v3Data, _ := json.Marshal(OrderCreatedV3{OrderID: "order-1", Amount: 100, Currency: "GBP", Tax: 20.0})
+		result, err := s.DeserializeWithVersion(v3Data, "OrderCreated", 3, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		event := result.(OrderCreatedV3)
+		if event.Currency != "GBP" {
+			t.Errorf("expected GBP, got %s", event.Currency)
+		}
+		if event.Tax != 20.0 {
+			t.Errorf("expected tax 20.0, got %f", event.Tax)
+		}
+	})
+}
+
+func TestUpcastingSerializer_DeserializeWithVersion_ErrorPropagation(t *testing.T) {
+	inner := NewJSONSerializer()
+	inner.Register("OrderCreated", OrderCreatedV2{})
+
+	chain := NewUpcasterChain()
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+		return nil, errors.New("upcast failed")
+	}))
+
+	s := NewUpcastingSerializer(inner, chain)
+
+	v1Data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
+	_, err := s.DeserializeWithVersion(v1Data, "OrderCreated", 1, Metadata{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrUpcastFailed) {
+		t.Errorf("expected ErrUpcastFailed, got %v", err)
+	}
+}
+
+func TestUpcastingSerializer_NilChain(t *testing.T) {
+	inner := NewJSONSerializer()
+	inner.Register("OrderCreated", OrderCreatedV1{})
+	s := NewUpcastingSerializer(inner, nil)
+
+	data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
+	result, err := s.Deserialize(data, "OrderCreated")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	event, ok := result.(OrderCreatedV1)
+	if !ok {
+		t.Fatalf("expected OrderCreatedV1, got %T", result)
+	}
+	if event.OrderID != "order-1" {
+		t.Errorf("expected order-1, got %s", event.OrderID)
+	}
+}
+
+func TestUpcastingSerializer_Inner(t *testing.T) {
+	inner := NewJSONSerializer()
+	chain := NewUpcasterChain()
+	s := NewUpcastingSerializer(inner, chain)
+
+	if s.Inner() != inner {
+		t.Error("Inner() should return the wrapped serializer")
+	}
+	if s.Chain() != chain {
+		t.Error("Chain() should return the upcaster chain")
+	}
+}
+
+func TestUpcastingSerializer_CompileTimeCheck(t *testing.T) {
+	// This test verifies the compile-time interface check
+	var _ Serializer = (*UpcastingSerializer)(nil)
+}

--- a/upcasting_serializer_test.go
+++ b/upcasting_serializer_test.go
@@ -24,10 +24,17 @@ type OrderCreatedV3 struct {
 	Tax      float64 `json:"tax"`
 }
 
+// newOrderCreatedChain builds a reusable v1→v2→v3 upcaster chain for OrderCreated tests.
+func newOrderCreatedChain() *UpcasterChain {
+	chain := NewUpcasterChain()
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, addJSONFieldUpcastFn("currency", "USD")))
+	_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, addJSONFieldUpcastFn("tax", 10.0)))
+	return chain
+}
+
 func TestUpcastingSerializer_Serialize(t *testing.T) {
 	inner := NewJSONSerializer()
-	chain := NewUpcasterChain()
-	s := NewUpcastingSerializer(inner, chain)
+	s := NewUpcastingSerializer(inner, NewUpcasterChain())
 
 	event := OrderCreatedV2{OrderID: "order-1", Amount: 100, Currency: "USD"}
 	data, err := s.Serialize(event)
@@ -35,7 +42,6 @@ func TestUpcastingSerializer_Serialize(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify it produces the same output as the inner serializer
 	expected, _ := inner.Serialize(event)
 	if string(data) != string(expected) {
 		t.Errorf("expected %s, got %s", expected, data)
@@ -45,8 +51,7 @@ func TestUpcastingSerializer_Serialize(t *testing.T) {
 func TestUpcastingSerializer_Deserialize_NoUpcasters(t *testing.T) {
 	inner := NewJSONSerializer()
 	inner.Register("OrderCreatedV2", OrderCreatedV2{})
-	chain := NewUpcasterChain()
-	s := NewUpcastingSerializer(inner, chain)
+	s := NewUpcastingSerializer(inner, NewUpcasterChain())
 
 	data, _ := json.Marshal(OrderCreatedV2{OrderID: "order-1", Amount: 100, Currency: "USD"})
 	result, err := s.Deserialize(data, "OrderCreatedV2")
@@ -58,11 +63,8 @@ func TestUpcastingSerializer_Deserialize_NoUpcasters(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected OrderCreatedV2, got %T", result)
 	}
-	if event.OrderID != "order-1" {
-		t.Errorf("expected order-1, got %s", event.OrderID)
-	}
-	if event.Currency != "USD" {
-		t.Errorf("expected USD, got %s", event.Currency)
+	if event.OrderID != "order-1" || event.Currency != "USD" {
+		t.Errorf("unexpected event values: %+v", event)
 	}
 }
 
@@ -71,21 +73,10 @@ func TestUpcastingSerializer_Deserialize_WithUpcasting(t *testing.T) {
 	inner.Register("OrderCreated", OrderCreatedV2{})
 
 	chain := NewUpcasterChain()
-	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-		var obj map[string]interface{}
-		if err := json.Unmarshal(data, &obj); err != nil {
-			return nil, err
-		}
-		obj["currency"] = "USD"
-		return json.Marshal(obj)
-	}))
-
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, addJSONFieldUpcastFn("currency", "USD")))
 	s := NewUpcastingSerializer(inner, chain)
 
-	// Serialize a v1 event (no currency field)
 	v1Data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
-
-	// Deserialize should upcast from v1 to v2
 	result, err := s.Deserialize(v1Data, "OrderCreated")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,85 +86,44 @@ func TestUpcastingSerializer_Deserialize_WithUpcasting(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected OrderCreatedV2, got %T", result)
 	}
-	if event.Currency != "USD" {
-		t.Errorf("expected USD after upcast, got %s", event.Currency)
-	}
-	if event.Amount != 100 {
-		t.Errorf("expected amount 100, got %f", event.Amount)
+	if event.Currency != "USD" || event.Amount != 100 {
+		t.Errorf("unexpected event values: %+v", event)
 	}
 }
 
 func TestUpcastingSerializer_DeserializeWithVersion(t *testing.T) {
 	inner := NewJSONSerializer()
 	inner.Register("OrderCreated", OrderCreatedV3{})
+	s := NewUpcastingSerializer(inner, newOrderCreatedChain())
 
-	chain := NewUpcasterChain()
-	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-		var obj map[string]interface{}
-		if err := json.Unmarshal(data, &obj); err != nil {
-			return nil, err
-		}
-		obj["currency"] = "USD"
-		return json.Marshal(obj)
-	}))
-	_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
-		var obj map[string]interface{}
-		if err := json.Unmarshal(data, &obj); err != nil {
-			return nil, err
-		}
-		obj["tax"] = 10.0
-		return json.Marshal(obj)
-	}))
+	tests := []struct {
+		name         string
+		data         interface{}
+		fromVersion  int
+		wantCurrency string
+		wantTax      float64
+	}{
+		{"v1 to v3", OrderCreatedV1{OrderID: "o1", Amount: 100}, 1, "USD", 10.0},
+		{"v2 to v3", OrderCreatedV2{OrderID: "o1", Amount: 100, Currency: "EUR"}, 2, "EUR", 10.0},
+		{"v3 no upcast", OrderCreatedV3{OrderID: "o1", Amount: 100, Currency: "GBP", Tax: 20.0}, 3, "GBP", 20.0},
+	}
 
-	s := NewUpcastingSerializer(inner, chain)
-
-	t.Run("upcast from v1 to v3", func(t *testing.T) {
-		v1Data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
-		result, err := s.DeserializeWithVersion(v1Data, "OrderCreated", 1, Metadata{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		event := result.(OrderCreatedV3)
-		if event.Currency != "USD" {
-			t.Errorf("expected USD, got %s", event.Currency)
-		}
-		if event.Tax != 10.0 {
-			t.Errorf("expected tax 10.0, got %f", event.Tax)
-		}
-	})
-
-	t.Run("upcast from v2 to v3", func(t *testing.T) {
-		v2Data, _ := json.Marshal(OrderCreatedV2{OrderID: "order-1", Amount: 100, Currency: "EUR"})
-		result, err := s.DeserializeWithVersion(v2Data, "OrderCreated", 2, Metadata{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		event := result.(OrderCreatedV3)
-		if event.Currency != "EUR" {
-			t.Errorf("expected EUR (preserved), got %s", event.Currency)
-		}
-		if event.Tax != 10.0 {
-			t.Errorf("expected tax 10.0, got %f", event.Tax)
-		}
-	})
-
-	t.Run("v3 data no upcasting needed", func(t *testing.T) {
-		v3Data, _ := json.Marshal(OrderCreatedV3{OrderID: "order-1", Amount: 100, Currency: "GBP", Tax: 20.0})
-		result, err := s.DeserializeWithVersion(v3Data, "OrderCreated", 3, Metadata{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		event := result.(OrderCreatedV3)
-		if event.Currency != "GBP" {
-			t.Errorf("expected GBP, got %s", event.Currency)
-		}
-		if event.Tax != 20.0 {
-			t.Errorf("expected tax 20.0, got %f", event.Tax)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, _ := json.Marshal(tt.data)
+			result, err := s.DeserializeWithVersion(data, "OrderCreated", tt.fromVersion, Metadata{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			event := result.(OrderCreatedV3)
+			if event.Currency != tt.wantCurrency {
+				t.Errorf("expected currency %s, got %s", tt.wantCurrency, event.Currency)
+			}
+			if event.Tax != tt.wantTax {
+				t.Errorf("expected tax %v, got %v", tt.wantTax, event.Tax)
+			}
+		})
+	}
 }
 
 func TestUpcastingSerializer_DeserializeWithVersion_ErrorPropagation(t *testing.T) {
@@ -181,17 +131,13 @@ func TestUpcastingSerializer_DeserializeWithVersion_ErrorPropagation(t *testing.
 	inner.Register("OrderCreated", OrderCreatedV2{})
 
 	chain := NewUpcasterChain()
-	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, _ Metadata) ([]byte, error) {
 		return nil, errors.New("upcast failed")
 	}))
 
 	s := NewUpcastingSerializer(inner, chain)
-
 	v1Data, _ := json.Marshal(OrderCreatedV1{OrderID: "order-1", Amount: 100})
 	_, err := s.DeserializeWithVersion(v1Data, "OrderCreated", 1, Metadata{})
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
 	if !errors.Is(err, ErrUpcastFailed) {
 		t.Errorf("expected ErrUpcastFailed, got %v", err)
 	}
@@ -207,13 +153,8 @@ func TestUpcastingSerializer_NilChain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	event, ok := result.(OrderCreatedV1)
-	if !ok {
-		t.Fatalf("expected OrderCreatedV1, got %T", result)
-	}
-	if event.OrderID != "order-1" {
-		t.Errorf("expected order-1, got %s", event.OrderID)
+	if event, ok := result.(OrderCreatedV1); !ok || event.OrderID != "order-1" {
+		t.Errorf("unexpected result: %+v", result)
 	}
 }
 
@@ -231,6 +172,5 @@ func TestUpcastingSerializer_Inner(t *testing.T) {
 }
 
 func TestUpcastingSerializer_CompileTimeCheck(t *testing.T) {
-	// This test verifies the compile-time interface check
 	var _ Serializer = (*UpcastingSerializer)(nil)
 }

--- a/versioning.go
+++ b/versioning.go
@@ -1,0 +1,210 @@
+package mink
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+const (
+	// schemaVersionKey is the metadata key used to store the schema version.
+	// The $ prefix marks it as system-managed, preventing collisions with user metadata.
+	schemaVersionKey = "$schema_version"
+
+	// DefaultSchemaVersion is the schema version assumed for events without an explicit version.
+	// All events stored before versioning was introduced are treated as version 1.
+	DefaultSchemaVersion = 1
+)
+
+// Upcaster transforms event data from one schema version to the next.
+// Upcasters operate on raw bytes and are serializer-agnostic.
+// Each upcaster handles exactly one version transition (FromVersion → ToVersion).
+type Upcaster interface {
+	// EventType returns the event type this upcaster handles.
+	EventType() string
+
+	// FromVersion returns the source schema version.
+	FromVersion() int
+
+	// ToVersion returns the target schema version. Must equal FromVersion() + 1.
+	ToVersion() int
+
+	// Upcast transforms event data from FromVersion to ToVersion.
+	// Metadata is provided as read-only context (e.g., for tenant-specific defaults).
+	Upcast(data []byte, metadata Metadata) ([]byte, error)
+}
+
+// UpcasterChain is a thread-safe registry of upcasters that applies them in sequence.
+// It validates that there are no gaps or duplicates in the version chain.
+type UpcasterChain struct {
+	mu        sync.RWMutex
+	upcasters map[string][]Upcaster // eventType → sorted by FromVersion
+	latest    map[string]int        // eventType → latest version
+}
+
+// NewUpcasterChain creates a new empty UpcasterChain.
+func NewUpcasterChain() *UpcasterChain {
+	return &UpcasterChain{
+		upcasters: make(map[string][]Upcaster),
+		latest:    make(map[string]int),
+	}
+}
+
+// Register adds an upcaster to the chain.
+// Returns an error if the upcaster's ToVersion != FromVersion + 1 or if
+// an upcaster for the same event type and version transition already exists.
+func (c *UpcasterChain) Register(u Upcaster) error {
+	if u.ToVersion() != u.FromVersion()+1 {
+		return fmt.Errorf("mink: upcaster for %q must have ToVersion (%d) == FromVersion (%d) + 1",
+			u.EventType(), u.ToVersion(), u.FromVersion())
+	}
+
+	if u.FromVersion() < 1 {
+		return fmt.Errorf("mink: upcaster for %q must have FromVersion >= 1, got %d",
+			u.EventType(), u.FromVersion())
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	eventType := u.EventType()
+	existing := c.upcasters[eventType]
+
+	// Check for duplicates
+	for _, e := range existing {
+		if e.FromVersion() == u.FromVersion() {
+			return fmt.Errorf("mink: duplicate upcaster for %q from version %d to %d",
+				eventType, u.FromVersion(), u.ToVersion())
+		}
+	}
+
+	// Insert and keep sorted by FromVersion
+	c.upcasters[eventType] = append(existing, u)
+	sort.Slice(c.upcasters[eventType], func(i, j int) bool {
+		return c.upcasters[eventType][i].FromVersion() < c.upcasters[eventType][j].FromVersion()
+	})
+
+	// Update latest version
+	if u.ToVersion() > c.latest[eventType] {
+		c.latest[eventType] = u.ToVersion()
+	}
+
+	return nil
+}
+
+// Validate checks the entire chain for gaps.
+// For each event type, the upcasters must form a contiguous chain from the
+// lowest FromVersion to the highest ToVersion.
+func (c *UpcasterChain) Validate() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for eventType, upcasters := range c.upcasters {
+		if len(upcasters) == 0 {
+			continue
+		}
+
+		// Check for contiguous chain
+		for i := 1; i < len(upcasters); i++ {
+			expected := upcasters[i-1].ToVersion()
+			actual := upcasters[i].FromVersion()
+			if actual != expected {
+				return NewSchemaVersionGapError(eventType, expected, actual)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Upcast transforms event data from fromVersion to the latest version.
+// Returns the transformed data, the final version, and any error.
+// If no upcasters exist for the event type or the data is already at the latest version,
+// the original data is returned unchanged.
+func (c *UpcasterChain) Upcast(eventType string, fromVersion int, data []byte, metadata Metadata) ([]byte, int, error) {
+	c.mu.RLock()
+	upcasters := c.upcasters[eventType]
+	c.mu.RUnlock()
+
+	if len(upcasters) == 0 {
+		return data, fromVersion, nil
+	}
+
+	currentVersion := fromVersion
+	currentData := data
+
+	for _, u := range upcasters {
+		if u.FromVersion() < currentVersion {
+			continue
+		}
+		if u.FromVersion() > currentVersion {
+			// Gap — the event is at a version we can't upcast from
+			break
+		}
+
+		result, err := u.Upcast(currentData, metadata)
+		if err != nil {
+			return nil, currentVersion, NewUpcastError(eventType, u.FromVersion(), u.ToVersion(), err)
+		}
+
+		currentData = result
+		currentVersion = u.ToVersion()
+	}
+
+	return currentData, currentVersion, nil
+}
+
+// HasUpcasters reports whether any upcasters are registered for the given event type.
+func (c *UpcasterChain) HasUpcasters(eventType string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.upcasters[eventType]) > 0
+}
+
+// LatestVersion returns the latest schema version for the given event type.
+// Returns DefaultSchemaVersion if no upcasters are registered for the type.
+func (c *UpcasterChain) LatestVersion(eventType string) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if v, ok := c.latest[eventType]; ok {
+		return v
+	}
+	return DefaultSchemaVersion
+}
+
+// RegisteredEventTypes returns a sorted list of event types that have upcasters registered.
+func (c *UpcasterChain) RegisteredEventTypes() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	types := make([]string, 0, len(c.upcasters))
+	for t := range c.upcasters {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// GetSchemaVersion extracts the schema version from event metadata.
+// Returns DefaultSchemaVersion if the version is not set or cannot be parsed.
+func GetSchemaVersion(m Metadata) int {
+	if m.Custom == nil {
+		return DefaultSchemaVersion
+	}
+	v, ok := m.Custom[schemaVersionKey]
+	if !ok {
+		return DefaultSchemaVersion
+	}
+	version, err := strconv.Atoi(v)
+	if err != nil {
+		return DefaultSchemaVersion
+	}
+	return version
+}
+
+// SetSchemaVersion returns a copy of Metadata with the schema version set.
+func SetSchemaVersion(m Metadata, version int) Metadata {
+	return m.WithCustom(schemaVersionKey, strconv.Itoa(version))
+}

--- a/versioning_errors.go
+++ b/versioning_errors.go
@@ -1,0 +1,123 @@
+package mink
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for event versioning and upcasting.
+var (
+	// ErrUpcastFailed indicates an upcaster failed to transform event data.
+	ErrUpcastFailed = errors.New("mink: upcast failed")
+
+	// ErrSchemaVersionGap indicates a gap in the upcaster chain for an event type.
+	ErrSchemaVersionGap = errors.New("mink: schema version gap")
+
+	// ErrIncompatibleSchema indicates a schema change is not backward compatible.
+	ErrIncompatibleSchema = errors.New("mink: incompatible schema")
+
+	// ErrSchemaNotFound indicates the requested schema was not found.
+	ErrSchemaNotFound = errors.New("mink: schema not found")
+)
+
+// UpcastError provides detailed information about an upcasting failure.
+type UpcastError struct {
+	EventType   string
+	FromVersion int
+	ToVersion   int
+	Cause       error
+}
+
+// Error returns the error message.
+func (e *UpcastError) Error() string {
+	return fmt.Sprintf("mink: failed to upcast event type %q from version %d to %d: %v",
+		e.EventType, e.FromVersion, e.ToVersion, e.Cause)
+}
+
+// Is reports whether this error matches the target error.
+func (e *UpcastError) Is(target error) bool {
+	return target == ErrUpcastFailed
+}
+
+// Unwrap returns the underlying cause for errors.Unwrap().
+func (e *UpcastError) Unwrap() error {
+	return e.Cause
+}
+
+// NewUpcastError creates a new UpcastError.
+func NewUpcastError(eventType string, fromVersion, toVersion int, cause error) *UpcastError {
+	return &UpcastError{
+		EventType:   eventType,
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
+		Cause:       cause,
+	}
+}
+
+// SchemaVersionGapError provides detailed information about a gap in the upcaster chain.
+type SchemaVersionGapError struct {
+	EventType       string
+	MissingVersion  int
+	ExpectedVersion int
+}
+
+// Error returns the error message.
+func (e *SchemaVersionGapError) Error() string {
+	return fmt.Sprintf("mink: schema version gap for event type %q: missing version %d (expected %d)",
+		e.EventType, e.MissingVersion, e.ExpectedVersion)
+}
+
+// Is reports whether this error matches the target error.
+func (e *SchemaVersionGapError) Is(target error) bool {
+	return target == ErrSchemaVersionGap
+}
+
+// Unwrap returns the underlying error for errors.Unwrap().
+func (e *SchemaVersionGapError) Unwrap() error {
+	return ErrSchemaVersionGap
+}
+
+// NewSchemaVersionGapError creates a new SchemaVersionGapError.
+func NewSchemaVersionGapError(eventType string, missingVersion, expectedVersion int) *SchemaVersionGapError {
+	return &SchemaVersionGapError{
+		EventType:       eventType,
+		MissingVersion:  missingVersion,
+		ExpectedVersion: expectedVersion,
+	}
+}
+
+// IncompatibleSchemaError provides detailed information about a schema incompatibility.
+type IncompatibleSchemaError struct {
+	EventType     string
+	OldVersion    int
+	NewVersion    int
+	Compatibility SchemaCompatibility
+	Reason        string
+}
+
+// Error returns the error message.
+func (e *IncompatibleSchemaError) Error() string {
+	return fmt.Sprintf("mink: incompatible schema for event type %q (v%d → v%d): %s",
+		e.EventType, e.OldVersion, e.NewVersion, e.Reason)
+}
+
+// Is reports whether this error matches the target error.
+func (e *IncompatibleSchemaError) Is(target error) bool {
+	return target == ErrIncompatibleSchema
+}
+
+// Unwrap returns the underlying error for errors.Unwrap().
+func (e *IncompatibleSchemaError) Unwrap() error {
+	return ErrIncompatibleSchema
+}
+
+// NewIncompatibleSchemaError creates a new IncompatibleSchemaError.
+func NewIncompatibleSchemaError(eventType string, oldVersion, newVersion int, compatibility SchemaCompatibility, reason string) *IncompatibleSchemaError {
+	return &IncompatibleSchemaError{
+		EventType:     eventType,
+		OldVersion:    oldVersion,
+		NewVersion:    newVersion,
+		Compatibility: compatibility,
+		Reason:        reason,
+	}
+}

--- a/versioning_test.go
+++ b/versioning_test.go
@@ -519,9 +519,19 @@ func TestSetSchemaVersion(t *testing.T) {
 
 func TestVersioningErrors(t *testing.T) {
 	t.Run("UpcastError matches ErrUpcastFailed", func(t *testing.T) {
-		err := NewUpcastError("OrderCreated", 1, 2, fmt.Errorf("bad data"))
+		cause := fmt.Errorf("bad data")
+		err := NewUpcastError("OrderCreated", 1, 2, cause)
 		if !errors.Is(err, ErrUpcastFailed) {
 			t.Error("expected UpcastError to match ErrUpcastFailed")
+		}
+		if err.Error() == "" {
+			t.Error("expected non-empty error message")
+		}
+		if !contains(err.Error(), "OrderCreated") {
+			t.Error("error message should contain event type")
+		}
+		if err.Unwrap() != cause {
+			t.Error("Unwrap should return the cause")
 		}
 	})
 
@@ -530,6 +540,15 @@ func TestVersioningErrors(t *testing.T) {
 		if !errors.Is(err, ErrSchemaVersionGap) {
 			t.Error("expected SchemaVersionGapError to match ErrSchemaVersionGap")
 		}
+		if err.Error() == "" {
+			t.Error("expected non-empty error message")
+		}
+		if !contains(err.Error(), "OrderCreated") {
+			t.Error("error message should contain event type")
+		}
+		if err.Unwrap() != ErrSchemaVersionGap {
+			t.Error("Unwrap should return ErrSchemaVersionGap")
+		}
 	})
 
 	t.Run("IncompatibleSchemaError matches ErrIncompatibleSchema", func(t *testing.T) {
@@ -537,7 +556,96 @@ func TestVersioningErrors(t *testing.T) {
 		if !errors.Is(err, ErrIncompatibleSchema) {
 			t.Error("expected IncompatibleSchemaError to match ErrIncompatibleSchema")
 		}
+		if err.Error() == "" {
+			t.Error("expected non-empty error message")
+		}
+		if !contains(err.Error(), "OrderCreated") {
+			t.Error("error message should contain event type")
+		}
+		if err.Unwrap() != ErrIncompatibleSchema {
+			t.Error("Unwrap should return ErrIncompatibleSchema")
+		}
 	})
+}
+
+func TestSerializeEventWithVersion(t *testing.T) {
+	serializer := NewJSONSerializer()
+
+	t.Run("stamps schema version in metadata", func(t *testing.T) {
+		type TestEvent struct {
+			Name string `json:"name"`
+		}
+		eventData, err := SerializeEventWithVersion(serializer, TestEvent{Name: "hello"}, Metadata{}, 3)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eventData.Type != "TestEvent" {
+			t.Errorf("expected type TestEvent, got %s", eventData.Type)
+		}
+		if v := GetSchemaVersion(eventData.Metadata); v != 3 {
+			t.Errorf("expected schema version 3, got %d", v)
+		}
+	})
+
+	t.Run("preserves existing metadata", func(t *testing.T) {
+		type TestEvent struct {
+			Name string `json:"name"`
+		}
+		m := Metadata{CorrelationID: "corr-1"}
+		eventData, err := SerializeEventWithVersion(serializer, TestEvent{Name: "test"}, m, 2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eventData.Metadata.CorrelationID != "corr-1" {
+			t.Error("expected correlation ID preserved")
+		}
+		if v := GetSchemaVersion(eventData.Metadata); v != 2 {
+			t.Errorf("expected schema version 2, got %d", v)
+		}
+	})
+
+	t.Run("error on nil event", func(t *testing.T) {
+		_, err := SerializeEventWithVersion(serializer, nil, Metadata{}, 1)
+		if err == nil {
+			t.Error("expected error for nil event")
+		}
+	})
+}
+
+func TestUpcasterChain_Validate_EmptyUpcasters(t *testing.T) {
+	// Register an upcaster, then ensure Validate doesn't fail on
+	// event types that happen to be registered with a single entry.
+	chain := NewUpcasterChain()
+	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
+	_ = chain.Register(newTestUpcaster("SingleEvent", 1, 2, noopFn))
+	if err := chain.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpcasterChain_Upcast_GapBreaks(t *testing.T) {
+	// When the event is at a version between registered upcasters (gap),
+	// upcast should stop and return the data as-is at the current version.
+	chain := NewUpcasterChain()
+	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
+	_ = chain.Register(newTestUpcaster("GapEvent", 1, 2, noopFn))
+	// Skip v2→v3, register v3→v4
+	_ = chain.Register(newTestUpcaster("GapEvent", 3, 4, noopFn))
+
+	data := []byte(`{"value":1}`)
+
+	// Upcast from v2 — the v1→v2 upcaster is skipped (fromVersion < currentVersion),
+	// but v3→v4 has fromVersion > currentVersion, so we hit the gap break.
+	result, version, err := chain.Upcast("GapEvent", 2, data, Metadata{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("expected version 2 (stopped at gap), got %d", version)
+	}
+	if string(result) != string(data) {
+		t.Errorf("expected data unchanged at gap, got %s", result)
+	}
 }
 
 // contains is a test helper to check if a string contains a substring.

--- a/versioning_test.go
+++ b/versioning_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -31,6 +32,26 @@ func newTestUpcaster(eventType string, from, to int, fn func([]byte, Metadata) (
 	}
 }
 
+// noopUpcastFn is a reusable no-op upcast function for tests that only need registration.
+var noopUpcastFn = func(data []byte, _ Metadata) ([]byte, error) { return data, nil }
+
+// newNoopUpcaster creates a test upcaster that passes data through unchanged.
+func newNoopUpcaster(eventType string, from, to int) *testUpcaster {
+	return newTestUpcaster(eventType, from, to, noopUpcastFn)
+}
+
+// addJSONFieldUpcastFn returns an upcast function that adds a field with a static value.
+func addJSONFieldUpcastFn(field string, value interface{}) func([]byte, Metadata) ([]byte, error) {
+	return func(data []byte, _ Metadata) ([]byte, error) {
+		var obj map[string]interface{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, err
+		}
+		obj[field] = value
+		return json.Marshal(obj)
+	}
+}
+
 func TestUpcasterChain_Register(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -41,43 +62,31 @@ func TestUpcasterChain_Register(t *testing.T) {
 		{
 			name: "register valid upcaster",
 			setup: func(c *UpcasterChain) error {
-				return c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				}))
+				return c.Register(newNoopUpcaster("OrderCreated", 1, 2))
 			},
 		},
 		{
 			name: "register multiple upcasters for same event type",
 			setup: func(c *UpcasterChain) error {
-				if err := c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				})); err != nil {
+				if err := c.Register(newNoopUpcaster("OrderCreated", 1, 2)); err != nil {
 					return err
 				}
-				return c.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				}))
+				return c.Register(newNoopUpcaster("OrderCreated", 2, 3))
 			},
 		},
 		{
 			name: "register upcasters for different event types",
 			setup: func(c *UpcasterChain) error {
-				if err := c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				})); err != nil {
+				if err := c.Register(newNoopUpcaster("OrderCreated", 1, 2)); err != nil {
 					return err
 				}
-				return c.Register(newTestUpcaster("OrderShipped", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				}))
+				return c.Register(newNoopUpcaster("OrderShipped", 1, 2))
 			},
 		},
 		{
 			name: "reject invalid version transition",
 			setup: func(c *UpcasterChain) error {
-				return c.Register(newTestUpcaster("OrderCreated", 1, 3, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				}))
+				return c.Register(newNoopUpcaster("OrderCreated", 1, 3))
 			},
 			wantErr: true,
 			errMsg:  "ToVersion (3) == FromVersion (1) + 1",
@@ -85,14 +94,10 @@ func TestUpcasterChain_Register(t *testing.T) {
 		{
 			name: "reject duplicate registration",
 			setup: func(c *UpcasterChain) error {
-				if err := c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				})); err != nil {
+				if err := c.Register(newNoopUpcaster("OrderCreated", 1, 2)); err != nil {
 					return err
 				}
-				return c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				}))
+				return c.Register(newNoopUpcaster("OrderCreated", 1, 2))
 			},
 			wantErr: true,
 			errMsg:  "duplicate upcaster",
@@ -100,9 +105,7 @@ func TestUpcasterChain_Register(t *testing.T) {
 		{
 			name: "reject FromVersion less than 1",
 			setup: func(c *UpcasterChain) error {
-				return c.Register(newTestUpcaster("OrderCreated", 0, 1, func(data []byte, m Metadata) ([]byte, error) {
-					return data, nil
-				}))
+				return c.Register(newNoopUpcaster("OrderCreated", 0, 1))
 			},
 			wantErr: true,
 			errMsg:  "FromVersion >= 1",
@@ -117,13 +120,11 @@ func TestUpcasterChain_Register(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error, got nil")
 				}
-				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
 					t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
 				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}
@@ -142,19 +143,17 @@ func TestUpcasterChain_Validate(t *testing.T) {
 		{
 			name: "contiguous chain is valid",
 			setup: func(c *UpcasterChain) {
-				noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
-				_ = c.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
-				_ = c.Register(newTestUpcaster("OrderCreated", 2, 3, noopFn))
-				_ = c.Register(newTestUpcaster("OrderCreated", 3, 4, noopFn))
+				_ = c.Register(newNoopUpcaster("OrderCreated", 1, 2))
+				_ = c.Register(newNoopUpcaster("OrderCreated", 2, 3))
+				_ = c.Register(newNoopUpcaster("OrderCreated", 3, 4))
 			},
 		},
 		{
 			name: "gap in chain is invalid",
 			setup: func(c *UpcasterChain) {
-				noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
-				_ = c.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
+				_ = c.Register(newNoopUpcaster("OrderCreated", 1, 2))
 				// Skip v2→v3
-				_ = c.Register(newTestUpcaster("OrderCreated", 3, 4, noopFn))
+				_ = c.Register(newNoopUpcaster("OrderCreated", 3, 4))
 			},
 			wantErr: ErrSchemaVersionGap,
 		},
@@ -194,93 +193,44 @@ func TestUpcasterChain_Upcast(t *testing.T) {
 
 	t.Run("single upcaster v1 to v2", func(t *testing.T) {
 		chain := NewUpcasterChain()
-		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-			var obj map[string]interface{}
-			if err := json.Unmarshal(data, &obj); err != nil {
-				return nil, err
-			}
-			obj["currency"] = "USD"
-			return json.Marshal(obj)
-		}))
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, addJSONFieldUpcastFn("currency", "USD")))
 
-		data := []byte(`{"amount":100}`)
-		result, version, err := chain.Upcast("OrderCreated", 1, data, Metadata{})
+		result, version, err := chain.Upcast("OrderCreated", 1, []byte(`{"amount":100}`), Metadata{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if version != 2 {
 			t.Errorf("expected version 2, got %d", version)
 		}
-
-		var obj map[string]interface{}
-		if err := json.Unmarshal(result, &obj); err != nil {
-			t.Fatalf("failed to unmarshal result: %v", err)
-		}
-		if obj["currency"] != "USD" {
-			t.Errorf("expected currency USD, got %v", obj["currency"])
-		}
+		assertJSONField(t, result, "currency", "USD")
 	})
 
 	t.Run("chain v1 to v2 to v3", func(t *testing.T) {
 		chain := NewUpcasterChain()
-		// v1→v2: add currency
-		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-			var obj map[string]interface{}
-			if err := json.Unmarshal(data, &obj); err != nil {
-				return nil, err
-			}
-			obj["currency"] = "USD"
-			return json.Marshal(obj)
-		}))
-		// v2→v3: add tax
-		_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
-			var obj map[string]interface{}
-			if err := json.Unmarshal(data, &obj); err != nil {
-				return nil, err
-			}
-			obj["tax"] = 0.0
-			return json.Marshal(obj)
-		}))
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, addJSONFieldUpcastFn("currency", "USD")))
+		_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, addJSONFieldUpcastFn("tax", 0.0)))
 
-		data := []byte(`{"amount":100}`)
-		result, version, err := chain.Upcast("OrderCreated", 1, data, Metadata{})
+		result, version, err := chain.Upcast("OrderCreated", 1, []byte(`{"amount":100}`), Metadata{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if version != 3 {
 			t.Errorf("expected version 3, got %d", version)
 		}
-
-		var obj map[string]interface{}
-		if err := json.Unmarshal(result, &obj); err != nil {
-			t.Fatalf("failed to unmarshal result: %v", err)
-		}
-		if obj["currency"] != "USD" {
-			t.Errorf("expected currency USD, got %v", obj["currency"])
-		}
-		if obj["tax"] != 0.0 {
-			t.Errorf("expected tax 0.0, got %v", obj["tax"])
-		}
+		assertJSONField(t, result, "currency", "USD")
+		assertJSONField(t, result, "tax", 0.0)
 	})
 
 	t.Run("upcast from v2 skips v1 upcaster", func(t *testing.T) {
 		chain := NewUpcasterChain()
 		v1Called := false
-		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, _ Metadata) ([]byte, error) {
 			v1Called = true
 			return data, nil
 		}))
-		_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
-			var obj map[string]interface{}
-			if err := json.Unmarshal(data, &obj); err != nil {
-				return nil, err
-			}
-			obj["tax"] = 0.0
-			return json.Marshal(obj)
-		}))
+		_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, addJSONFieldUpcastFn("tax", 0.0)))
 
-		data := []byte(`{"amount":100,"currency":"EUR"}`)
-		result, version, err := chain.Upcast("OrderCreated", 2, data, Metadata{})
+		result, version, err := chain.Upcast("OrderCreated", 2, []byte(`{"amount":100,"currency":"EUR"}`), Metadata{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -290,58 +240,32 @@ func TestUpcasterChain_Upcast(t *testing.T) {
 		if version != 3 {
 			t.Errorf("expected version 3, got %d", version)
 		}
-
-		var obj map[string]interface{}
-		if err := json.Unmarshal(result, &obj); err != nil {
-			t.Fatalf("failed to unmarshal result: %v", err)
-		}
-		if obj["currency"] != "EUR" {
-			t.Errorf("expected currency EUR (unchanged), got %v", obj["currency"])
-		}
+		assertJSONField(t, result, "currency", "EUR")
 	})
 
 	t.Run("metadata context passed to upcaster", func(t *testing.T) {
 		chain := NewUpcasterChain()
 		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-			var obj map[string]interface{}
-			if err := json.Unmarshal(data, &obj); err != nil {
-				return nil, err
-			}
-			// Use tenant ID from metadata to set default currency
+			currency := "USD"
 			if m.TenantID == "eu-tenant" {
-				obj["currency"] = "EUR"
-			} else {
-				obj["currency"] = "USD"
+				currency = "EUR"
 			}
-			return json.Marshal(obj)
+			return addJSONFieldUpcastFn("currency", currency)(data, m)
 		}))
 
 		data := []byte(`{"amount":100}`)
 
-		// Test with EU tenant
 		result, _, err := chain.Upcast("OrderCreated", 1, data, Metadata{TenantID: "eu-tenant"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		var obj map[string]interface{}
-		if err := json.Unmarshal(result, &obj); err != nil {
-			t.Fatalf("failed to unmarshal result: %v", err)
-		}
-		if obj["currency"] != "EUR" {
-			t.Errorf("expected EUR for eu-tenant, got %v", obj["currency"])
-		}
+		assertJSONField(t, result, "currency", "EUR")
 
-		// Test with default tenant
 		result, _, err = chain.Upcast("OrderCreated", 1, data, Metadata{TenantID: "us-tenant"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if err := json.Unmarshal(result, &obj); err != nil {
-			t.Fatalf("failed to unmarshal result: %v", err)
-		}
-		if obj["currency"] != "USD" {
-			t.Errorf("expected USD for us-tenant, got %v", obj["currency"])
-		}
+		assertJSONField(t, result, "currency", "USD")
 	})
 
 	t.Run("upcaster error propagation", func(t *testing.T) {
@@ -381,9 +305,7 @@ func TestUpcasterChain_HasUpcasters(t *testing.T) {
 		t.Error("expected no upcasters for OrderCreated")
 	}
 
-	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
-		return data, nil
-	}))
+	_ = chain.Register(newNoopUpcaster("OrderCreated", 1, 2))
 
 	if !chain.HasUpcasters("OrderCreated") {
 		t.Error("expected upcasters for OrderCreated")
@@ -396,18 +318,16 @@ func TestUpcasterChain_HasUpcasters(t *testing.T) {
 func TestUpcasterChain_LatestVersion(t *testing.T) {
 	chain := NewUpcasterChain()
 
-	// No upcasters → default version
 	if v := chain.LatestVersion("OrderCreated"); v != DefaultSchemaVersion {
 		t.Errorf("expected DefaultSchemaVersion, got %d", v)
 	}
 
-	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
-	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
+	_ = chain.Register(newNoopUpcaster("OrderCreated", 1, 2))
 	if v := chain.LatestVersion("OrderCreated"); v != 2 {
 		t.Errorf("expected 2, got %d", v)
 	}
 
-	_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, noopFn))
+	_ = chain.Register(newNoopUpcaster("OrderCreated", 2, 3))
 	if v := chain.LatestVersion("OrderCreated"); v != 3 {
 		t.Errorf("expected 3, got %d", v)
 	}
@@ -416,20 +336,17 @@ func TestUpcasterChain_LatestVersion(t *testing.T) {
 func TestUpcasterChain_RegisteredEventTypes(t *testing.T) {
 	chain := NewUpcasterChain()
 
-	types := chain.RegisteredEventTypes()
-	if len(types) != 0 {
+	if types := chain.RegisteredEventTypes(); len(types) != 0 {
 		t.Errorf("expected empty, got %v", types)
 	}
 
-	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
-	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
-	_ = chain.Register(newTestUpcaster("OrderShipped", 1, 2, noopFn))
+	_ = chain.Register(newNoopUpcaster("OrderCreated", 1, 2))
+	_ = chain.Register(newNoopUpcaster("OrderShipped", 1, 2))
 
-	types = chain.RegisteredEventTypes()
+	types := chain.RegisteredEventTypes()
 	if len(types) != 2 {
 		t.Fatalf("expected 2 types, got %d", len(types))
 	}
-	// Should be sorted
 	if types[0] != "OrderCreated" || types[1] != "OrderShipped" {
 		t.Errorf("expected [OrderCreated, OrderShipped], got %v", types)
 	}
@@ -527,7 +444,7 @@ func TestVersioningErrors(t *testing.T) {
 		if err.Error() == "" {
 			t.Error("expected non-empty error message")
 		}
-		if !contains(err.Error(), "OrderCreated") {
+		if !strings.Contains(err.Error(), "OrderCreated") {
 			t.Error("error message should contain event type")
 		}
 		if err.Unwrap() != cause {
@@ -543,7 +460,7 @@ func TestVersioningErrors(t *testing.T) {
 		if err.Error() == "" {
 			t.Error("expected non-empty error message")
 		}
-		if !contains(err.Error(), "OrderCreated") {
+		if !strings.Contains(err.Error(), "OrderCreated") {
 			t.Error("error message should contain event type")
 		}
 		if err.Unwrap() != ErrSchemaVersionGap {
@@ -559,7 +476,7 @@ func TestVersioningErrors(t *testing.T) {
 		if err.Error() == "" {
 			t.Error("expected non-empty error message")
 		}
-		if !contains(err.Error(), "OrderCreated") {
+		if !strings.Contains(err.Error(), "OrderCreated") {
 			t.Error("error message should contain event type")
 		}
 		if err.Unwrap() != ErrIncompatibleSchema {
@@ -613,29 +530,19 @@ func TestSerializeEventWithVersion(t *testing.T) {
 }
 
 func TestUpcasterChain_Validate_EmptyUpcasters(t *testing.T) {
-	// Register an upcaster, then ensure Validate doesn't fail on
-	// event types that happen to be registered with a single entry.
 	chain := NewUpcasterChain()
-	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
-	_ = chain.Register(newTestUpcaster("SingleEvent", 1, 2, noopFn))
+	_ = chain.Register(newNoopUpcaster("SingleEvent", 1, 2))
 	if err := chain.Validate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestUpcasterChain_Upcast_GapBreaks(t *testing.T) {
-	// When the event is at a version between registered upcasters (gap),
-	// upcast should stop and return the data as-is at the current version.
 	chain := NewUpcasterChain()
-	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
-	_ = chain.Register(newTestUpcaster("GapEvent", 1, 2, noopFn))
-	// Skip v2→v3, register v3→v4
-	_ = chain.Register(newTestUpcaster("GapEvent", 3, 4, noopFn))
+	_ = chain.Register(newNoopUpcaster("GapEvent", 1, 2))
+	_ = chain.Register(newNoopUpcaster("GapEvent", 3, 4)) // skip v2→v3
 
 	data := []byte(`{"value":1}`)
-
-	// Upcast from v2 — the v1→v2 upcaster is skipped (fromVersion < currentVersion),
-	// but v3→v4 has fromVersion > currentVersion, so we hit the gap break.
 	result, version, err := chain.Upcast("GapEvent", 2, data, Metadata{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -648,16 +555,14 @@ func TestUpcasterChain_Upcast_GapBreaks(t *testing.T) {
 	}
 }
 
-// contains is a test helper to check if a string contains a substring.
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+// assertJSONField unmarshals JSON data and checks that the given field has the expected value.
+func assertJSONField(t *testing.T, data []byte, field string, expected interface{}) {
+	t.Helper()
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
 	}
-	return false
+	if obj[field] != expected {
+		t.Errorf("expected %s=%v, got %v", field, expected, obj[field])
+	}
 }

--- a/versioning_test.go
+++ b/versioning_test.go
@@ -1,0 +1,555 @@
+package mink
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// testUpcaster is a simple upcaster for testing.
+type testUpcaster struct {
+	eventType   string
+	fromVersion int
+	toVersion   int
+	upcastFn    func(data []byte, metadata Metadata) ([]byte, error)
+}
+
+func (u *testUpcaster) EventType() string  { return u.eventType }
+func (u *testUpcaster) FromVersion() int   { return u.fromVersion }
+func (u *testUpcaster) ToVersion() int     { return u.toVersion }
+func (u *testUpcaster) Upcast(data []byte, metadata Metadata) ([]byte, error) {
+	return u.upcastFn(data, metadata)
+}
+
+func newTestUpcaster(eventType string, from, to int, fn func([]byte, Metadata) ([]byte, error)) *testUpcaster {
+	return &testUpcaster{
+		eventType:   eventType,
+		fromVersion: from,
+		toVersion:   to,
+		upcastFn:    fn,
+	}
+}
+
+func TestUpcasterChain_Register(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(c *UpcasterChain) error
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "register valid upcaster",
+			setup: func(c *UpcasterChain) error {
+				return c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				}))
+			},
+		},
+		{
+			name: "register multiple upcasters for same event type",
+			setup: func(c *UpcasterChain) error {
+				if err := c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				})); err != nil {
+					return err
+				}
+				return c.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				}))
+			},
+		},
+		{
+			name: "register upcasters for different event types",
+			setup: func(c *UpcasterChain) error {
+				if err := c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				})); err != nil {
+					return err
+				}
+				return c.Register(newTestUpcaster("OrderShipped", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				}))
+			},
+		},
+		{
+			name: "reject invalid version transition",
+			setup: func(c *UpcasterChain) error {
+				return c.Register(newTestUpcaster("OrderCreated", 1, 3, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				}))
+			},
+			wantErr: true,
+			errMsg:  "ToVersion (3) == FromVersion (1) + 1",
+		},
+		{
+			name: "reject duplicate registration",
+			setup: func(c *UpcasterChain) error {
+				if err := c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				})); err != nil {
+					return err
+				}
+				return c.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				}))
+			},
+			wantErr: true,
+			errMsg:  "duplicate upcaster",
+		},
+		{
+			name: "reject FromVersion less than 1",
+			setup: func(c *UpcasterChain) error {
+				return c.Register(newTestUpcaster("OrderCreated", 0, 1, func(data []byte, m Metadata) ([]byte, error) {
+					return data, nil
+				}))
+			},
+			wantErr: true,
+			errMsg:  "FromVersion >= 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := NewUpcasterChain()
+			err := tt.setup(chain)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestUpcasterChain_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(c *UpcasterChain)
+		wantErr error
+	}{
+		{
+			name:  "empty chain is valid",
+			setup: func(c *UpcasterChain) {},
+		},
+		{
+			name: "contiguous chain is valid",
+			setup: func(c *UpcasterChain) {
+				noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
+				_ = c.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
+				_ = c.Register(newTestUpcaster("OrderCreated", 2, 3, noopFn))
+				_ = c.Register(newTestUpcaster("OrderCreated", 3, 4, noopFn))
+			},
+		},
+		{
+			name: "gap in chain is invalid",
+			setup: func(c *UpcasterChain) {
+				noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
+				_ = c.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
+				// Skip v2→v3
+				_ = c.Register(newTestUpcaster("OrderCreated", 3, 4, noopFn))
+			},
+			wantErr: ErrSchemaVersionGap,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain := NewUpcasterChain()
+			tt.setup(chain)
+			err := chain.Validate()
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpcasterChain_Upcast(t *testing.T) {
+	t.Run("no upcasters returns data unchanged", func(t *testing.T) {
+		chain := NewUpcasterChain()
+		data := []byte(`{"name":"test"}`)
+		result, version, err := chain.Upcast("OrderCreated", 1, data, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version != 1 {
+			t.Errorf("expected version 1, got %d", version)
+		}
+		if string(result) != string(data) {
+			t.Errorf("expected data unchanged, got %s", result)
+		}
+	})
+
+	t.Run("single upcaster v1 to v2", func(t *testing.T) {
+		chain := NewUpcasterChain()
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, err
+			}
+			obj["currency"] = "USD"
+			return json.Marshal(obj)
+		}))
+
+		data := []byte(`{"amount":100}`)
+		result, version, err := chain.Upcast("OrderCreated", 1, data, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version != 2 {
+			t.Errorf("expected version 2, got %d", version)
+		}
+
+		var obj map[string]interface{}
+		if err := json.Unmarshal(result, &obj); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+		if obj["currency"] != "USD" {
+			t.Errorf("expected currency USD, got %v", obj["currency"])
+		}
+	})
+
+	t.Run("chain v1 to v2 to v3", func(t *testing.T) {
+		chain := NewUpcasterChain()
+		// v1→v2: add currency
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, err
+			}
+			obj["currency"] = "USD"
+			return json.Marshal(obj)
+		}))
+		// v2→v3: add tax
+		_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, err
+			}
+			obj["tax"] = 0.0
+			return json.Marshal(obj)
+		}))
+
+		data := []byte(`{"amount":100}`)
+		result, version, err := chain.Upcast("OrderCreated", 1, data, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version != 3 {
+			t.Errorf("expected version 3, got %d", version)
+		}
+
+		var obj map[string]interface{}
+		if err := json.Unmarshal(result, &obj); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+		if obj["currency"] != "USD" {
+			t.Errorf("expected currency USD, got %v", obj["currency"])
+		}
+		if obj["tax"] != 0.0 {
+			t.Errorf("expected tax 0.0, got %v", obj["tax"])
+		}
+	})
+
+	t.Run("upcast from v2 skips v1 upcaster", func(t *testing.T) {
+		chain := NewUpcasterChain()
+		v1Called := false
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+			v1Called = true
+			return data, nil
+		}))
+		_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, func(data []byte, m Metadata) ([]byte, error) {
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, err
+			}
+			obj["tax"] = 0.0
+			return json.Marshal(obj)
+		}))
+
+		data := []byte(`{"amount":100,"currency":"EUR"}`)
+		result, version, err := chain.Upcast("OrderCreated", 2, data, Metadata{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v1Called {
+			t.Error("v1→v2 upcaster should not have been called")
+		}
+		if version != 3 {
+			t.Errorf("expected version 3, got %d", version)
+		}
+
+		var obj map[string]interface{}
+		if err := json.Unmarshal(result, &obj); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+		if obj["currency"] != "EUR" {
+			t.Errorf("expected currency EUR (unchanged), got %v", obj["currency"])
+		}
+	})
+
+	t.Run("metadata context passed to upcaster", func(t *testing.T) {
+		chain := NewUpcasterChain()
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+			var obj map[string]interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, err
+			}
+			// Use tenant ID from metadata to set default currency
+			if m.TenantID == "eu-tenant" {
+				obj["currency"] = "EUR"
+			} else {
+				obj["currency"] = "USD"
+			}
+			return json.Marshal(obj)
+		}))
+
+		data := []byte(`{"amount":100}`)
+
+		// Test with EU tenant
+		result, _, err := chain.Upcast("OrderCreated", 1, data, Metadata{TenantID: "eu-tenant"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var obj map[string]interface{}
+		if err := json.Unmarshal(result, &obj); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+		if obj["currency"] != "EUR" {
+			t.Errorf("expected EUR for eu-tenant, got %v", obj["currency"])
+		}
+
+		// Test with default tenant
+		result, _, err = chain.Upcast("OrderCreated", 1, data, Metadata{TenantID: "us-tenant"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := json.Unmarshal(result, &obj); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+		if obj["currency"] != "USD" {
+			t.Errorf("expected USD for us-tenant, got %v", obj["currency"])
+		}
+	})
+
+	t.Run("upcaster error propagation", func(t *testing.T) {
+		chain := NewUpcasterChain()
+		_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+			return nil, fmt.Errorf("transformation failed")
+		}))
+
+		_, _, err := chain.Upcast("OrderCreated", 1, []byte(`{}`), Metadata{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, ErrUpcastFailed) {
+			t.Errorf("expected ErrUpcastFailed, got %v", err)
+		}
+
+		var upcastErr *UpcastError
+		if !errors.As(err, &upcastErr) {
+			t.Fatal("expected UpcastError type")
+		}
+		if upcastErr.EventType != "OrderCreated" {
+			t.Errorf("expected event type OrderCreated, got %s", upcastErr.EventType)
+		}
+		if upcastErr.FromVersion != 1 {
+			t.Errorf("expected from version 1, got %d", upcastErr.FromVersion)
+		}
+		if upcastErr.ToVersion != 2 {
+			t.Errorf("expected to version 2, got %d", upcastErr.ToVersion)
+		}
+	})
+}
+
+func TestUpcasterChain_HasUpcasters(t *testing.T) {
+	chain := NewUpcasterChain()
+
+	if chain.HasUpcasters("OrderCreated") {
+		t.Error("expected no upcasters for OrderCreated")
+	}
+
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, func(data []byte, m Metadata) ([]byte, error) {
+		return data, nil
+	}))
+
+	if !chain.HasUpcasters("OrderCreated") {
+		t.Error("expected upcasters for OrderCreated")
+	}
+	if chain.HasUpcasters("OrderShipped") {
+		t.Error("expected no upcasters for OrderShipped")
+	}
+}
+
+func TestUpcasterChain_LatestVersion(t *testing.T) {
+	chain := NewUpcasterChain()
+
+	// No upcasters → default version
+	if v := chain.LatestVersion("OrderCreated"); v != DefaultSchemaVersion {
+		t.Errorf("expected DefaultSchemaVersion, got %d", v)
+	}
+
+	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
+	if v := chain.LatestVersion("OrderCreated"); v != 2 {
+		t.Errorf("expected 2, got %d", v)
+	}
+
+	_ = chain.Register(newTestUpcaster("OrderCreated", 2, 3, noopFn))
+	if v := chain.LatestVersion("OrderCreated"); v != 3 {
+		t.Errorf("expected 3, got %d", v)
+	}
+}
+
+func TestUpcasterChain_RegisteredEventTypes(t *testing.T) {
+	chain := NewUpcasterChain()
+
+	types := chain.RegisteredEventTypes()
+	if len(types) != 0 {
+		t.Errorf("expected empty, got %v", types)
+	}
+
+	noopFn := func(data []byte, m Metadata) ([]byte, error) { return data, nil }
+	_ = chain.Register(newTestUpcaster("OrderCreated", 1, 2, noopFn))
+	_ = chain.Register(newTestUpcaster("OrderShipped", 1, 2, noopFn))
+
+	types = chain.RegisteredEventTypes()
+	if len(types) != 2 {
+		t.Fatalf("expected 2 types, got %d", len(types))
+	}
+	// Should be sorted
+	if types[0] != "OrderCreated" || types[1] != "OrderShipped" {
+		t.Errorf("expected [OrderCreated, OrderShipped], got %v", types)
+	}
+}
+
+func TestGetSchemaVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata Metadata
+		want     int
+	}{
+		{
+			name:     "empty metadata returns default",
+			metadata: Metadata{},
+			want:     DefaultSchemaVersion,
+		},
+		{
+			name:     "nil custom map returns default",
+			metadata: Metadata{Custom: nil},
+			want:     DefaultSchemaVersion,
+		},
+		{
+			name:     "missing key returns default",
+			metadata: Metadata{Custom: map[string]string{"other": "value"}},
+			want:     DefaultSchemaVersion,
+		},
+		{
+			name:     "invalid value returns default",
+			metadata: Metadata{Custom: map[string]string{schemaVersionKey: "invalid"}},
+			want:     DefaultSchemaVersion,
+		},
+		{
+			name:     "valid version 1",
+			metadata: Metadata{Custom: map[string]string{schemaVersionKey: "1"}},
+			want:     1,
+		},
+		{
+			name:     "valid version 3",
+			metadata: Metadata{Custom: map[string]string{schemaVersionKey: "3"}},
+			want:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetSchemaVersion(tt.metadata)
+			if got != tt.want {
+				t.Errorf("GetSchemaVersion() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetSchemaVersion(t *testing.T) {
+	t.Run("set version on empty metadata", func(t *testing.T) {
+		m := SetSchemaVersion(Metadata{}, 2)
+		if v := GetSchemaVersion(m); v != 2 {
+			t.Errorf("expected version 2, got %d", v)
+		}
+	})
+
+	t.Run("set version preserves existing metadata", func(t *testing.T) {
+		m := Metadata{
+			CorrelationID: "corr-123",
+			Custom:        map[string]string{"tenant": "acme"},
+		}
+		m = SetSchemaVersion(m, 3)
+		if v := GetSchemaVersion(m); v != 3 {
+			t.Errorf("expected version 3, got %d", v)
+		}
+		if m.CorrelationID != "corr-123" {
+			t.Errorf("expected correlation ID preserved, got %s", m.CorrelationID)
+		}
+		if m.Custom["tenant"] != "acme" {
+			t.Errorf("expected tenant preserved, got %s", m.Custom["tenant"])
+		}
+	})
+
+	t.Run("overwrite existing version", func(t *testing.T) {
+		m := SetSchemaVersion(Metadata{}, 2)
+		m = SetSchemaVersion(m, 5)
+		if v := GetSchemaVersion(m); v != 5 {
+			t.Errorf("expected version 5, got %d", v)
+		}
+	})
+}
+
+func TestVersioningErrors(t *testing.T) {
+	t.Run("UpcastError matches ErrUpcastFailed", func(t *testing.T) {
+		err := NewUpcastError("OrderCreated", 1, 2, fmt.Errorf("bad data"))
+		if !errors.Is(err, ErrUpcastFailed) {
+			t.Error("expected UpcastError to match ErrUpcastFailed")
+		}
+	})
+
+	t.Run("SchemaVersionGapError matches ErrSchemaVersionGap", func(t *testing.T) {
+		err := NewSchemaVersionGapError("OrderCreated", 2, 3)
+		if !errors.Is(err, ErrSchemaVersionGap) {
+			t.Error("expected SchemaVersionGapError to match ErrSchemaVersionGap")
+		}
+	})
+
+	t.Run("IncompatibleSchemaError matches ErrIncompatibleSchema", func(t *testing.T) {
+		err := NewIncompatibleSchemaError("OrderCreated", 1, 2, SchemaBreaking, "field removed")
+		if !errors.Is(err, ErrIncompatibleSchema) {
+			t.Error("expected IncompatibleSchemaError to match ErrIncompatibleSchema")
+		}
+	})
+}
+
+// contains is a test helper to check if a string contains a substring.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request introduces a new event schema registry to the codebase, providing first-class support for schema versioning, compatibility checks, and schema metadata for events. It also updates documentation to clarify infrastructure requirements and file locations, adds a PostgreSQL schema example, and introduces a convenience serialization function for schema version stamping. These changes improve event evolution safety and developer ergonomics for event-sourced systems.


## Changes
<!-- List of changes -->
**Schema Registry and Versioning Support**

* Added a new `schema_registry.go` module implementing an in-memory `SchemaRegistry` with support for registering event schemas, tracking versions, checking compatibility (fully compatible, backward, forward, breaking), and retrieving schema metadata. (`schema_registry.go`)
* Added comprehensive unit tests for the schema registry covering registration, retrieval, compatibility checks, event type listing, and JSON schema support. (`schema_registry_test.go`)

**Developer Ergonomics**

* Introduced `SerializeEventWithVersion` in `serializer.go` to serialize events and automatically stamp metadata with schema version, simplifying usage for versioned events. (`serializer.go`)
* Updated the `EventStore` struct to include an optional `UpcasterChain` field for future support of event upcasting and migration. (`store.go`)

**Documentation and Infrastructure**

* Updated documentation (`CLAUDE.md`) to clarify infrastructure requirements (Kafka now required for integration tests), CI coverage enforcement, key file locations, and added a sample PostgreSQL events table schema. (`CLAUDE.md`) [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L14-R46) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L54-R69) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R135) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R175-R199)

These changes lay the groundwork for robust schema evolution in event-sourced applications and improve clarity for contributors and users.


## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
