### PR TITLE
Add tests for ProjectionRebuilder and subscription error handling

### DIFF
--- a/projection_engine.go
+++ b/projection_engine.go
@@ -577,7 +577,7 @@ func (w *asyncProjectionWorker) getStatus() *ProjectionStatus {
 		Name:            w.projection.Name(),
 		State:           w.state,
 		LastPosition:    w.lastPosition,
-		EventsProcessed: w.eventsProcessed,
+		EventsProcessed: atomic.LoadUint64(&w.eventsProcessed),
 		LastProcessedAt: w.lastProcessedAt,
 	}
 
@@ -626,7 +626,9 @@ func (e *ProjectionEngine) runAsyncWorker(ctx context.Context, worker *asyncProj
 			startPosition = pos
 		}
 	}
+	worker.stateMu.Lock()
 	worker.lastPosition = startPosition
+	worker.stateMu.Unlock()
 
 	worker.setState(ProjectionStateRunning)
 

--- a/projection_test.go
+++ b/projection_test.go
@@ -14,6 +14,27 @@ import (
 
 // Test projections, checkpoint store, logger, and metrics are defined in test_helpers_test.go
 
+// newTestEngineWithStore creates a fully wired ProjectionEngine backed by an in-memory
+// EventStore with ProjectionTestEvent registered and a fresh checkpoint store.
+// It returns the engine, store, and checkpoint store for further assertions.
+func newTestEngineWithStore() (*ProjectionEngine, *EventStore, *testCheckpointStore) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	return engine, store, checkpoint
+}
+
+// fastAsyncOpts returns default AsyncOptions tuned for fast tests:
+// PollInterval=20ms, StartFromBeginning=true.
+func fastAsyncOpts() AsyncOptions {
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.StartFromBeginning = true
+	return opts
+}
+
 // --- Projection Tests ---
 
 func TestProjectionBase(t *testing.T) {
@@ -480,9 +501,7 @@ func TestProjectionEngine_RegisterAsync_EmptyName(t *testing.T) {
 }
 
 func TestProjectionEngine_Stop_Timeout(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+	engine, _, _ := newTestEngineWithStore()
 
 	// Register projections
 	_ = engine.RegisterAsync(newTestAsyncProjection("AsyncStopTimeout"))
@@ -501,10 +520,7 @@ func TestProjectionEngine_Stop_Timeout(t *testing.T) {
 }
 
 func TestProjectionEngine_LiveProjection_WithEvents(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+	engine, store, _ := newTestEngineWithStore()
 
 	projection := newTestLiveProjection("LiveWithEvents", true, "ProjectionTestEvent")
 	_ = engine.RegisterLive(projection)
@@ -559,11 +575,7 @@ func TestProjectionEngine_NotifyLiveProjections_NotRunning(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_BatchProcessing(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, _ := newTestEngineWithStore()
 
 	projection := newTestAsyncProjection("AsyncBatch", "ProjectionTestEvent")
 	projection.EnableBatch() // Enable batch processing
@@ -588,10 +600,7 @@ func TestProjectionEngine_AsyncWorker_BatchProcessing(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_RetryPolicy(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, _, _ := newTestEngineWithStore()
 
 	projection := newTestAsyncProjection("AsyncRetry")
 	opts := DefaultAsyncOptions()
@@ -663,21 +672,12 @@ func TestProjectionEngine_GetStatus_InlineActive(t *testing.T) {
 }
 
 func TestAsyncProjectionWorker_ProcessBatch_WithCheckpoint(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, store, checkpoint := newTestEngineWithStore()
 	logger := newTestLogger()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionLogger(logger),
-	)
+	engine.logger = logger
 
 	projection := newTestAsyncProjection("CheckpointProj", "ProjectionTestEvent")
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
+	_ = engine.RegisterAsync(projection, fastAsyncOpts())
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -699,18 +699,11 @@ func TestAsyncProjectionWorker_ProcessBatch_WithCheckpoint(t *testing.T) {
 
 // Test projection filtering
 func TestProjectionEngine_AsyncWorker_EventFiltering(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, _ := newTestEngineWithStore()
 
 	// Projection only handles specific events
 	projection := newTestAsyncProjection("FilteredAsync", "DifferentEventType")
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
+	_ = engine.RegisterAsync(projection, fastAsyncOpts())
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -729,9 +722,7 @@ func TestProjectionEngine_AsyncWorker_EventFiltering(t *testing.T) {
 
 // Test context cancellation during NotifyLiveProjections
 func TestProjectionEngine_NotifyLiveProjections_ContextCancel(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+	engine, _, _ := newTestEngineWithStore()
 
 	projection := newTestLiveProjection("LiveCancel", true)
 	_ = engine.RegisterLive(projection)
@@ -759,11 +750,7 @@ type ProjectionTestEvent struct {
 }
 
 func TestProjectionEngine_AsyncWorker(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, checkpoint := newTestEngineWithStore()
 
 	t.Run("async worker processes events", func(t *testing.T) {
 		// Register async projection
@@ -810,12 +797,9 @@ func TestProjectionEngine_AsyncWorker(t *testing.T) {
 
 	t.Run("async worker handles checkpoint", func(t *testing.T) {
 		projection := newTestAsyncProjection("AsyncCheckpointTest")
-		opts := DefaultAsyncOptions()
-		opts.PollInterval = 20 * time.Millisecond
-		opts.StartFromBeginning = true
 
 		engine3 := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
-		_ = engine3.RegisterAsync(projection, opts)
+		_ = engine3.RegisterAsync(projection, fastAsyncOpts())
 
 		ctx, cancel := context.WithCancel(context.Background())
 		err := engine3.Start(ctx)
@@ -1074,17 +1058,11 @@ func TestExponentialBackoffRetry_DelayEdgeCases(t *testing.T) {
 // --- Async Worker Error Handling, Backoff & Recovery ---
 
 func TestProjectionEngine_AsyncWorker_ErrorAndRecovery(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, store, _ := newTestEngineWithStore()
 	logger := newTestLogger()
 	metrics := newTestProjectionMetrics()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionLogger(logger),
-		WithProjectionMetrics(metrics),
-	)
+	engine.logger = logger
+	engine.metrics = metrics
 
 	// Append an event so the worker has something to process
 	ctx := context.Background()
@@ -1094,10 +1072,8 @@ func TestProjectionEngine_AsyncWorker_ErrorAndRecovery(t *testing.T) {
 		projection := newTestAsyncProjection("AsyncErrorRecovery", "ProjectionTestEvent")
 		projection.SetError(assert.AnError) // Will fail initially
 
-		opts := DefaultAsyncOptions()
-		opts.PollInterval = 20 * time.Millisecond
+		opts := fastAsyncOpts()
 		opts.RetryPolicy = ExponentialBackoffRetry(10, 10*time.Millisecond, 50*time.Millisecond)
-		opts.StartFromBeginning = true
 		_ = engine.RegisterAsync(projection, opts)
 
 		runCtx, cancel := context.WithCancel(ctx)
@@ -1122,44 +1098,21 @@ func TestProjectionEngine_AsyncWorker_ErrorAndRecovery(t *testing.T) {
 		_ = engine.Stop(context.Background())
 
 		// Logger should have recorded errors and recovery
-		logger.mu.Lock()
-		hasError := false
-		for _, msg := range logger.errorLogs {
-			if msg == "Async projection error" {
-				hasError = true
-				break
-			}
-		}
-		hasRecovery := false
-		for _, msg := range logger.infoLogs {
-			if msg == "Async projection recovered" {
-				hasRecovery = true
-				break
-			}
-		}
-		logger.mu.Unlock()
-
-		assert.True(t, hasError, "expected error log")
-		assert.True(t, hasRecovery, "expected recovery log")
+		assert.True(t, logger.hasLogMessage("error", "Async projection error"), "expected error log")
+		assert.True(t, logger.hasLogMessage("info", "Async projection recovered"), "expected recovery log")
 	})
 }
 
 func TestProjectionEngine_AsyncWorker_NilRetryPolicy(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, _ := newTestEngineWithStore()
 
 	_ = store.Append(context.Background(), "Order-nil-retry", []interface{}{&ProjectionTestEvent{OrderID: "nilretry"}})
 
 	// Use nil retry policy to exercise the built-in fallback backoff
 	projection := newTestAsyncProjection("AsyncNilRetry", "ProjectionTestEvent")
 	projection.SetError(assert.AnError)
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
+	opts := fastAsyncOpts()
 	opts.RetryPolicy = nil
-	opts.StartFromBeginning = true
 	_ = engine.RegisterAsync(projection, opts)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1173,24 +1126,16 @@ func TestProjectionEngine_AsyncWorker_NilRetryPolicy(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_PanicRecovery(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, store, _ := newTestEngineWithStore()
 	logger := newTestLogger()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionLogger(logger),
-	)
+	engine.logger = logger
 
 	_ = store.Append(context.Background(), "Order-panic-1", []interface{}{&ProjectionTestEvent{OrderID: "panic1"}})
 
 	// Create a panicking projection
 	projection := newTestPanickingAsyncProjection("AsyncPanic", "ProjectionTestEvent")
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
+	opts := fastAsyncOpts()
 	opts.RetryPolicy = ExponentialBackoffRetry(3, 10*time.Millisecond, 50*time.Millisecond)
-	opts.StartFromBeginning = true
 	_ = engine.RegisterAsync(projection, opts)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1203,28 +1148,13 @@ func TestProjectionEngine_AsyncWorker_PanicRecovery(t *testing.T) {
 	_ = engine.Stop(context.Background())
 
 	// Logger should have recorded the panic
-	logger.mu.Lock()
-	hasPanic := false
-	for _, msg := range logger.errorLogs {
-		if msg == "Async projection panicked" {
-			hasPanic = true
-			break
-		}
-	}
-	logger.mu.Unlock()
-	assert.True(t, hasPanic, "expected panic log")
+	assert.True(t, logger.hasLogMessage("error", "Async projection panicked"), "expected panic log")
 }
 
 func TestProjectionEngine_AsyncWorker_BatchApplySuccess(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, store, _ := newTestEngineWithStore()
 	metrics := newTestProjectionMetrics()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionMetrics(metrics),
-	)
+	engine.metrics = metrics
 
 	// Append events
 	ctx := context.Background()
@@ -1236,10 +1166,7 @@ func TestProjectionEngine_AsyncWorker_BatchApplySuccess(t *testing.T) {
 	// Create projection that supports batch mode
 	projection := newTestAsyncProjection("AsyncBatchSuccess", "ProjectionTestEvent")
 	projection.EnableBatch()
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
+	_ = engine.RegisterAsync(projection, fastAsyncOpts())
 
 	runCtx, cancel := context.WithCancel(ctx)
 	_ = engine.Start(runCtx)
@@ -1260,25 +1187,17 @@ func TestProjectionEngine_AsyncWorker_BatchApplySuccess(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_BatchApplyError(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, store, _ := newTestEngineWithStore()
 	metrics := newTestProjectionMetrics()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionMetrics(metrics),
-	)
+	engine.metrics = metrics
 
 	_ = store.Append(context.Background(), "Order-batch-err", []interface{}{&ProjectionTestEvent{OrderID: "batcherr"}})
 
 	projection := newTestAsyncProjection("AsyncBatchError", "ProjectionTestEvent")
 	projection.EnableBatch()
 	projection.batchApplyErr = assert.AnError
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
+	opts := fastAsyncOpts()
 	opts.RetryPolicy = ExponentialBackoffRetry(2, 10*time.Millisecond, 50*time.Millisecond)
-	opts.StartFromBeginning = true
 	_ = engine.RegisterAsync(projection, opts)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1297,11 +1216,7 @@ func TestProjectionEngine_AsyncWorker_BatchApplyError(t *testing.T) {
 }
 
 func TestProjectionEngine_Stop_ContextTimeout(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, _ := newTestEngineWithStore()
 
 	// Register a slow projection that blocks on Apply
 	projection := newTestBlockingAsyncProjection("AsyncBlocking")
@@ -1336,21 +1251,15 @@ func TestProjectionEngine_Stop_ContextTimeout(t *testing.T) {
 }
 
 func TestProjectionEngine_GetStatus_AsyncWithError(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, _ := newTestEngineWithStore()
 
 	// Append an event
 	_ = store.Append(context.Background(), "Order-status-err", []interface{}{&ProjectionTestEvent{OrderID: "statuserr"}})
 
 	projection := newTestAsyncProjection("StatusErrProj", "ProjectionTestEvent")
 	projection.SetError(assert.AnError)
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
+	opts := fastAsyncOpts()
 	opts.RetryPolicy = ExponentialBackoffRetry(1, 10*time.Millisecond, 50*time.Millisecond)
-	opts.StartFromBeginning = true
 	_ = engine.RegisterAsync(projection, opts)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1368,9 +1277,7 @@ func TestProjectionEngine_GetStatus_AsyncWithError(t *testing.T) {
 }
 
 func TestProjectionEngine_LiveWorker_StopViaClose(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+	engine, _, _ := newTestEngineWithStore()
 
 	projection := newTestLiveProjection("LiveStopClose", true)
 	_ = engine.RegisterLive(projection)
@@ -1388,14 +1295,9 @@ func TestProjectionEngine_LiveWorker_StopViaClose(t *testing.T) {
 }
 
 func TestProjectionEngine_LiveWorker_PanicRecovery(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
+	engine, _, _ := newTestEngineWithStore()
 	logger := newTestLogger()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(newTestCheckpointStore()),
-		WithProjectionLogger(logger),
-	)
+	engine.logger = logger
 
 	projection := newTestPanickingLiveProjection("LivePanic", "ProjectionTestEvent")
 	_ = engine.RegisterLive(projection)
@@ -1416,16 +1318,7 @@ func TestProjectionEngine_LiveWorker_PanicRecovery(t *testing.T) {
 	_ = engine.Stop(context.Background())
 
 	// Logger should have recorded the panic
-	logger.mu.Lock()
-	hasPanic := false
-	for _, msg := range logger.errorLogs {
-		if msg == "Live projection panicked" {
-			hasPanic = true
-			break
-		}
-	}
-	logger.mu.Unlock()
-	assert.True(t, hasPanic, "expected live projection panic log")
+	assert.True(t, logger.hasLogMessage("error", "Live projection panicked"), "expected live projection panic log")
 }
 
 func TestProjectionEngine_LiveWorker_GetStatusWithError(t *testing.T) {
@@ -1449,16 +1342,11 @@ func TestProjectionEngine_LiveWorker_GetStatusWithError(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_ProcessBatchContextCancel(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, _, _ := newTestEngineWithStore()
 
 	projection := newTestAsyncProjection("AsyncCtxCancel", "ProjectionTestEvent")
-	opts := DefaultAsyncOptions()
+	opts := fastAsyncOpts()
 	opts.PollInterval = 10 * time.Millisecond
-	opts.StartFromBeginning = true
 	_ = engine.RegisterAsync(projection, opts)
 
 	// Start with a context we'll cancel immediately
@@ -1473,15 +1361,9 @@ func TestProjectionEngine_AsyncWorker_ProcessBatchContextCancel(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_CheckpointSetError(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, store, checkpoint := newTestEngineWithStore()
 	logger := newTestLogger()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionLogger(logger),
-	)
+	engine.logger = logger
 
 	_ = store.Append(context.Background(), "Order-cps", []interface{}{&ProjectionTestEvent{OrderID: "cps"}})
 
@@ -1489,10 +1371,7 @@ func TestProjectionEngine_AsyncWorker_CheckpointSetError(t *testing.T) {
 	checkpoint.setErr = assert.AnError
 
 	projection := newTestAsyncProjection("AsyncCheckpointSetErr", "ProjectionTestEvent")
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 20 * time.Millisecond
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
+	_ = engine.RegisterAsync(projection, fastAsyncOpts())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	_ = engine.Start(ctx)
@@ -1503,24 +1382,11 @@ func TestProjectionEngine_AsyncWorker_CheckpointSetError(t *testing.T) {
 	_ = engine.Stop(context.Background())
 
 	// Logger should warn about failed checkpoint
-	logger.mu.Lock()
-	hasError := false
-	for _, msg := range logger.errorLogs {
-		if msg == "Failed to save checkpoint" {
-			hasError = true
-			break
-		}
-	}
-	logger.mu.Unlock()
-	assert.True(t, hasError)
+	assert.True(t, logger.hasLogMessage("error", "Failed to save checkpoint"))
 }
 
 func TestProjectionEngine_AsyncWorker_StopViaUnregister(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, _, _ := newTestEngineWithStore()
 
 	projection := newTestAsyncProjection("AsyncUnregStop", "ProjectionTestEvent")
 	opts := DefaultAsyncOptions()
@@ -1544,9 +1410,7 @@ func TestProjectionEngine_AsyncWorker_StopViaUnregister(t *testing.T) {
 }
 
 func TestProjectionEngine_NotifyLiveProjections_FullBuffer(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+	engine, _, _ := newTestEngineWithStore()
 
 	// Use buffer size of 1
 	projection := newTestLiveProjection("LiveFullBuffer", true)
@@ -1579,21 +1443,16 @@ func TestProjectionEngine_NotifyLiveProjections_FullBuffer(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_HighConsecutiveErrors(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	engine, store, _ := newTestEngineWithStore()
 
 	_ = store.Append(context.Background(), "Order-hce", []interface{}{&ProjectionTestEvent{OrderID: "hce"}})
 
 	// Use nil retry policy to exercise the built-in fallback with high shift values
 	projection := newTestAsyncProjection("AsyncHighErrors", "ProjectionTestEvent")
 	projection.SetError(assert.AnError)
-	opts := DefaultAsyncOptions()
+	opts := fastAsyncOpts()
 	opts.PollInterval = 5 * time.Millisecond
 	opts.RetryPolicy = nil
-	opts.StartFromBeginning = true
 	_ = engine.RegisterAsync(projection, opts)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1607,16 +1466,10 @@ func TestProjectionEngine_AsyncWorker_HighConsecutiveErrors(t *testing.T) {
 }
 
 func TestProjectionEngine_AsyncWorker_CheckpointGetError(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
+	engine, _, checkpoint := newTestEngineWithStore()
 	checkpoint.getErr = assert.AnError
 	logger := newTestLogger()
-	engine := NewProjectionEngine(store,
-		WithCheckpointStore(checkpoint),
-		WithProjectionLogger(logger),
-	)
+	engine.logger = logger
 
 	projection := newTestAsyncProjection("AsyncCheckpointGetErr", "ProjectionTestEvent")
 	opts := DefaultAsyncOptions()
@@ -1632,115 +1485,75 @@ func TestProjectionEngine_AsyncWorker_CheckpointGetError(t *testing.T) {
 	_ = engine.Stop(context.Background())
 
 	// Logger should have recorded the error
-	logger.mu.Lock()
-	hasError := false
-	for _, msg := range logger.errorLogs {
-		if msg == "Failed to get checkpoint" {
-			hasError = true
-			break
-		}
+	assert.True(t, logger.hasLogMessage("error", "Failed to get checkpoint"))
+}
+
+func TestProjectionEngine_AsyncWorker_InterruptDuringBackoff(t *testing.T) {
+	tests := []struct {
+		name       string
+		projName   string
+		streamID   string
+		interrupt  func(t *testing.T, engine *ProjectionEngine, projName string, cancel context.CancelFunc)
+	}{
+		{
+			name:     "stop",
+			projName: "AsyncStopDuringBackoff",
+			streamID: "Order-sdb",
+			interrupt: func(t *testing.T, engine *ProjectionEngine, projName string, cancel context.CancelFunc) {
+				defer cancel()
+				stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer stopCancel()
+				err := engine.Stop(stopCtx)
+				assert.NoError(t, err)
+				status, statusErr := engine.GetStatus(projName)
+				require.NoError(t, statusErr)
+				assert.Equal(t, ProjectionStateStopped, status.State)
+			},
+		},
+		{
+			name:     "unregister",
+			projName: "AsyncUnregDuringBackoff",
+			streamID: "Order-udb",
+			interrupt: func(t *testing.T, engine *ProjectionEngine, projName string, cancel context.CancelFunc) {
+				defer cancel()
+				err := engine.Unregister(projName)
+				assert.NoError(t, err)
+				time.Sleep(50 * time.Millisecond)
+				_ = engine.Stop(context.Background())
+			},
+		},
+		{
+			name:     "context cancel",
+			projName: "AsyncCtxCancelBackoff",
+			streamID: "Order-ccdb",
+			interrupt: func(t *testing.T, engine *ProjectionEngine, projName string, cancel context.CancelFunc) {
+				cancel()
+				time.Sleep(50 * time.Millisecond)
+				_ = engine.Stop(context.Background())
+			},
+		},
 	}
-	logger.mu.Unlock()
-	assert.True(t, hasError)
-}
 
-func TestProjectionEngine_AsyncWorker_StopDuringBackoff(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, store, _ := newTestEngineWithStore()
 
-	_ = store.Append(context.Background(), "Order-sdb", []interface{}{&ProjectionTestEvent{OrderID: "sdb"}})
+			_ = store.Append(context.Background(), tt.streamID, []interface{}{&ProjectionTestEvent{OrderID: tt.streamID}})
 
-	// Projection always errors to keep the worker in error/backoff state
-	projection := newTestAsyncProjection("AsyncStopDuringBackoff", "ProjectionTestEvent")
-	projection.SetError(assert.AnError)
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 10 * time.Millisecond
-	opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second) // Long backoff so we're definitely in the wait
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
+			projection := newTestAsyncProjection(tt.projName, "ProjectionTestEvent")
+			projection.SetError(assert.AnError)
+			opts := fastAsyncOpts()
+			opts.PollInterval = 10 * time.Millisecond
+			opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second)
+			_ = engine.RegisterAsync(projection, opts)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	_ = engine.Start(ctx)
+			ctx, cancel := context.WithCancel(context.Background())
+			_ = engine.Start(ctx)
 
-	// Wait for at least one error to occur and the worker to enter backoff wait
-	time.Sleep(100 * time.Millisecond)
+			// Wait for at least one error to occur and the worker to enter backoff wait
+			time.Sleep(100 * time.Millisecond)
 
-	// Stop the engine while the worker is waiting in the backoff select
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer stopCancel()
-	err := engine.Stop(stopCtx)
-	assert.NoError(t, err)
-
-	status, statusErr := engine.GetStatus("AsyncStopDuringBackoff")
-	require.NoError(t, statusErr)
-	assert.Equal(t, ProjectionStateStopped, status.State)
-}
-
-func TestProjectionEngine_AsyncWorker_UnregisterDuringBackoff(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
-
-	_ = store.Append(context.Background(), "Order-udb", []interface{}{&ProjectionTestEvent{OrderID: "udb"}})
-
-	projection := newTestAsyncProjection("AsyncUnregDuringBackoff", "ProjectionTestEvent")
-	projection.SetError(assert.AnError)
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 10 * time.Millisecond
-	opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second)
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	_ = engine.Start(ctx)
-
-	// Wait for the worker to enter the backoff wait
-	time.Sleep(100 * time.Millisecond)
-
-	// Unregister while the worker is waiting in the backoff select (exercises worker.stopCh path)
-	err := engine.Unregister("AsyncUnregDuringBackoff")
-	assert.NoError(t, err)
-
-	time.Sleep(50 * time.Millisecond)
-
-	cancel()
-	_ = engine.Stop(context.Background())
-}
-
-func TestProjectionEngine_AsyncWorker_ContextCancelDuringBackoff(t *testing.T) {
-	adapter := memory.NewAdapter()
-	store := New(adapter)
-	store.RegisterEvents(&ProjectionTestEvent{})
-	checkpoint := newTestCheckpointStore()
-	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
-
-	_ = store.Append(context.Background(), "Order-ccdb", []interface{}{&ProjectionTestEvent{OrderID: "ccdb"}})
-
-	projection := newTestAsyncProjection("AsyncCtxCancelBackoff", "ProjectionTestEvent")
-	projection.SetError(assert.AnError)
-	opts := DefaultAsyncOptions()
-	opts.PollInterval = 10 * time.Millisecond
-	opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second)
-	opts.StartFromBeginning = true
-	_ = engine.RegisterAsync(projection, opts)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	_ = engine.Start(ctx)
-
-	// Wait for the worker to enter the backoff wait
-	time.Sleep(100 * time.Millisecond)
-
-	// Cancel context while the worker is waiting in the backoff select (exercises ctx.Done() path)
-	cancel()
-
-	time.Sleep(50 * time.Millisecond)
-
-	_ = engine.Stop(context.Background())
+			tt.interrupt(t, engine, tt.projName, cancel)
+		})
+	}
 }

--- a/projection_test.go
+++ b/projection_test.go
@@ -1051,3 +1051,696 @@ func TestShouldHandleEventType(t *testing.T) {
 		assert.False(t, ShouldHandleEventType(handledEvents, "ORDERCREATED"))
 	})
 }
+
+// --- Exponential Backoff Delay Edge Cases ---
+
+func TestExponentialBackoffRetry_DelayEdgeCases(t *testing.T) {
+	policy := ExponentialBackoffRetry(5, 100*time.Millisecond, 10*time.Second)
+
+	t.Run("negative attempt clamps to zero", func(t *testing.T) {
+		delay := policy.Delay(-1)
+		assert.Equal(t, 100*time.Millisecond, delay)
+	})
+
+	t.Run("large attempt returns max delay", func(t *testing.T) {
+		delay := policy.Delay(63)
+		assert.Equal(t, 10*time.Second, delay)
+
+		delay = policy.Delay(100)
+		assert.Equal(t, 10*time.Second, delay)
+	})
+}
+
+// --- Async Worker Error Handling, Backoff & Recovery ---
+
+func TestProjectionEngine_AsyncWorker_ErrorAndRecovery(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	logger := newTestLogger()
+	metrics := newTestProjectionMetrics()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(checkpoint),
+		WithProjectionLogger(logger),
+		WithProjectionMetrics(metrics),
+	)
+
+	// Append an event so the worker has something to process
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-err-1", []interface{}{&ProjectionTestEvent{OrderID: "err1"}})
+
+	t.Run("worker enters faulted state on Apply error and recovers", func(t *testing.T) {
+		projection := newTestAsyncProjection("AsyncErrorRecovery", "ProjectionTestEvent")
+		projection.SetError(assert.AnError) // Will fail initially
+
+		opts := DefaultAsyncOptions()
+		opts.PollInterval = 20 * time.Millisecond
+		opts.RetryPolicy = ExponentialBackoffRetry(10, 10*time.Millisecond, 50*time.Millisecond)
+		opts.StartFromBeginning = true
+		_ = engine.RegisterAsync(projection, opts)
+
+		runCtx, cancel := context.WithCancel(ctx)
+		_ = engine.Start(runCtx)
+
+		// Wait for error to be detected
+		time.Sleep(150 * time.Millisecond)
+
+		// Check the projection is faulted
+		status, err := engine.GetStatus("AsyncErrorRecovery")
+		require.NoError(t, err)
+		assert.Equal(t, ProjectionStateFaulted, status.State)
+		assert.NotEmpty(t, status.Error)
+
+		// Fix the error — should recover
+		projection.SetError(nil)
+
+		// Wait for recovery
+		time.Sleep(200 * time.Millisecond)
+
+		cancel()
+		_ = engine.Stop(context.Background())
+
+		// Logger should have recorded errors and recovery
+		logger.mu.Lock()
+		hasError := false
+		for _, msg := range logger.errorLogs {
+			if msg == "Async projection error" {
+				hasError = true
+				break
+			}
+		}
+		hasRecovery := false
+		for _, msg := range logger.infoLogs {
+			if msg == "Async projection recovered" {
+				hasRecovery = true
+				break
+			}
+		}
+		logger.mu.Unlock()
+
+		assert.True(t, hasError, "expected error log")
+		assert.True(t, hasRecovery, "expected recovery log")
+	})
+}
+
+func TestProjectionEngine_AsyncWorker_NilRetryPolicy(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	_ = store.Append(context.Background(), "Order-nil-retry", []interface{}{&ProjectionTestEvent{OrderID: "nilretry"}})
+
+	// Use nil retry policy to exercise the built-in fallback backoff
+	projection := newTestAsyncProjection("AsyncNilRetry", "ProjectionTestEvent")
+	projection.SetError(assert.AnError)
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.RetryPolicy = nil
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	// Wait for a few error cycles with built-in backoff
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_AsyncWorker_PanicRecovery(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	logger := newTestLogger()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(checkpoint),
+		WithProjectionLogger(logger),
+	)
+
+	_ = store.Append(context.Background(), "Order-panic-1", []interface{}{&ProjectionTestEvent{OrderID: "panic1"}})
+
+	// Create a panicking projection
+	projection := newTestPanickingAsyncProjection("AsyncPanic", "ProjectionTestEvent")
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.RetryPolicy = ExponentialBackoffRetry(3, 10*time.Millisecond, 50*time.Millisecond)
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	// Wait for panic to be caught and logged
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+
+	// Logger should have recorded the panic
+	logger.mu.Lock()
+	hasPanic := false
+	for _, msg := range logger.errorLogs {
+		if msg == "Async projection panicked" {
+			hasPanic = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	assert.True(t, hasPanic, "expected panic log")
+}
+
+func TestProjectionEngine_AsyncWorker_BatchApplySuccess(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	metrics := newTestProjectionMetrics()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(checkpoint),
+		WithProjectionMetrics(metrics),
+	)
+
+	// Append events
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		_ = store.Append(ctx, "Order-batch-ok-"+string(rune('0'+i)),
+			[]interface{}{&ProjectionTestEvent{OrderID: "batchok"}})
+	}
+
+	// Create projection that supports batch mode
+	projection := newTestAsyncProjection("AsyncBatchSuccess", "ProjectionTestEvent")
+	projection.EnableBatch()
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	_ = engine.Start(runCtx)
+
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+
+	// Should have processed events via batch
+	assert.GreaterOrEqual(t, len(projection.Events()), 1)
+
+	// Metrics should have recorded batch processing
+	metrics.mu.Lock()
+	batches := metrics.batchesProcessed
+	metrics.mu.Unlock()
+	assert.Greater(t, batches, 0)
+}
+
+func TestProjectionEngine_AsyncWorker_BatchApplyError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	metrics := newTestProjectionMetrics()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(checkpoint),
+		WithProjectionMetrics(metrics),
+	)
+
+	_ = store.Append(context.Background(), "Order-batch-err", []interface{}{&ProjectionTestEvent{OrderID: "batcherr"}})
+
+	projection := newTestAsyncProjection("AsyncBatchError", "ProjectionTestEvent")
+	projection.EnableBatch()
+	projection.batchApplyErr = assert.AnError
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.RetryPolicy = ExponentialBackoffRetry(2, 10*time.Millisecond, 50*time.Millisecond)
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+
+	// Metrics should have recorded failed batch
+	metrics.mu.Lock()
+	batches := metrics.batchesProcessed
+	metrics.mu.Unlock()
+	assert.Greater(t, batches, 0)
+}
+
+func TestProjectionEngine_Stop_ContextTimeout(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	// Register a slow projection that blocks on Apply
+	projection := newTestBlockingAsyncProjection("AsyncBlocking")
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 5 * time.Millisecond
+	_ = engine.RegisterAsync(projection, opts)
+
+	// Append an event to make the worker busy
+	_ = store.Append(context.Background(), "Order-block", []interface{}{&ProjectionTestEvent{OrderID: "block"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_ = engine.Start(ctx)
+
+	// Give worker time to start processing
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop with already-expired context
+	expiredCtx, expiredCancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer expiredCancel()
+	time.Sleep(time.Millisecond)
+
+	err := engine.Stop(expiredCtx)
+	// Should timeout or succeed — either is OK since the context is expired
+	_ = err
+
+	// Clean up
+	cancel()
+	projection.unblock()
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_GetStatus_AsyncWithError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	// Append an event
+	_ = store.Append(context.Background(), "Order-status-err", []interface{}{&ProjectionTestEvent{OrderID: "statuserr"}})
+
+	projection := newTestAsyncProjection("StatusErrProj", "ProjectionTestEvent")
+	projection.SetError(assert.AnError)
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.RetryPolicy = ExponentialBackoffRetry(1, 10*time.Millisecond, 50*time.Millisecond)
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	time.Sleep(150 * time.Millisecond)
+
+	// Status should show the error
+	status, err := engine.GetStatus("StatusErrProj")
+	require.NoError(t, err)
+	assert.NotEmpty(t, status.Error)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_LiveWorker_StopViaClose(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+
+	projection := newTestLiveProjection("LiveStopClose", true)
+	_ = engine.RegisterLive(projection)
+
+	ctx := context.Background()
+	_ = engine.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Unregister (which closes worker.stopCh)
+	_ = engine.Unregister("LiveStopClose")
+
+	// Stop engine
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_LiveWorker_PanicRecovery(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	logger := newTestLogger()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(newTestCheckpointStore()),
+		WithProjectionLogger(logger),
+	)
+
+	projection := newTestPanickingLiveProjection("LivePanic", "ProjectionTestEvent")
+	_ = engine.RegisterLive(projection)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Deliver event to trigger panic
+	events := []StoredEvent{{ID: "1", Type: "ProjectionTestEvent", Data: []byte("{}")}}
+	engine.NotifyLiveProjections(ctx, events)
+
+	// Wait for panic recovery
+	time.Sleep(100 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+
+	// Logger should have recorded the panic
+	logger.mu.Lock()
+	hasPanic := false
+	for _, msg := range logger.errorLogs {
+		if msg == "Live projection panicked" {
+			hasPanic = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	assert.True(t, hasPanic, "expected live projection panic log")
+}
+
+func TestProjectionEngine_LiveWorker_GetStatusWithError(t *testing.T) {
+	store := &EventStore{}
+	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+
+	projection := newTestLiveProjection("LiveStatusErr", true)
+	_ = engine.RegisterLive(projection)
+
+	// Manually set an error on the worker
+	engine.liveMu.RLock()
+	worker := engine.liveProjections["LiveStatusErr"]
+	engine.liveMu.RUnlock()
+	worker.stateMu.Lock()
+	worker.lastError = assert.AnError
+	worker.stateMu.Unlock()
+
+	status, err := engine.GetStatus("LiveStatusErr")
+	require.NoError(t, err)
+	assert.NotEmpty(t, status.Error)
+}
+
+func TestProjectionEngine_AsyncWorker_ProcessBatchContextCancel(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	projection := newTestAsyncProjection("AsyncCtxCancel", "ProjectionTestEvent")
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 10 * time.Millisecond
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	// Start with a context we'll cancel immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	// Cancel to trigger the context.Canceled path
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_AsyncWorker_CheckpointSetError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	logger := newTestLogger()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(checkpoint),
+		WithProjectionLogger(logger),
+	)
+
+	_ = store.Append(context.Background(), "Order-cps", []interface{}{&ProjectionTestEvent{OrderID: "cps"}})
+
+	// Make checkpoint set fail
+	checkpoint.setErr = assert.AnError
+
+	projection := newTestAsyncProjection("AsyncCheckpointSetErr", "ProjectionTestEvent")
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+
+	// Logger should warn about failed checkpoint
+	logger.mu.Lock()
+	hasError := false
+	for _, msg := range logger.errorLogs {
+		if msg == "Failed to save checkpoint" {
+			hasError = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	assert.True(t, hasError)
+}
+
+func TestProjectionEngine_AsyncWorker_StopViaUnregister(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	projection := newTestAsyncProjection("AsyncUnregStop", "ProjectionTestEvent")
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_ = engine.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Unregister while running — this closes worker.stopCh
+	err := engine.Unregister("AsyncUnregStop")
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_NotifyLiveProjections_FullBuffer(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	engine := NewProjectionEngine(store, WithCheckpointStore(newTestCheckpointStore()))
+
+	// Use buffer size of 1
+	projection := newTestLiveProjection("LiveFullBuffer", true)
+	opts := LiveOptions{BufferSize: 1}
+	_ = engine.RegisterLive(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	// Fill the buffer by not consuming events
+	// The live worker goroutine reads from eventCh, so we need to
+	// deliver many events rapidly to overflow. Use a separate goroutine
+	// that doesn't read.
+
+	// Cancel context first, then try to deliver - this should hit the ctx.Done path
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	// Now try to notify with cancelled context - the channel send should be
+	// competing with ctx.Done. We use a non-handled event type so the live
+	// worker's read from eventCh is not consuming.
+	events := make([]StoredEvent, 10)
+	for i := range events {
+		events[i] = StoredEvent{ID: string(rune('0' + i)), Type: "AllTypes", Data: []byte("{}")}
+	}
+	engine.NotifyLiveProjections(ctx, events)
+
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_AsyncWorker_HighConsecutiveErrors(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	_ = store.Append(context.Background(), "Order-hce", []interface{}{&ProjectionTestEvent{OrderID: "hce"}})
+
+	// Use nil retry policy to exercise the built-in fallback with high shift values
+	projection := newTestAsyncProjection("AsyncHighErrors", "ProjectionTestEvent")
+	projection.SetError(assert.AnError)
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 5 * time.Millisecond
+	opts.RetryPolicy = nil
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	// Let it accumulate many consecutive errors to exercise the shift > 18 cap
+	time.Sleep(300 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_AsyncWorker_CheckpointGetError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	checkpoint.getErr = assert.AnError
+	logger := newTestLogger()
+	engine := NewProjectionEngine(store,
+		WithCheckpointStore(checkpoint),
+		WithProjectionLogger(logger),
+	)
+
+	projection := newTestAsyncProjection("AsyncCheckpointGetErr", "ProjectionTestEvent")
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 20 * time.Millisecond
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+
+	// Logger should have recorded the error
+	logger.mu.Lock()
+	hasError := false
+	for _, msg := range logger.errorLogs {
+		if msg == "Failed to get checkpoint" {
+			hasError = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	assert.True(t, hasError)
+}
+
+func TestProjectionEngine_AsyncWorker_StopDuringBackoff(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	_ = store.Append(context.Background(), "Order-sdb", []interface{}{&ProjectionTestEvent{OrderID: "sdb"}})
+
+	// Projection always errors to keep the worker in error/backoff state
+	projection := newTestAsyncProjection("AsyncStopDuringBackoff", "ProjectionTestEvent")
+	projection.SetError(assert.AnError)
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 10 * time.Millisecond
+	opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second) // Long backoff so we're definitely in the wait
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	// Wait for at least one error to occur and the worker to enter backoff wait
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop the engine while the worker is waiting in the backoff select
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	err := engine.Stop(stopCtx)
+	assert.NoError(t, err)
+
+	status, statusErr := engine.GetStatus("AsyncStopDuringBackoff")
+	require.NoError(t, statusErr)
+	assert.Equal(t, ProjectionStateStopped, status.State)
+}
+
+func TestProjectionEngine_AsyncWorker_UnregisterDuringBackoff(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	_ = store.Append(context.Background(), "Order-udb", []interface{}{&ProjectionTestEvent{OrderID: "udb"}})
+
+	projection := newTestAsyncProjection("AsyncUnregDuringBackoff", "ProjectionTestEvent")
+	projection.SetError(assert.AnError)
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 10 * time.Millisecond
+	opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second)
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	// Wait for the worker to enter the backoff wait
+	time.Sleep(100 * time.Millisecond)
+
+	// Unregister while the worker is waiting in the backoff select (exercises worker.stopCh path)
+	err := engine.Unregister("AsyncUnregDuringBackoff")
+	assert.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	_ = engine.Stop(context.Background())
+}
+
+func TestProjectionEngine_AsyncWorker_ContextCancelDuringBackoff(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&ProjectionTestEvent{})
+	checkpoint := newTestCheckpointStore()
+	engine := NewProjectionEngine(store, WithCheckpointStore(checkpoint))
+
+	_ = store.Append(context.Background(), "Order-ccdb", []interface{}{&ProjectionTestEvent{OrderID: "ccdb"}})
+
+	projection := newTestAsyncProjection("AsyncCtxCancelBackoff", "ProjectionTestEvent")
+	projection.SetError(assert.AnError)
+	opts := DefaultAsyncOptions()
+	opts.PollInterval = 10 * time.Millisecond
+	opts.RetryPolicy = ExponentialBackoffRetry(100, 5*time.Second, 10*time.Second)
+	opts.StartFromBeginning = true
+	_ = engine.RegisterAsync(projection, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = engine.Start(ctx)
+
+	// Wait for the worker to enter the backoff wait
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel context while the worker is waiting in the backoff select (exercises ctx.Done() path)
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+
+	_ = engine.Stop(context.Background())
+}

--- a/rebuilder_test.go
+++ b/rebuilder_test.go
@@ -527,3 +527,231 @@ func TestProjectionRebuilder_RebuildWithFromPosition(t *testing.T) {
 	// Should have processed only events after position 5
 	assert.LessOrEqual(t, len(projection.events), 5)
 }
+
+// --- Additional Rebuilder Coverage Tests ---
+
+func TestProjectionRebuilder_RebuildAsync_BatchModeSuccess(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint)
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		_ = store.Append(ctx, "Order-bm-"+string(rune('0'+i)),
+			[]interface{}{&OrderCreatedEvent{OrderID: "bm-" + string(rune('0'+i))}})
+	}
+
+	// Use batch-enabled projection
+	projection := newTestAsyncProjection("BatchModeRebuild")
+	projection.EnableBatch()
+
+	err := rebuilder.RebuildAsync(ctx, projection)
+	require.NoError(t, err)
+
+	// Events should be processed via batch
+	assert.GreaterOrEqual(t, len(projection.Events()), 1)
+}
+
+func TestProjectionRebuilder_RebuildAsync_ApplyError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint)
+
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-err-1", []interface{}{&OrderCreatedEvent{OrderID: "err1"}})
+
+	projection := newTestAsyncProjection("AsyncApplyError")
+	projection.SetError(assert.AnError)
+
+	err := rebuilder.RebuildAsync(ctx, projection)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process batch")
+}
+
+func TestProjectionRebuilder_RebuildAsync_BatchApplyError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint)
+
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-be-1", []interface{}{&OrderCreatedEvent{OrderID: "be1"}})
+
+	projection := newTestAsyncProjection("BatchApplyError")
+	projection.EnableBatch()
+	projection.batchApplyErr = assert.AnError
+
+	err := rebuilder.RebuildAsync(ctx, projection)
+	assert.Error(t, err)
+}
+
+func TestProjectionRebuilder_RebuildInline_ApplyError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint)
+
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-ie-1", []interface{}{&OrderCreatedEvent{OrderID: "ie1"}})
+
+	projection := newTestInlineProjection("InlineApplyError")
+	projection.SetError(assert.AnError)
+
+	err := rebuilder.RebuildInline(ctx, projection)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process batch")
+}
+
+func TestProjectionRebuilder_RebuildWithNilCheckpointStore(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	rebuilder := NewProjectionRebuilder(store, nil)
+
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-nc-1", []interface{}{&OrderCreatedEvent{OrderID: "nc1"}})
+
+	projection := newTestAsyncProjection("NilCheckpointRebuild")
+
+	err := rebuilder.RebuildAsync(ctx, projection)
+	require.NoError(t, err)
+}
+
+func TestProjectionRebuilder_RebuildWithContextCancel(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint,
+		WithRebuilderBatchSize(2),
+	)
+
+	ctx := context.Background()
+
+	// Add many events
+	for i := 0; i < 50; i++ {
+		_ = store.Append(ctx, "Order-ctx-"+string(rune('0'+i%10)),
+			[]interface{}{&OrderCreatedEvent{OrderID: "ctx"}})
+	}
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel() // Cancel immediately
+
+	projection := newTestAsyncProjection("ContextCancelRebuild")
+	err := rebuilder.RebuildAsync(cancelCtx, projection)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestProjectionRebuilder_CheckpointDeleteError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	checkpoint.deleteErr = assert.AnError
+	logger := newTestLogger()
+	rebuilder := NewProjectionRebuilder(store, checkpoint,
+		WithRebuilderLogger(logger),
+	)
+
+	ctx := context.Background()
+	projection := newTestAsyncProjection("CheckpointDeleteErr")
+
+	// Should still succeed (checkpoint delete failure is non-fatal)
+	err := rebuilder.RebuildAsync(ctx, projection)
+	require.NoError(t, err)
+
+	// Logger should warn about failed delete
+	logger.mu.Lock()
+	hasWarn := false
+	for _, msg := range logger.warnLogs {
+		if msg == "Failed to delete checkpoint" {
+			hasWarn = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	assert.True(t, hasWarn)
+}
+
+func TestProjectionRebuilder_CheckpointSetError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	logger := newTestLogger()
+	rebuilder := NewProjectionRebuilder(store, checkpoint,
+		WithRebuilderLogger(logger),
+	)
+
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-cse-1", []interface{}{&OrderCreatedEvent{OrderID: "cse1"}})
+
+	// Set error after deletion succeeds
+	checkpoint.setErr = assert.AnError
+
+	projection := newTestAsyncProjection("CheckpointSetErr")
+	err := rebuilder.RebuildAsync(ctx, projection)
+	require.NoError(t, err)
+
+	// Logger should warn about failed set
+	logger.mu.Lock()
+	hasWarn := false
+	for _, msg := range logger.warnLogs {
+		if msg == "Failed to save checkpoint" {
+			hasWarn = true
+			break
+		}
+	}
+	logger.mu.Unlock()
+	assert.True(t, hasWarn)
+}
+
+func TestProjectionRebuilder_RebuildWithFilteredEvents(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint)
+
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_ = store.Append(ctx, "Order-filt-"+string(rune('0'+i)),
+			[]interface{}{&OrderCreatedEvent{OrderID: "filt-" + string(rune('0'+i))}})
+	}
+
+	// Projection that only handles a non-existent event type — all events filtered out
+	projection := newTestAsyncProjection("FilteredEventsRebuild", "NonExistentEventType")
+
+	err := rebuilder.RebuildAsync(ctx, projection)
+	require.NoError(t, err)
+
+	// No events should be processed
+	assert.Empty(t, projection.Events())
+}
+
+func TestParallelRebuilder_RebuildAll_WithError(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&OrderCreatedEvent{})
+	checkpoint := newTestCheckpointStore()
+	rebuilder := NewProjectionRebuilder(store, checkpoint)
+
+	ctx := context.Background()
+	_ = store.Append(ctx, "Order-par-err", []interface{}{&OrderCreatedEvent{OrderID: "parerr"}})
+
+	pr := NewParallelRebuilder(rebuilder, 2)
+
+	// One projection that errors
+	proj1 := newTestAsyncProjection("ParallelErr1")
+	proj1.SetError(assert.AnError)
+	proj2 := newTestAsyncProjection("ParallelErr2")
+
+	err := pr.RebuildAll(ctx, []AsyncProjection{proj1, proj2})
+	assert.Error(t, err)
+}

--- a/subscription.go
+++ b/subscription.go
@@ -220,7 +220,7 @@ func (s *CatchupSubscription) run(ctx context.Context, pollInterval time.Duratio
 		default:
 		}
 
-		events, err := subAdapter.LoadFromPosition(ctx, s.position, 100)
+		events, err := subAdapter.LoadFromPosition(ctx, s.getPosition(), 100)
 		if err != nil {
 			s.setErr(err)
 			return
@@ -232,13 +232,13 @@ func (s *CatchupSubscription) run(ctx context.Context, pollInterval time.Duratio
 
 		for _, event := range events {
 			if s.opts.Filter != nil && !s.opts.Filter.Matches(event) {
-				s.position = event.GlobalPosition
+				s.setPosition(event.GlobalPosition)
 				continue
 			}
 
 			select {
 			case s.eventCh <- event:
-				s.position = event.GlobalPosition
+				s.setPosition(event.GlobalPosition)
 			case <-ctx.Done():
 				s.setErr(ctx.Err())
 				return
@@ -260,7 +260,7 @@ func (s *CatchupSubscription) run(ctx context.Context, pollInterval time.Duratio
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
-			events, err := subAdapter.LoadFromPosition(ctx, s.position, 100)
+			events, err := subAdapter.LoadFromPosition(ctx, s.getPosition(), 100)
 			if err != nil {
 				// Retry on error unless configured not to
 				if !s.opts.RetryOnError {
@@ -272,13 +272,13 @@ func (s *CatchupSubscription) run(ctx context.Context, pollInterval time.Duratio
 
 			for _, event := range events {
 				if s.opts.Filter != nil && !s.opts.Filter.Matches(event) {
-					s.position = event.GlobalPosition
+					s.setPosition(event.GlobalPosition)
 					continue
 				}
 
 				select {
 				case s.eventCh <- event:
-					s.position = event.GlobalPosition
+					s.setPosition(event.GlobalPosition)
 				case <-ctx.Done():
 					s.setErr(ctx.Err())
 					return
@@ -321,6 +321,18 @@ func (s *CatchupSubscription) Position() uint64 {
 	s.errMu.RLock()
 	defer s.errMu.RUnlock()
 	return s.position
+}
+
+func (s *CatchupSubscription) getPosition() uint64 {
+	s.errMu.RLock()
+	defer s.errMu.RUnlock()
+	return s.position
+}
+
+func (s *CatchupSubscription) setPosition(pos uint64) {
+	s.errMu.Lock()
+	s.position = pos
+	s.errMu.Unlock()
 }
 
 func (s *CatchupSubscription) setErr(err error) {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AshkanYarmoradi/go-mink/adapters"
 	"github.com/AshkanYarmoradi/go-mink/adapters/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -723,4 +724,618 @@ func TestMinkSubscriptionAdapter(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, events, 2)
 	})
+}
+
+// --- Additional Subscription Coverage Tests ---
+
+func TestCatchupSubscription_WithRetryOnErrorFalse(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&CatchupTestEvent{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Append events so subscription transitions to polling
+	_ = store.Append(ctx, "Order-retry-1", []interface{}{&CatchupTestEvent{ID: "retry1"}})
+
+	opts := DefaultSubscriptionOptions()
+	opts.RetryOnError = false
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	err = sub.Start(ctx, 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Wait for catchup and a few poll cycles
+	time.Sleep(150 * time.Millisecond)
+
+	_ = sub.Close()
+}
+
+func TestCatchupSubscription_ContextCancelDuringCatchup(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&CatchupTestEvent{})
+
+	ctx := context.Background()
+
+	// Append many events to ensure catchup phase takes time
+	for i := 0; i < 20; i++ {
+		_ = store.Append(ctx, "Order-cc-"+string(rune('A'+i%26)),
+			[]interface{}{&CatchupTestEvent{ID: "cc-" + string(rune('A'+i%26))}})
+	}
+
+	// Use tiny buffer so backpressure causes the subscription to block
+	opts := DefaultSubscriptionOptions()
+	opts.BufferSize = 1
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	cancelCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
+	defer cancel()
+
+	err = sub.Start(cancelCtx, 10*time.Millisecond)
+	require.NoError(t, err)
+
+	// Wait for timeout to fire
+	time.Sleep(100 * time.Millisecond)
+
+	// Should have context error
+	subErr := sub.Err()
+	if subErr != nil {
+		assert.ErrorIs(t, subErr, context.DeadlineExceeded)
+	}
+	_ = sub.Close()
+}
+
+func TestCatchupSubscription_StopDuringPollingDelivery(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&CatchupTestEvent{})
+
+	ctx := context.Background()
+
+	// Start with no events (goes straight to polling)
+	sub, err := NewCatchupSubscription(store, 0)
+	require.NoError(t, err)
+
+	err = sub.Start(ctx, 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Wait for polling phase
+	time.Sleep(30 * time.Millisecond)
+
+	// Append event while polling
+	_ = store.Append(ctx, "Order-poll-stop", []interface{}{&CatchupTestEvent{ID: "pollstop"}})
+
+	// Close during polling
+	time.Sleep(50 * time.Millisecond)
+	_ = sub.Close()
+
+	time.Sleep(30 * time.Millisecond)
+}
+
+func TestPollingSubscription_ErrorDuringPoll(t *testing.T) {
+	// Use a store with a nil adapter to trigger errors during poll
+	store := &EventStore{}
+	sub := NewPollingSubscription(store, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sub.Start(ctx, 20*time.Millisecond)
+
+	// Let it try to poll (will get adapter errors)
+	time.Sleep(100 * time.Millisecond)
+
+	cancel()
+	time.Sleep(30 * time.Millisecond)
+
+	_ = sub.Close()
+}
+
+func TestCatchupSubscription_WithMinkSubscriptionAdapter(t *testing.T) {
+	// Create a store whose adapter implements mink.SubscriptionAdapter (not adapters.SubscriptionAdapter)
+	mockAdapter := &testMinkSubscriptionStoreAdapter{
+		events: []StoredEvent{
+			{ID: "1", StreamID: "Order-1", Type: "CatchupTestEvent", GlobalPosition: 1, Data: []byte("{}")},
+			{ID: "2", StreamID: "Order-2", Type: "CatchupTestEvent", GlobalPosition: 2, Data: []byte("{}")},
+		},
+	}
+
+	store := New(mockAdapter)
+	store.RegisterEvents(&CatchupTestEvent{})
+
+	sub, err := NewCatchupSubscription(store, 0)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err = sub.Start(ctx, 30*time.Millisecond)
+	require.NoError(t, err)
+
+	// Collect events
+	var received []StoredEvent
+	for event := range sub.Events() {
+		received = append(received, event)
+	}
+
+	_ = sub.Close()
+	assert.GreaterOrEqual(t, len(received), 1)
+}
+
+// testMinkSubscriptionStoreAdapter implements EventStoreAdapter AND mink.SubscriptionAdapter.
+type testMinkSubscriptionStoreAdapter struct {
+	events []StoredEvent
+}
+
+func (a *testMinkSubscriptionStoreAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
+	return nil, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) GetLastPosition(_ context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) Initialize(_ context.Context) error { return nil }
+func (a *testMinkSubscriptionStoreAdapter) Close() error                       { return nil }
+
+// Implement mink.SubscriptionAdapter (the one defined in projection_engine.go)
+func (a *testMinkSubscriptionStoreAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
+	var result []StoredEvent
+	for _, e := range a.events {
+		if e.GlobalPosition > fromPosition {
+			result = append(result, e)
+			if len(result) >= limit {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) SubscribeAll(_ context.Context, _ uint64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) SubscribeStream(_ context.Context, _ string, _ int64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testMinkSubscriptionStoreAdapter) SubscribeCategory(_ context.Context, _ string, _ uint64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+// --- Tests for Subscription Error Paths ---
+
+// testFailingSubscriptionAdapter returns errors from LoadFromPosition after N successful calls.
+type testFailingSubscriptionAdapter struct {
+	events    []StoredEvent
+	callCount int
+	failAfter int
+	failErr   error
+}
+
+func (a *testFailingSubscriptionAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testFailingSubscriptionAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testFailingSubscriptionAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
+	return nil, nil
+}
+
+func (a *testFailingSubscriptionAdapter) GetLastPosition(_ context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (a *testFailingSubscriptionAdapter) Initialize(_ context.Context) error { return nil }
+func (a *testFailingSubscriptionAdapter) Close() error                       { return nil }
+
+// Implement adapters.SubscriptionAdapter
+func (a *testFailingSubscriptionAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]adapters.StoredEvent, error) {
+	a.callCount++
+	if a.callCount > a.failAfter {
+		return nil, a.failErr
+	}
+	var result []adapters.StoredEvent
+	for _, e := range a.events {
+		if e.GlobalPosition > fromPosition {
+			result = append(result, adapters.StoredEvent{
+				ID:             e.ID,
+				StreamID:       e.StreamID,
+				Version:        e.Version,
+				Type:           e.Type,
+				Data:           e.Data,
+				GlobalPosition: e.GlobalPosition,
+			})
+			if len(result) >= limit {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (a *testFailingSubscriptionAdapter) SubscribeAll(_ context.Context, _ uint64, _ ...adapters.SubscriptionOptions) (<-chan adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testFailingSubscriptionAdapter) SubscribeStream(_ context.Context, _ string, _ int64, _ ...adapters.SubscriptionOptions) (<-chan adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testFailingSubscriptionAdapter) SubscribeCategory(_ context.Context, _ string, _ uint64, _ ...adapters.SubscriptionOptions) (<-chan adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func TestCatchupSubscription_ErrorDuringCatchup(t *testing.T) {
+	failAdapter := &testFailingSubscriptionAdapter{
+		events: []StoredEvent{
+			{ID: "1", StreamID: "Order-1", Type: "Test", GlobalPosition: 1, Data: []byte("{}")},
+		},
+		failAfter: 0, // Fail on first call
+		failErr:   assert.AnError,
+	}
+
+	store := New(failAdapter)
+
+	sub, err := NewCatchupSubscription(store, 0)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err = sub.Start(ctx, 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Wait for error
+	time.Sleep(100 * time.Millisecond)
+
+	// Should have error from LoadFromPosition
+	assert.Error(t, sub.Err())
+	_ = sub.Close()
+}
+
+func TestCatchupSubscription_RetryOnErrorFalse_DuringPolling(t *testing.T) {
+	failAdapter := &testFailingSubscriptionAdapter{
+		events: []StoredEvent{
+			{ID: "1", StreamID: "Order-1", Type: "Test", GlobalPosition: 1, Data: []byte("{}")},
+		},
+		failAfter: 2, // Succeed catchup, fail during polling
+		failErr:   assert.AnError,
+	}
+
+	store := New(failAdapter)
+
+	opts := DefaultSubscriptionOptions()
+	opts.RetryOnError = false
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err = sub.Start(ctx, 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Drain events — channel closes when run exits
+	for range sub.Events() {
+	}
+
+	// With RetryOnError=false, the polling error should cause the subscription to stop
+	subErr := sub.Err()
+	assert.Error(t, subErr, "expected an error from the subscription")
+	_ = sub.Close()
+}
+
+func TestCatchupSubscription_FilterDuringPolling(t *testing.T) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	store.RegisterEvents(&CatchupTestEvent{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start subscription with filter, no initial events (go to polling immediately)
+	opts := DefaultSubscriptionOptions()
+	opts.Filter = NewEventTypeFilter("SpecificType")
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	err = sub.Start(ctx, 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Wait for polling phase
+	time.Sleep(30 * time.Millisecond)
+
+	// Append events of different types
+	_ = store.Append(ctx, "Order-filt-1", []interface{}{&CatchupTestEvent{ID: "filt1"}})
+
+	// Wait for poll to pick up events
+	time.Sleep(100 * time.Millisecond)
+
+	_ = sub.Close()
+
+	// Position should have advanced even though events were filtered
+	assert.GreaterOrEqual(t, sub.Position(), uint64(0))
+}
+
+func TestCatchupSubscription_ContextCancelDuringEventDelivery(t *testing.T) {
+	// Create adapter with many events to force backpressure
+	events := make([]StoredEvent, 50)
+	for i := range events {
+		events[i] = StoredEvent{
+			ID:             string(rune('A' + i%26)),
+			StreamID:       "Order-1",
+			Type:           "Test",
+			GlobalPosition: uint64(i + 1),
+			Data:           []byte("{}"),
+		}
+	}
+	mockAdapter := &testMinkSubscriptionStoreAdapter{events: events}
+	store := New(mockAdapter)
+
+	// Tiny buffer = backpressure when not reading
+	opts := DefaultSubscriptionOptions()
+	opts.BufferSize = 1
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = sub.Start(ctx, 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Don't read from Events() — the buffer fills up, then the send blocks.
+	// Cancel context while the goroutine is blocked on channel send.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	// Wait for run to exit
+	time.Sleep(100 * time.Millisecond)
+
+	// Should have context cancelled error
+	assert.ErrorIs(t, sub.Err(), context.Canceled)
+	_ = sub.Close()
+}
+
+func TestCatchupSubscription_CloseDuringEventDelivery(t *testing.T) {
+	events := make([]StoredEvent, 50)
+	for i := range events {
+		events[i] = StoredEvent{
+			ID:             string(rune('A' + i%26)),
+			StreamID:       "Order-1",
+			Type:           "Test",
+			GlobalPosition: uint64(i + 1),
+			Data:           []byte("{}"),
+		}
+	}
+	mockAdapter := &testMinkSubscriptionStoreAdapter{events: events}
+	store := New(mockAdapter)
+
+	opts := DefaultSubscriptionOptions()
+	opts.BufferSize = 1
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	err = sub.Start(context.Background(), 20*time.Millisecond)
+	require.NoError(t, err)
+
+	// Don't read — Close while goroutine is blocked on send
+	time.Sleep(20 * time.Millisecond)
+	_ = sub.Close()
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestCatchupSubscription_ContextCancelDuringPollingDelivery(t *testing.T) {
+	// Adapter starts with no events (catchup finishes immediately), then returns many events on polling
+	pollingAdapter := &testDelayedEventsAdapter{
+		callThreshold: 2, // First 2 calls return nothing (catchup finishes), then returns many
+	}
+	// Fill events for polling
+	for i := 0; i < 50; i++ {
+		pollingAdapter.events = append(pollingAdapter.events, StoredEvent{
+			ID:             string(rune('A' + i%26)),
+			StreamID:       "Order-1",
+			Type:           "Test",
+			GlobalPosition: uint64(i + 1),
+			Data:           []byte("{}"),
+		})
+	}
+
+	store := New(pollingAdapter)
+
+	opts := DefaultSubscriptionOptions()
+	opts.BufferSize = 1
+
+	sub, err := NewCatchupSubscription(store, 0, opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = sub.Start(ctx, 10*time.Millisecond)
+	require.NoError(t, err)
+
+	// Wait for catchup to finish and polling to start delivering events
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel while polling is delivering events with a full buffer
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	assert.ErrorIs(t, sub.Err(), context.Canceled)
+	_ = sub.Close()
+}
+
+func TestPollingSubscription_ContextCancelDuringEventDelivery(t *testing.T) {
+	mockAdapter := &testMinkSubscriptionStoreAdapter{
+		events: func() []StoredEvent {
+			events := make([]StoredEvent, 50)
+			for i := range events {
+				events[i] = StoredEvent{
+					ID:             string(rune('A' + i%26)),
+					StreamID:       "Order-1",
+					Type:           "Test",
+					GlobalPosition: uint64(i + 1),
+					Data:           []byte("{}"),
+				}
+			}
+			return events
+		}(),
+	}
+	store := New(mockAdapter)
+
+	opts := DefaultSubscriptionOptions()
+	opts.BufferSize = 1
+
+	sub := NewPollingSubscription(store, 0, opts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sub.Start(ctx, 10*time.Millisecond)
+
+	// Wait for polling to fill the small buffer
+	time.Sleep(30 * time.Millisecond)
+
+	// Cancel while blocked on send
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	assert.ErrorIs(t, sub.Err(), context.Canceled)
+	_ = sub.Close()
+}
+
+func TestPollingSubscription_CloseDuringEventDelivery(t *testing.T) {
+	mockAdapter := &testMinkSubscriptionStoreAdapter{
+		events: func() []StoredEvent {
+			events := make([]StoredEvent, 50)
+			for i := range events {
+				events[i] = StoredEvent{
+					ID:             string(rune('A' + i%26)),
+					StreamID:       "Order-1",
+					Type:           "Test",
+					GlobalPosition: uint64(i + 1),
+					Data:           []byte("{}"),
+				}
+			}
+			return events
+		}(),
+	}
+	store := New(mockAdapter)
+
+	opts := DefaultSubscriptionOptions()
+	opts.BufferSize = 1
+
+	sub := NewPollingSubscription(store, 0, opts)
+
+	sub.Start(context.Background(), 10*time.Millisecond)
+
+	// Wait for polling to fill buffer
+	time.Sleep(30 * time.Millisecond)
+
+	// Close while blocked on send
+	_ = sub.Close()
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+// testDelayedEventsAdapter returns no events for the first N calls, then returns events.
+type testDelayedEventsAdapter struct {
+	events        []StoredEvent
+	callCount     int
+	callThreshold int
+}
+
+func (a *testDelayedEventsAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testDelayedEventsAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testDelayedEventsAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
+	return nil, nil
+}
+
+func (a *testDelayedEventsAdapter) GetLastPosition(_ context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (a *testDelayedEventsAdapter) Initialize(_ context.Context) error { return nil }
+func (a *testDelayedEventsAdapter) Close() error                       { return nil }
+
+// Implement mink.SubscriptionAdapter
+func (a *testDelayedEventsAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
+	a.callCount++
+	if a.callCount <= a.callThreshold {
+		return nil, nil // No events yet
+	}
+	var result []StoredEvent
+	for _, e := range a.events {
+		if e.GlobalPosition > fromPosition {
+			result = append(result, e)
+			if len(result) >= limit {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (a *testDelayedEventsAdapter) SubscribeAll(_ context.Context, _ uint64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testDelayedEventsAdapter) SubscribeStream(_ context.Context, _ string, _ int64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func (a *testDelayedEventsAdapter) SubscribeCategory(_ context.Context, _ string, _ uint64) (<-chan StoredEvent, error) {
+	return nil, nil
+}
+
+func TestPollingSubscription_WithMinkSubscriptionAdapter(t *testing.T) {
+	mockAdapter := &testMinkSubscriptionStoreAdapter{
+		events: []StoredEvent{
+			{ID: "1", StreamID: "Order-1", Type: "Test", GlobalPosition: 1, Data: []byte("{}")},
+		},
+	}
+
+	store := New(mockAdapter)
+
+	sub := NewPollingSubscription(store, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	sub.Start(ctx, 30*time.Millisecond)
+
+	// Collect events
+	var received []StoredEvent
+	for event := range sub.Events() {
+		received = append(received, event)
+		if len(received) >= 1 {
+			_ = sub.Close()
+			break
+		}
+	}
+
+	assert.GreaterOrEqual(t, len(received), 1)
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -682,17 +682,8 @@ type testMinkSubscriptionAdapter struct {
 	events []StoredEvent
 }
 
-func (m *testMinkSubscriptionAdapter) LoadFromPosition(ctx context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
-	var result []StoredEvent
-	for _, e := range m.events {
-		if e.GlobalPosition > fromPosition {
-			result = append(result, e)
-			if len(result) >= limit {
-				break
-			}
-		}
-	}
-	return result, nil
+func (m *testMinkSubscriptionAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
+	return filterEventsByPosition(m.events, fromPosition, limit), nil
 }
 
 func (m *testMinkSubscriptionAdapter) SubscribeAll(ctx context.Context, fromPosition uint64) (<-chan StoredEvent, error) {
@@ -866,34 +857,48 @@ func TestCatchupSubscription_WithMinkSubscriptionAdapter(t *testing.T) {
 	assert.GreaterOrEqual(t, len(received), 1)
 }
 
-// testMinkSubscriptionStoreAdapter implements EventStoreAdapter AND mink.SubscriptionAdapter.
-type testMinkSubscriptionStoreAdapter struct {
-	events []StoredEvent
-}
+// stubEventStoreAdapter provides no-op implementations of all adapters.EventStoreAdapter methods.
+// Embed it in test adapters to avoid duplicating these stubs.
+type stubEventStoreAdapter struct{}
 
-func (a *testMinkSubscriptionStoreAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
+func (stubEventStoreAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
 	return nil, nil
 }
 
-func (a *testMinkSubscriptionStoreAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
+func (stubEventStoreAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
 	return nil, nil
 }
 
-func (a *testMinkSubscriptionStoreAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
+func (stubEventStoreAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
 	return nil, nil
 }
 
-func (a *testMinkSubscriptionStoreAdapter) GetLastPosition(_ context.Context) (uint64, error) {
+func (stubEventStoreAdapter) GetLastPosition(_ context.Context) (uint64, error) {
 	return 0, nil
 }
 
-func (a *testMinkSubscriptionStoreAdapter) Initialize(_ context.Context) error { return nil }
-func (a *testMinkSubscriptionStoreAdapter) Close() error                       { return nil }
+func (stubEventStoreAdapter) Initialize(_ context.Context) error { return nil }
+func (stubEventStoreAdapter) Close() error                       { return nil }
 
-// Implement mink.SubscriptionAdapter (the one defined in projection_engine.go)
-func (a *testMinkSubscriptionStoreAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
+// makeTestStoredEvents creates a slice of StoredEvent for testing.
+func makeTestStoredEvents(count int) []StoredEvent {
+	events := make([]StoredEvent, count)
+	for i := range events {
+		events[i] = StoredEvent{
+			ID:             string(rune('A' + i%26)),
+			StreamID:       "Order-1",
+			Type:           "Test",
+			GlobalPosition: uint64(i + 1),
+			Data:           []byte("{}"),
+		}
+	}
+	return events
+}
+
+// filterEventsByPosition returns events whose GlobalPosition > fromPosition, up to limit.
+func filterEventsByPosition(events []StoredEvent, fromPosition uint64, limit int) []StoredEvent {
 	var result []StoredEvent
-	for _, e := range a.events {
+	for _, e := range events {
 		if e.GlobalPosition > fromPosition {
 			result = append(result, e)
 			if len(result) >= limit {
@@ -901,7 +906,18 @@ func (a *testMinkSubscriptionStoreAdapter) LoadFromPosition(_ context.Context, f
 			}
 		}
 	}
-	return result, nil
+	return result
+}
+
+// testMinkSubscriptionStoreAdapter implements EventStoreAdapter AND mink.SubscriptionAdapter.
+type testMinkSubscriptionStoreAdapter struct {
+	stubEventStoreAdapter
+	events []StoredEvent
+}
+
+// Implement mink.SubscriptionAdapter (the one defined in projection_engine.go)
+func (a *testMinkSubscriptionStoreAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
+	return filterEventsByPosition(a.events, fromPosition, limit), nil
 }
 
 func (a *testMinkSubscriptionStoreAdapter) SubscribeAll(_ context.Context, _ uint64) (<-chan StoredEvent, error) {
@@ -920,30 +936,12 @@ func (a *testMinkSubscriptionStoreAdapter) SubscribeCategory(_ context.Context, 
 
 // testFailingSubscriptionAdapter returns errors from LoadFromPosition after N successful calls.
 type testFailingSubscriptionAdapter struct {
+	stubEventStoreAdapter
 	events    []StoredEvent
 	callCount int
 	failAfter int
 	failErr   error
 }
-
-func (a *testFailingSubscriptionAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
-	return nil, nil
-}
-
-func (a *testFailingSubscriptionAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
-	return nil, nil
-}
-
-func (a *testFailingSubscriptionAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
-	return nil, nil
-}
-
-func (a *testFailingSubscriptionAdapter) GetLastPosition(_ context.Context) (uint64, error) {
-	return 0, nil
-}
-
-func (a *testFailingSubscriptionAdapter) Initialize(_ context.Context) error { return nil }
-func (a *testFailingSubscriptionAdapter) Close() error                       { return nil }
 
 // Implement adapters.SubscriptionAdapter
 func (a *testFailingSubscriptionAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]adapters.StoredEvent, error) {
@@ -1078,17 +1076,7 @@ func TestCatchupSubscription_FilterDuringPolling(t *testing.T) {
 
 func TestCatchupSubscription_ContextCancelDuringEventDelivery(t *testing.T) {
 	// Create adapter with many events to force backpressure
-	events := make([]StoredEvent, 50)
-	for i := range events {
-		events[i] = StoredEvent{
-			ID:             string(rune('A' + i%26)),
-			StreamID:       "Order-1",
-			Type:           "Test",
-			GlobalPosition: uint64(i + 1),
-			Data:           []byte("{}"),
-		}
-	}
-	mockAdapter := &testMinkSubscriptionStoreAdapter{events: events}
+	mockAdapter := &testMinkSubscriptionStoreAdapter{events: makeTestStoredEvents(50)}
 	store := New(mockAdapter)
 
 	// Tiny buffer = backpressure when not reading
@@ -1116,17 +1104,7 @@ func TestCatchupSubscription_ContextCancelDuringEventDelivery(t *testing.T) {
 }
 
 func TestCatchupSubscription_CloseDuringEventDelivery(t *testing.T) {
-	events := make([]StoredEvent, 50)
-	for i := range events {
-		events[i] = StoredEvent{
-			ID:             string(rune('A' + i%26)),
-			StreamID:       "Order-1",
-			Type:           "Test",
-			GlobalPosition: uint64(i + 1),
-			Data:           []byte("{}"),
-		}
-	}
-	mockAdapter := &testMinkSubscriptionStoreAdapter{events: events}
+	mockAdapter := &testMinkSubscriptionStoreAdapter{events: makeTestStoredEvents(50)}
 	store := New(mockAdapter)
 
 	opts := DefaultSubscriptionOptions()
@@ -1149,16 +1127,7 @@ func TestCatchupSubscription_ContextCancelDuringPollingDelivery(t *testing.T) {
 	// Adapter starts with no events (catchup finishes immediately), then returns many events on polling
 	pollingAdapter := &testDelayedEventsAdapter{
 		callThreshold: 2, // First 2 calls return nothing (catchup finishes), then returns many
-	}
-	// Fill events for polling
-	for i := 0; i < 50; i++ {
-		pollingAdapter.events = append(pollingAdapter.events, StoredEvent{
-			ID:             string(rune('A' + i%26)),
-			StreamID:       "Order-1",
-			Type:           "Test",
-			GlobalPosition: uint64(i + 1),
-			Data:           []byte("{}"),
-		})
+		events:        makeTestStoredEvents(50),
 	}
 
 	store := New(pollingAdapter)
@@ -1185,21 +1154,7 @@ func TestCatchupSubscription_ContextCancelDuringPollingDelivery(t *testing.T) {
 }
 
 func TestPollingSubscription_ContextCancelDuringEventDelivery(t *testing.T) {
-	mockAdapter := &testMinkSubscriptionStoreAdapter{
-		events: func() []StoredEvent {
-			events := make([]StoredEvent, 50)
-			for i := range events {
-				events[i] = StoredEvent{
-					ID:             string(rune('A' + i%26)),
-					StreamID:       "Order-1",
-					Type:           "Test",
-					GlobalPosition: uint64(i + 1),
-					Data:           []byte("{}"),
-				}
-			}
-			return events
-		}(),
-	}
+	mockAdapter := &testMinkSubscriptionStoreAdapter{events: makeTestStoredEvents(50)}
 	store := New(mockAdapter)
 
 	opts := DefaultSubscriptionOptions()
@@ -1222,21 +1177,7 @@ func TestPollingSubscription_ContextCancelDuringEventDelivery(t *testing.T) {
 }
 
 func TestPollingSubscription_CloseDuringEventDelivery(t *testing.T) {
-	mockAdapter := &testMinkSubscriptionStoreAdapter{
-		events: func() []StoredEvent {
-			events := make([]StoredEvent, 50)
-			for i := range events {
-				events[i] = StoredEvent{
-					ID:             string(rune('A' + i%26)),
-					StreamID:       "Order-1",
-					Type:           "Test",
-					GlobalPosition: uint64(i + 1),
-					Data:           []byte("{}"),
-				}
-			}
-			return events
-		}(),
-	}
+	mockAdapter := &testMinkSubscriptionStoreAdapter{events: makeTestStoredEvents(50)}
 	store := New(mockAdapter)
 
 	opts := DefaultSubscriptionOptions()
@@ -1257,29 +1198,11 @@ func TestPollingSubscription_CloseDuringEventDelivery(t *testing.T) {
 
 // testDelayedEventsAdapter returns no events for the first N calls, then returns events.
 type testDelayedEventsAdapter struct {
+	stubEventStoreAdapter
 	events        []StoredEvent
 	callCount     int
 	callThreshold int
 }
-
-func (a *testDelayedEventsAdapter) Append(_ context.Context, _ string, _ []adapters.EventRecord, _ int64) ([]adapters.StoredEvent, error) {
-	return nil, nil
-}
-
-func (a *testDelayedEventsAdapter) Load(_ context.Context, _ string, _ int64) ([]adapters.StoredEvent, error) {
-	return nil, nil
-}
-
-func (a *testDelayedEventsAdapter) GetStreamInfo(_ context.Context, _ string) (*adapters.StreamInfo, error) {
-	return nil, nil
-}
-
-func (a *testDelayedEventsAdapter) GetLastPosition(_ context.Context) (uint64, error) {
-	return 0, nil
-}
-
-func (a *testDelayedEventsAdapter) Initialize(_ context.Context) error { return nil }
-func (a *testDelayedEventsAdapter) Close() error                       { return nil }
 
 // Implement mink.SubscriptionAdapter
 func (a *testDelayedEventsAdapter) LoadFromPosition(_ context.Context, fromPosition uint64, limit int) ([]StoredEvent, error) {
@@ -1287,16 +1210,7 @@ func (a *testDelayedEventsAdapter) LoadFromPosition(_ context.Context, fromPosit
 	if a.callCount <= a.callThreshold {
 		return nil, nil // No events yet
 	}
-	var result []StoredEvent
-	for _, e := range a.events {
-		if e.GlobalPosition > fromPosition {
-			result = append(result, e)
-			if len(result) >= limit {
-				break
-			}
-		}
-	}
-	return result, nil
+	return filterEventsByPosition(a.events, fromPosition, limit), nil
 }
 
 func (a *testDelayedEventsAdapter) SubscribeAll(_ context.Context, _ uint64) (<-chan StoredEvent, error) {

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -311,3 +311,71 @@ func (p *testLiveProjection) WaitForEvent(timeout time.Duration) (StoredEvent, b
 		return StoredEvent{}, false
 	}
 }
+
+// =============================================================================
+// Shared Test Panicking Async Projection
+// =============================================================================
+
+// testPanickingAsyncProjection panics on Apply to test panic recovery.
+type testPanickingAsyncProjection struct {
+	AsyncProjectionBase
+}
+
+func newTestPanickingAsyncProjection(name string, handledEvents ...string) *testPanickingAsyncProjection {
+	return &testPanickingAsyncProjection{
+		AsyncProjectionBase: NewAsyncProjectionBase(name, handledEvents...),
+	}
+}
+
+func (p *testPanickingAsyncProjection) Apply(_ context.Context, _ StoredEvent) error {
+	panic("test panic in projection Apply")
+}
+
+// =============================================================================
+// Shared Test Blocking Async Projection
+// =============================================================================
+
+// testBlockingAsyncProjection blocks on Apply until unblocked.
+type testBlockingAsyncProjection struct {
+	AsyncProjectionBase
+	blockCh chan struct{}
+}
+
+func newTestBlockingAsyncProjection(name string, handledEvents ...string) *testBlockingAsyncProjection {
+	return &testBlockingAsyncProjection{
+		AsyncProjectionBase: NewAsyncProjectionBase(name, handledEvents...),
+		blockCh:             make(chan struct{}),
+	}
+}
+
+func (p *testBlockingAsyncProjection) Apply(_ context.Context, _ StoredEvent) error {
+	<-p.blockCh
+	return nil
+}
+
+func (p *testBlockingAsyncProjection) unblock() {
+	select {
+	case <-p.blockCh:
+	default:
+		close(p.blockCh)
+	}
+}
+
+// =============================================================================
+// Shared Test Panicking Live Projection
+// =============================================================================
+
+// testPanickingLiveProjection panics on OnEvent to test panic recovery.
+type testPanickingLiveProjection struct {
+	LiveProjectionBase
+}
+
+func newTestPanickingLiveProjection(name string, handledEvents ...string) *testPanickingLiveProjection {
+	return &testPanickingLiveProjection{
+		LiveProjectionBase: NewLiveProjectionBase(name, true, handledEvents...),
+	}
+}
+
+func (p *testPanickingLiveProjection) OnEvent(_ context.Context, _ StoredEvent) {
+	panic("test panic in live projection OnEvent")
+}

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -225,8 +225,11 @@ func newTestAsyncProjection(name string, handledEvents ...string) *testAsyncProj
 }
 
 func (p *testAsyncProjection) Apply(ctx context.Context, event StoredEvent) error {
-	if p.applyErr != nil {
-		return p.applyErr
+	p.mu.Lock()
+	err := p.applyErr
+	p.mu.Unlock()
+	if err != nil {
+		return err
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -235,11 +238,15 @@ func (p *testAsyncProjection) Apply(ctx context.Context, event StoredEvent) erro
 }
 
 func (p *testAsyncProjection) ApplyBatch(ctx context.Context, events []StoredEvent) error {
-	if !p.supportsBatch {
+	p.mu.Lock()
+	batch := p.supportsBatch
+	batchErr := p.batchApplyErr
+	p.mu.Unlock()
+	if !batch {
 		return ErrNotImplemented
 	}
-	if p.batchApplyErr != nil {
-		return p.batchApplyErr
+	if batchErr != nil {
+		return batchErr
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -256,10 +263,14 @@ func (p *testAsyncProjection) Events() []StoredEvent {
 }
 
 func (p *testAsyncProjection) SetError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.applyErr = err
 }
 
 func (p *testAsyncProjection) EnableBatch() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.supportsBatch = true
 }
 

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -50,6 +50,30 @@ func (l *testLogger) Error(msg string, args ...interface{}) {
 	l.errorLogs = append(l.errorLogs, msg)
 }
 
+// hasLogMessage checks whether a log message exists at the given level.
+// level must be one of "debug", "info", "warn", "error".
+func (l *testLogger) hasLogMessage(level string, message string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var logs []string
+	switch level {
+	case "debug":
+		logs = l.debugLogs
+	case "info":
+		logs = l.infoLogs
+	case "warn":
+		logs = l.warnLogs
+	case "error":
+		logs = l.errorLogs
+	}
+	for _, msg := range logs {
+		if msg == message {
+			return true
+		}
+	}
+	return false
+}
+
 // =============================================================================
 // Shared Test CheckpointStore
 // =============================================================================


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request adds extensive new test coverage for projection rebuilder logic, including edge cases and error handling scenarios. The main focus is on verifying the robustness of asynchronous and batch rebuilding, proper error propagation, checkpoint handling, and context cancellation. Additionally, new test helper types are introduced to simulate panicking and blocking projections for more thorough testing.

## Changes
<!-- List of changes -->

**Expanded Rebuilder Test Coverage:**

* Added multiple new tests to `rebuilder_test.go` covering batch mode success, error handling in both async and inline projections, context cancellation, and checkpoint store failures. These tests ensure the rebuilder handles various scenarios gracefully and logs warnings for non-fatal checkpoint errors.
* Included a test for rebuilding with filtered events, verifying that projections correctly ignore events they do not handle.
* Added parallel rebuilder tests to check error propagation when one of multiple projections fails during rebuild.

**New Test Helper Types:**

* Introduced `testPanickingAsyncProjection` and `testPanickingLiveProjection` in `test_helpers_test.go` to simulate panics in projection methods, enabling validation of panic recovery mechanisms.
* Added `testBlockingAsyncProjection` to allow controlled blocking and unblocking in tests, useful for concurrency and cancellation scenarios.

## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [ ] Code comments added
- [ ] README updated (if applicable)
- [ ] API docs updated

## Checklist
- [ ] Code follows project style guidelines
- [X] All tests pass
- [ ] No breaking changes (or documented if intentional)
