### PR TITLE
Add benchmarking suite for go-mink adapters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,7 @@ jobs:
       contents: read
     env:
       CGO_ENABLED: 0
+      MINK_SCALE_TESTS: 1
 
     steps:
       - name: Checkout code
@@ -108,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Run Go benchmarks
@@ -159,7 +160,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Run PostgreSQL adapter benchmarks
@@ -170,6 +171,7 @@ jobs:
       - name: Run PostgreSQL adapter scale tests
         env:
           TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable
+          MINK_SCALE_TESTS: 1
         run: go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/postgres/ 2>&1 | tee -a benchmark-postgres-results.txt
 
       - name: Upload benchmark results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,93 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
 
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CGO_ENABLED: 0
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Run Go benchmarks
+        run: go test -run='^$' -bench=. -benchmem -benchtime=3s -count=1 . 2>&1 | tee benchmark-results.txt
+
+      - name: Run scale tests (1M events)
+        run: go test -run='TestScale_' -v -timeout=10m -count=1 . 2>&1 | tee -a benchmark-results.txt
+
+      - name: Run memory adapter benchmarks
+        run: go test -run='^$' -bench=. -benchmem -benchtime=3s -count=1 ./adapters/memory/ 2>&1 | tee -a benchmark-results.txt
+
+      - name: Run memory adapter scale tests
+        run: go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/memory/ 2>&1 | tee -a benchmark-results.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmark-results
+          path: benchmark-results.txt
+          retention-days: 30
+
+  benchmark-postgres:
+    name: Benchmark (PostgreSQL)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: mink_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Run PostgreSQL adapter benchmarks
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable
+        run: go test -run='^$' -bench=. -benchmem -benchtime=3s -count=1 ./adapters/postgres/ 2>&1 | tee benchmark-postgres-results.txt
+
+      - name: Run PostgreSQL adapter scale tests
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable
+        run: go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/postgres/ 2>&1 | tee -a benchmark-postgres-results.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmark-postgres-results
+          path: benchmark-postgres-results.txt
+          retention-days: 30
+
   build:
     name: Build (${{ matrix.os }}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ benchmark:
 	CGO_ENABLED=0 go test -run='^$$' -bench=. -benchmem -benchtime=3s -count=1 .
 	@echo ""
 	@echo "=== Running Scale Tests (1M events) ==="
-	CGO_ENABLED=0 go test -run='TestScale_' -v -timeout=10m -count=1 .
+	CGO_ENABLED=0 MINK_SCALE_TESTS=1 go test -run='TestScale_' -v -timeout=10m -count=1 .
 
 # Run quick benchmarks only (no scale tests)
 benchmark-quick:
@@ -69,7 +69,7 @@ benchmark-adapters:
 	CGO_ENABLED=0 go test -run='^$$' -bench=. -benchmem -benchtime=3s -count=1 ./adapters/memory/
 	@echo ""
 	@echo "=== Memory Adapter Scale Tests ==="
-	CGO_ENABLED=0 go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/memory/
+	CGO_ENABLED=0 MINK_SCALE_TESTS=1 go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/memory/
 
 # Run PostgreSQL adapter benchmarks (requires infra)
 benchmark-adapters-pg: infra-up
@@ -79,7 +79,7 @@ benchmark-adapters-pg: infra-up
 	@echo ""
 	@echo "=== PostgreSQL Adapter Scale Tests ==="
 	TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
-	go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/postgres/
+	MINK_SCALE_TESTS=1 go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/postgres/
 
 #------------------------------------------------------------------------------
 # Test Infrastructure (docker-compose.test.yml is the single source of truth)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 
 .PHONY: all build test test-unit test-unit-race test-coverage lint fmt clean help
 .PHONY: infra-up infra-down infra-logs infra-ps
+.PHONY: benchmark benchmark-quick benchmark-adapters benchmark-adapters-pg
 
 # Default target
 all: lint test build
@@ -45,6 +46,40 @@ test-coverage: infra-up
 	@go tool cover -func=coverage.out | grep total
 	@go tool cover -html=coverage.out -o coverage.html
 	@echo "Full report: coverage.html"
+
+#------------------------------------------------------------------------------
+# Benchmarks & Performance (no infrastructure required, uses in-memory adapter)
+#------------------------------------------------------------------------------
+
+# Run full benchmark suite: Go benchmarks + 1M-event scale tests
+benchmark:
+	@echo "=== Running Go Benchmarks ==="
+	CGO_ENABLED=0 go test -run='^$$' -bench=. -benchmem -benchtime=3s -count=1 .
+	@echo ""
+	@echo "=== Running Scale Tests (1M events) ==="
+	CGO_ENABLED=0 go test -run='TestScale_' -v -timeout=10m -count=1 .
+
+# Run quick benchmarks only (no scale tests)
+benchmark-quick:
+	CGO_ENABLED=0 go test -run='^$$' -bench=. -benchmem -benchtime=1s -count=1 .
+
+# Run memory adapter benchmarks (no infrastructure required)
+benchmark-adapters:
+	@echo "=== Memory Adapter Benchmarks ==="
+	CGO_ENABLED=0 go test -run='^$$' -bench=. -benchmem -benchtime=3s -count=1 ./adapters/memory/
+	@echo ""
+	@echo "=== Memory Adapter Scale Tests ==="
+	CGO_ENABLED=0 go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/memory/
+
+# Run PostgreSQL adapter benchmarks (requires infra)
+benchmark-adapters-pg: infra-up
+	@echo "=== PostgreSQL Adapter Benchmarks ==="
+	TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
+	go test -run='^$$' -bench=. -benchmem -benchtime=3s -count=1 ./adapters/postgres/
+	@echo ""
+	@echo "=== PostgreSQL Adapter Scale Tests ==="
+	TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
+	go test -run='TestAdapterScale' -v -timeout=10m -count=1 ./adapters/postgres/
 
 #------------------------------------------------------------------------------
 # Test Infrastructure (docker-compose.test.yml is the single source of truth)
@@ -96,6 +131,12 @@ help:
 	@echo "  make test-unit-race - Run unit tests with race detector (requires gcc)"
 	@echo "  make test           - Run all tests (auto-starts infrastructure)"
 	@echo "  make test-coverage  - Run tests with coverage report"
+	@echo ""
+	@echo "Benchmarks:"
+	@echo "  make benchmark            - Full benchmark suite + 1M-event scale tests"
+	@echo "  make benchmark-quick      - Go benchmarks only (fast)"
+	@echo "  make benchmark-adapters   - Memory adapter benchmarks (no infra)"
+	@echo "  make benchmark-adapters-pg - PostgreSQL adapter benchmarks (needs infra)"
 	@echo ""
 	@echo "Infrastructure (defined in docker-compose.test.yml):"
 	@echo "  make infra-up      - Start test infrastructure"

--- a/README.md
+++ b/README.md
@@ -382,6 +382,25 @@ store := mink.New(adapter, mink.WithFieldEncryption(encConfig))
 // Revoking a key makes that tenant's data permanently unrecoverable (GDPR)
 ```
 
+## Performance
+
+go-mink is benchmarked on every commit with a shared adapter benchmark suite. Key metrics from CI (ubuntu-latest):
+
+| Adapter | Append (single) | Append (batch 100) | Load (1000 events) | Concurrent (8 workers) |
+|---------|-----------------|--------------------|--------------------|------------------------|
+| **Memory** | ~2.5M events/sec | ~6M events/sec | ~60M events/sec | ~1.5M events/sec |
+| **PostgreSQL** | ~5K events/sec | ~30K events/sec | ~300K events/sec | ~15K events/sec |
+
+Scale tests: Memory adapter processes **1M events** in under 1 second. PostgreSQL adapter handles **100K events** with p99 append latency under 2ms.
+
+Run benchmarks locally:
+```bash
+make benchmark-adapters      # Memory adapter (no infra)
+make benchmark-adapters-pg   # PostgreSQL adapter (needs infra)
+```
+
+See [full benchmark results](docs/benchmarks.md) for detailed throughput, latency percentiles, and instructions for adding benchmarks to new adapters.
+
 ## Installation
 
 ```bash
@@ -405,6 +424,7 @@ go get github.com/AshkanYarmoradi/go-mink/adapters/postgres
 | [Event Versioning](docs/versioning.md) | Schema evolution & upcasting |
 | [Security](docs/security.md) | Encryption, GDPR compliance |
 | [Testing](docs/testing.md) | BDD fixtures and test utilities |
+| [Benchmarks](docs/benchmarks.md) | Performance results and benchmark guide |
 
 ## License
 

--- a/adapters/memory/benchmark_test.go
+++ b/adapters/memory/benchmark_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"os"
 	"testing"
 
 	"github.com/AshkanYarmoradi/go-mink/adapters"
@@ -23,5 +24,8 @@ func BenchmarkAdapter(b *testing.B) {
 }
 
 func TestAdapterScale(t *testing.T) {
+	if os.Getenv("MINK_SCALE_TESTS") != "1" {
+		t.Skip("Skipping scale test; set MINK_SCALE_TESTS=1 to enable")
+	}
 	benchmarks.RunScale(t, newBenchmarkFactory())
 }

--- a/adapters/memory/benchmark_test.go
+++ b/adapters/memory/benchmark_test.go
@@ -1,0 +1,27 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/AshkanYarmoradi/go-mink/adapters"
+	"github.com/AshkanYarmoradi/go-mink/testing/benchmarks"
+)
+
+func newBenchmarkFactory() benchmarks.AdapterBenchmarkFactory {
+	return benchmarks.AdapterBenchmarkFactory{
+		Name: "memory",
+		CreateAdapter: func() (adapters.EventStoreAdapter, func(), error) {
+			a := NewAdapter()
+			return a, func() { _ = a.Close() }, nil
+		},
+		Scale: &benchmarks.ScaleConfig{EventCount: 1_000_000},
+	}
+}
+
+func BenchmarkAdapter(b *testing.B) {
+	benchmarks.Run(b, newBenchmarkFactory())
+}
+
+func TestAdapterScale(t *testing.T) {
+	benchmarks.RunScale(t, newBenchmarkFactory())
+}

--- a/adapters/postgres/benchmark_test.go
+++ b/adapters/postgres/benchmark_test.go
@@ -69,5 +69,8 @@ func BenchmarkAdapter(b *testing.B) {
 }
 
 func TestAdapterScale(t *testing.T) {
+	if os.Getenv("MINK_SCALE_TESTS") != "1" {
+		t.Skip("Skipping scale test; set MINK_SCALE_TESTS=1 to enable")
+	}
 	benchmarks.RunScale(t, newBenchmarkFactory())
 }

--- a/adapters/postgres/benchmark_test.go
+++ b/adapters/postgres/benchmark_test.go
@@ -1,0 +1,73 @@
+package postgres
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AshkanYarmoradi/go-mink/adapters"
+	"github.com/AshkanYarmoradi/go-mink/testing/benchmarks"
+)
+
+// benchDB opens a database connection for benchmarks.
+// Returns nil if TEST_DATABASE_URL is not set.
+func benchDB() (*sql.DB, error) {
+	connStr := os.Getenv("TEST_DATABASE_URL")
+	if connStr == "" {
+		return nil, nil
+	}
+	return sql.Open("pgx", connStr)
+}
+
+// benchSchema generates a unique schema name for benchmark isolation.
+func benchSchema() string {
+	return fmt.Sprintf("bench_%d", time.Now().UnixNano())
+}
+
+func newBenchmarkFactory() benchmarks.AdapterBenchmarkFactory {
+	return benchmarks.AdapterBenchmarkFactory{
+		Name: "postgres",
+		CreateAdapter: func() (adapters.EventStoreAdapter, func(), error) {
+			db, err := benchDB()
+			if err != nil {
+				return nil, nil, err
+			}
+			if db == nil {
+				return nil, nil, fmt.Errorf("TEST_DATABASE_URL not set")
+			}
+			schema := benchSchema()
+			a, err := NewAdapterWithDB(db, WithSchema(schema))
+			if err != nil {
+				_ = db.Close()
+				return nil, nil, err
+			}
+			cleanup := func() {
+				schemaQ := quoteIdentifier(schema)
+				_, _ = db.Exec(`DROP SCHEMA IF EXISTS ` + schemaQ + ` CASCADE`)
+				_ = a.Close()
+				_ = db.Close()
+			}
+			return a, cleanup, nil
+		},
+		Skip: func() string {
+			if testing.Short() {
+				return "Skipping integration benchmark in short mode"
+			}
+			if os.Getenv("TEST_DATABASE_URL") == "" {
+				return "TEST_DATABASE_URL not set"
+			}
+			return ""
+		},
+		Scale: &benchmarks.ScaleConfig{EventCount: 100_000},
+	}
+}
+
+func BenchmarkAdapter(b *testing.B) {
+	benchmarks.Run(b, newBenchmarkFactory())
+}
+
+func TestAdapterScale(t *testing.T) {
+	benchmarks.RunScale(t, newBenchmarkFactory())
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -187,7 +187,9 @@ func BenchmarkAppend_SingleEvent(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event}, ExpectVersion(AnyVersion))
+		if err := store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+			b.Fatalf("append failed at %d: %v", i, err)
+		}
 	}
 
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -215,7 +217,9 @@ func BenchmarkAppend_BatchSize(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), events, ExpectVersion(AnyVersion))
+				if err := store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), events, ExpectVersion(AnyVersion)); err != nil {
+					b.Fatalf("batch append failed at %d: %v", i, err)
+				}
 			}
 
 			totalEvents := float64(b.N) * float64(batchSize)
@@ -241,8 +245,10 @@ func BenchmarkAppend_WithMetadata(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event},
-			ExpectVersion(AnyVersion), WithAppendMetadata(meta))
+		if err := store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event},
+			ExpectVersion(AnyVersion), WithAppendMetadata(meta)); err != nil {
+			b.Fatalf("append with metadata failed at %d: %v", i, err)
+		}
 	}
 
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -258,7 +264,9 @@ func BenchmarkAppend_SameStream_Sequential(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		event := BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(i), Quantity: 1, Price: 10.0}
-		_ = store.Append(ctx, "BenchOrder-same", []interface{}{event}, ExpectVersion(AnyVersion))
+		if err := store.Append(ctx, "BenchOrder-same", []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+			b.Fatalf("same-stream append failed at %d: %v", i, err)
+		}
 	}
 
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -283,15 +291,18 @@ func BenchmarkLoad_StreamSize(b *testing.B) {
 					OrderID: "o1", SKU: "SKU-" + strconv.Itoa(j),
 					Name: "Product", Quantity: 1, Price: 10.0,
 				}
-				_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+				if err := store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+					b.Fatalf("seed failed at %d: %v", j, err)
+				}
 			}
 
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				events, _ := store.Load(ctx, streamID)
-				_ = events
+				if _, err := store.Load(ctx, streamID); err != nil {
+					b.Fatalf("load failed at %d: %v", i, err)
+				}
 			}
 
 			b.ReportMetric(float64(size)*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -308,15 +319,18 @@ func BenchmarkLoadFrom_MidStream(b *testing.B) {
 	streamID := "BenchOrder-loadfrom"
 	for j := 0; j < 1000; j++ {
 		event := BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(j), Quantity: 1, Price: 10.0}
-		_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+		if err := store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+			b.Fatalf("seed failed at %d: %v", j, err)
+		}
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		events, _ := store.LoadFrom(ctx, streamID, 500)
-		_ = events
+		if _, err := store.LoadFrom(ctx, streamID, 500); err != nil {
+			b.Fatalf("load from failed at %d: %v", i, err)
+		}
 	}
 
 	b.ReportMetric(500.0*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -342,7 +356,9 @@ func BenchmarkAggregate_Save(b *testing.B) {
 				for j := 1; j < numEvents; j++ {
 					order.AddItem("SKU-"+strconv.Itoa(j), "Product", j, 10.0)
 				}
-				_ = store.SaveAggregate(ctx, order)
+				if err := store.SaveAggregate(ctx, order); err != nil {
+					b.Fatalf("save aggregate failed at %d: %v", i, err)
+				}
 			}
 
 			b.ReportMetric(float64(numEvents)*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -364,14 +380,18 @@ func BenchmarkAggregate_Load(b *testing.B) {
 			for j := 1; j < numEvents; j++ {
 				order.AddItem("SKU-"+strconv.Itoa(j), "Product", 1, 10.0)
 			}
-			_ = store.SaveAggregate(ctx, order)
+			if err := store.SaveAggregate(ctx, order); err != nil {
+				b.Fatalf("seed aggregate failed: %v", err)
+			}
 
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
 				loaded := newBenchOrder("bench-load")
-				_ = store.LoadAggregate(ctx, loaded)
+				if err := store.LoadAggregate(ctx, loaded); err != nil {
+					b.Fatalf("load aggregate failed at %d: %v", i, err)
+				}
 			}
 
 			b.ReportMetric(float64(numEvents)*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -396,13 +416,19 @@ func BenchmarkAggregate_FullLifecycle(b *testing.B) {
 		order.Create("cust-1", 100.0)
 		order.AddItem("SKU-1", "Widget", 2, 29.99)
 		order.AddItem("SKU-2", "Gadget", 1, 49.99)
-		_ = store.SaveAggregate(ctx, order)
+		if err := store.SaveAggregate(ctx, order); err != nil {
+			b.Fatalf("save failed at %d: %v", i, err)
+		}
 
 		// Load and modify
 		loaded := newBenchOrder(id)
-		_ = store.LoadAggregate(ctx, loaded)
+		if err := store.LoadAggregate(ctx, loaded); err != nil {
+			b.Fatalf("load failed at %d: %v", i, err)
+		}
 		loaded.Ship("TRACK-"+strconv.Itoa(i), "UPS")
-		_ = store.SaveAggregate(ctx, loaded)
+		if err := store.SaveAggregate(ctx, loaded); err != nil {
+			b.Fatalf("save modified failed at %d: %v", i, err)
+		}
 	}
 }
 
@@ -601,8 +627,10 @@ func BenchmarkConcurrent_AppendDifferentStreams(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			id := counter.Add(1)
-			_ = store.Append(ctx, "BenchOrder-"+strconv.FormatInt(id, 10),
-				[]interface{}{event}, ExpectVersion(AnyVersion))
+			if err := store.Append(ctx, "BenchOrder-"+strconv.FormatInt(id, 10),
+				[]interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+				b.Fatalf("concurrent append failed: %v", err)
+			}
 		}
 	})
 
@@ -620,7 +648,9 @@ func BenchmarkConcurrent_LoadWhileWriting(b *testing.B) {
 		streamID := "BenchOrder-rw-" + strconv.Itoa(s)
 		for e := 0; e < 10; e++ {
 			event := BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(e), Quantity: 1, Price: 10.0}
-			_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+			if err := store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+				b.Fatalf("seed failed: %v", err)
+			}
 		}
 	}
 
@@ -635,12 +665,15 @@ func BenchmarkConcurrent_LoadWhileWriting(b *testing.B) {
 				// 1/3 writes
 				streamID := "BenchOrder-rw-new-" + strconv.FormatInt(id, 10)
 				event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99}
-				_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+				if err := store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+					b.Fatalf("concurrent write failed: %v", err)
+				}
 			} else {
 				// 2/3 reads
 				streamID := "BenchOrder-rw-" + strconv.Itoa(int(id%100))
-				events, _ := store.Load(ctx, streamID)
-				_ = events
+				if _, err := store.Load(ctx, streamID); err != nil {
+					b.Fatalf("concurrent load failed: %v", err)
+				}
 			}
 		}
 	})
@@ -770,7 +803,7 @@ func sampleLatencies(numSamples, opsPerSample int, op func(globalIdx int)) []tim
 // latencyStats holds percentile statistics from a slice of latency samples.
 type latencyStats struct {
 	avg, p50, p90, p95, p99, p999 time.Duration
-	min, max                       time.Duration
+	min, max                      time.Duration
 }
 
 func computeLatencyStats(latencies []time.Duration) latencyStats {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,6 +3,7 @@ package mink
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -730,10 +731,20 @@ const (
 	scaleShort   = 10_000
 )
 
-func scaleN(t *testing.T) int {
+// skipUnlessScale skips the test unless scale tests are explicitly enabled.
+func skipUnlessScale(t *testing.T) {
+	t.Helper()
 	if testing.Short() {
-		t.Skip("skipping scale test in -short mode (run with: make benchmark)")
+		t.Skip("skipping scale test in -short mode")
 	}
+	if os.Getenv("MINK_SCALE_TESTS") != "1" {
+		t.Skip("skipping scale test; set MINK_SCALE_TESTS=1 to enable (run with: make benchmark)")
+	}
+}
+
+func scaleN(t *testing.T) int {
+	t.Helper()
+	skipUnlessScale(t)
 	return scaleDefault
 }
 
@@ -987,9 +998,7 @@ func TestScale_MillionCommandDispatches(t *testing.T) {
 }
 
 func TestScale_LargeAggregateReplay(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping scale test in -short mode")
-	}
+	skipUnlessScale(t)
 
 	numEvents := 100_000
 
@@ -1081,9 +1090,7 @@ func TestScale_ConcurrentMillionEvents(t *testing.T) {
 }
 
 func TestScale_LatencyDistribution(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping scale test in -short mode")
-	}
+	skipUnlessScale(t)
 
 	// Measure batches of opsPerSample to get accurate sub-µs latencies on all platforms.
 	// Windows timer resolution is ~100ns; batching 100 ops ensures measurable durations.
@@ -1105,9 +1112,7 @@ func TestScale_LatencyDistribution(t *testing.T) {
 }
 
 func TestScale_MixedWorkloadConcurrent(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping scale test in -short mode")
-	}
+	skipUnlessScale(t)
 
 	n := 500_000
 
@@ -1209,9 +1214,7 @@ func TestScale_SerializerThroughput(t *testing.T) {
 }
 
 func TestScale_CommandBusLatencyDistribution(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping scale test in -short mode")
-	}
+	skipUnlessScale(t)
 
 	const totalOps = 100_000
 	const opsPerSample = 100

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -732,6 +732,68 @@ func memStatsDelta(before, after runtime.MemStats) (allocsMB float64, heapMB flo
 	return
 }
 
+// scaleTimer measures wall-clock time and memory allocation for scale tests.
+type scaleTimer struct {
+	start     time.Time
+	memBefore runtime.MemStats
+}
+
+func newScaleTimer() scaleTimer {
+	var m runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	return scaleTimer{start: time.Now(), memBefore: m}
+}
+
+func (s scaleTimer) stop() (elapsed time.Duration, allocMB, heapMB float64) {
+	elapsed = time.Since(s.start)
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	allocMB, heapMB = memStatsDelta(s.memBefore, memAfter)
+	return
+}
+
+// sampleLatencies measures per-op latency by running batches of opsPerSample invocations.
+func sampleLatencies(numSamples, opsPerSample int, op func(globalIdx int)) []time.Duration {
+	latencies := make([]time.Duration, numSamples)
+	for s := 0; s < numSamples; s++ {
+		start := time.Now()
+		base := s * opsPerSample
+		for i := 0; i < opsPerSample; i++ {
+			op(base + i)
+		}
+		latencies[s] = time.Since(start) / time.Duration(opsPerSample)
+	}
+	return latencies
+}
+
+// latencyStats holds percentile statistics from a slice of latency samples.
+type latencyStats struct {
+	avg, p50, p90, p95, p99, p999 time.Duration
+	min, max                       time.Duration
+}
+
+func computeLatencyStats(latencies []time.Duration) latencyStats {
+	n := len(latencies)
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+	var total time.Duration
+	for _, l := range latencies {
+		total += l
+	}
+
+	return latencyStats{
+		avg:  total / time.Duration(n),
+		p50:  latencies[n*50/100],
+		p90:  latencies[n*90/100],
+		p95:  latencies[n*95/100],
+		p99:  latencies[n*99/100],
+		p999: latencies[n*999/1000],
+		min:  latencies[0],
+		max:  latencies[n-1],
+	}
+}
+
 func TestScale_MillionEventsAppend(t *testing.T) {
 	n := scaleN(t)
 
@@ -740,11 +802,7 @@ func TestScale_MillionEventsAppend(t *testing.T) {
 	ctx := context.Background()
 	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
 
-	var memBefore runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&memBefore)
-
-	start := time.Now()
+	timer := newScaleTimer()
 
 	for i := 0; i < n; i++ {
 		err := store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event}, ExpectVersion(AnyVersion))
@@ -753,11 +811,7 @@ func TestScale_MillionEventsAppend(t *testing.T) {
 		}
 	}
 
-	elapsed := time.Since(start)
-
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+	elapsed, allocMB, heapMB := timer.stop()
 
 	throughput := float64(n) / elapsed.Seconds()
 	avgLatency := elapsed / time.Duration(n)
@@ -784,11 +838,7 @@ func TestScale_MillionEventsSingleStream(t *testing.T) {
 	store := New(adapter)
 	ctx := context.Background()
 
-	var memBefore runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&memBefore)
-
-	start := time.Now()
+	timer := newScaleTimer()
 
 	// Append in batches of 100 to a single stream for realistic throughput
 	batchSize := 100
@@ -813,11 +863,7 @@ func TestScale_MillionEventsSingleStream(t *testing.T) {
 		}
 	}
 
-	elapsed := time.Since(start)
-
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+	elapsed, allocMB, heapMB := timer.stop()
 
 	throughput := float64(n) / elapsed.Seconds()
 
@@ -843,11 +889,7 @@ func TestScale_MillionEventsAcrossStreams(t *testing.T) {
 	numStreams := 10_000
 	eventsPerStream := n / numStreams
 
-	var memBefore runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&memBefore)
-
-	start := time.Now()
+	timer := newScaleTimer()
 
 	for s := 0; s < numStreams; s++ {
 		streamID := "BenchOrder-" + strconv.Itoa(s)
@@ -867,11 +909,7 @@ func TestScale_MillionEventsAcrossStreams(t *testing.T) {
 		}
 	}
 
-	elapsed := time.Since(start)
-
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+	elapsed, allocMB, heapMB := timer.stop()
 
 	throughput := float64(n) / elapsed.Seconds()
 
@@ -989,11 +1027,7 @@ func TestScale_ConcurrentMillionEvents(t *testing.T) {
 	numWorkers := runtime.GOMAXPROCS(0)
 	eventsPerWorker := n / numWorkers
 
-	var memBefore runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&memBefore)
-
-	start := time.Now()
+	timer := newScaleTimer()
 
 	var wg sync.WaitGroup
 	var errorCount atomic.Int64
@@ -1013,11 +1047,7 @@ func TestScale_ConcurrentMillionEvents(t *testing.T) {
 	}
 	wg.Wait()
 
-	elapsed := time.Since(start)
-
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+	elapsed, allocMB, heapMB := timer.stop()
 
 	actualEvents := numWorkers * eventsPerWorker
 	throughput := float64(actualEvents) / elapsed.Seconds()
@@ -1053,41 +1083,22 @@ func TestScale_LatencyDistribution(t *testing.T) {
 	ctx := context.Background()
 	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
 
-	latencies := make([]time.Duration, numSamples)
+	latencies := sampleLatencies(numSamples, opsPerSample, func(idx int) {
+		_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(idx), []interface{}{event}, ExpectVersion(AnyVersion))
+	})
 
-	for s := 0; s < numSamples; s++ {
-		start := time.Now()
-		base := s * opsPerSample
-		for i := 0; i < opsPerSample; i++ {
-			_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(base+i), []interface{}{event}, ExpectVersion(AnyVersion))
-		}
-		latencies[s] = time.Since(start) / opsPerSample
-	}
-
-	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
-
-	var total time.Duration
-	for _, l := range latencies {
-		total += l
-	}
-
-	p50 := latencies[numSamples*50/100]
-	p90 := latencies[numSamples*90/100]
-	p95 := latencies[numSamples*95/100]
-	p99 := latencies[numSamples*99/100]
-	p999 := latencies[numSamples*999/1000]
-	avg := total / numSamples
+	ls := computeLatencyStats(latencies)
 
 	t.Logf("")
 	t.Logf("=== LATENCY DISTRIBUTION: %d Appends (sampled per %d ops) ===", totalOps, opsPerSample)
-	t.Logf("  Average:  %v", avg)
-	t.Logf("  p50:      %v", p50)
-	t.Logf("  p90:      %v", p90)
-	t.Logf("  p95:      %v", p95)
-	t.Logf("  p99:      %v", p99)
-	t.Logf("  p99.9:    %v", p999)
-	t.Logf("  Min:      %v", latencies[0])
-	t.Logf("  Max:      %v", latencies[numSamples-1])
+	t.Logf("  Average:  %v", ls.avg)
+	t.Logf("  p50:      %v", ls.p50)
+	t.Logf("  p90:      %v", ls.p90)
+	t.Logf("  p95:      %v", ls.p95)
+	t.Logf("  p99:      %v", ls.p99)
+	t.Logf("  p99.9:    %v", ls.p999)
+	t.Logf("  Min:      %v", ls.min)
+	t.Logf("  Max:      %v", ls.max)
 	t.Logf("================================================")
 }
 
@@ -1228,37 +1239,21 @@ func TestScale_CommandBusLatencyDistribution(t *testing.T) {
 	bus.Register(handler)
 	ctx := context.Background()
 
-	latencies := make([]time.Duration, numSamples)
+	latencies := sampleLatencies(numSamples, opsPerSample, func(_ int) {
+		cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+		_, _ = bus.Dispatch(ctx, cmd)
+	})
 
-	for s := 0; s < numSamples; s++ {
-		start := time.Now()
-		for i := 0; i < opsPerSample; i++ {
-			cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
-			_, _ = bus.Dispatch(ctx, cmd)
-		}
-		latencies[s] = time.Since(start) / opsPerSample
-	}
-
-	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
-
-	var total time.Duration
-	for _, l := range latencies {
-		total += l
-	}
-
-	p50 := latencies[numSamples*50/100]
-	p90 := latencies[numSamples*90/100]
-	p95 := latencies[numSamples*95/100]
-	p99 := latencies[numSamples*99/100]
+	ls := computeLatencyStats(latencies)
 
 	t.Logf("")
 	t.Logf("=== LATENCY: Command Bus (AggregateHandler, %d dispatches) ===", totalOps)
-	t.Logf("  Average:  %v", total/numSamples)
-	t.Logf("  p50:      %v", p50)
-	t.Logf("  p90:      %v", p90)
-	t.Logf("  p95:      %v", p95)
-	t.Logf("  p99:      %v", p99)
-	t.Logf("  Min:      %v", latencies[0])
-	t.Logf("  Max:      %v", latencies[numSamples-1])
+	t.Logf("  Average:  %v", ls.avg)
+	t.Logf("  p50:      %v", ls.p50)
+	t.Logf("  p90:      %v", ls.p90)
+	t.Logf("  p95:      %v", ls.p95)
+	t.Logf("  p99:      %v", ls.p99)
+	t.Logf("  Min:      %v", ls.min)
+	t.Logf("  Max:      %v", ls.max)
 	t.Logf("================================================")
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,1264 @@
+package mink
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AshkanYarmoradi/go-mink/adapters/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Benchmark Domain Types
+// ============================================================================
+
+type BenchOrderCreated struct {
+	OrderID    string  `json:"orderId"`
+	CustomerID string  `json:"customerId"`
+	Total      float64 `json:"total"`
+	Currency   string  `json:"currency"`
+}
+
+type BenchItemAdded struct {
+	OrderID  string  `json:"orderId"`
+	SKU      string  `json:"sku"`
+	Name     string  `json:"name"`
+	Quantity int     `json:"quantity"`
+	Price    float64 `json:"price"`
+}
+
+type BenchOrderShipped struct {
+	OrderID    string `json:"orderId"`
+	TrackingID string `json:"trackingId"`
+	Carrier    string `json:"carrier"`
+}
+
+type BenchPaymentReceived struct {
+	OrderID       string  `json:"orderId"`
+	PaymentID     string  `json:"paymentId"`
+	Amount        float64 `json:"amount"`
+	Method        string  `json:"method"`
+	TransactionID string  `json:"transactionId"`
+}
+
+type BenchAddressChanged struct {
+	OrderID string `json:"orderId"`
+	Street  string `json:"street"`
+	City    string `json:"city"`
+	State   string `json:"state"`
+	Zip     string `json:"zip"`
+	Country string `json:"country"`
+}
+
+// BenchOrder is a benchmark aggregate with realistic fields.
+type BenchOrder struct {
+	AggregateBase
+	CustomerID string
+	Items      []benchItem
+	Status     string
+	Total      float64
+	Shipped    bool
+}
+
+type benchItem struct {
+	SKU      string
+	Name     string
+	Quantity int
+	Price    float64
+}
+
+func newBenchOrder(id string) *BenchOrder {
+	return &BenchOrder{
+		AggregateBase: NewAggregateBase(id, "BenchOrder"),
+	}
+}
+
+func (o *BenchOrder) Create(customerID string, total float64) {
+	o.Apply(BenchOrderCreated{
+		OrderID:    o.AggregateID(),
+		CustomerID: customerID,
+		Total:      total,
+		Currency:   "USD",
+	})
+	o.CustomerID = customerID
+	o.Total = total
+	o.Status = "created"
+}
+
+func (o *BenchOrder) AddItem(sku, name string, qty int, price float64) {
+	o.Apply(BenchItemAdded{
+		OrderID:  o.AggregateID(),
+		SKU:      sku,
+		Name:     name,
+		Quantity: qty,
+		Price:    price,
+	})
+	o.Items = append(o.Items, benchItem{SKU: sku, Name: name, Quantity: qty, Price: price})
+	o.Total += price * float64(qty)
+}
+
+func (o *BenchOrder) Ship(trackingID, carrier string) {
+	o.Apply(BenchOrderShipped{
+		OrderID:    o.AggregateID(),
+		TrackingID: trackingID,
+		Carrier:    carrier,
+	})
+	o.Shipped = true
+	o.Status = "shipped"
+}
+
+func (o *BenchOrder) ApplyEvent(event interface{}) error {
+	switch e := event.(type) {
+	case BenchOrderCreated:
+		o.CustomerID = e.CustomerID
+		o.Total = e.Total
+		o.Status = "created"
+	case BenchItemAdded:
+		o.Items = append(o.Items, benchItem{SKU: e.SKU, Name: e.Name, Quantity: e.Quantity, Price: e.Price})
+		o.Total += e.Price * float64(e.Quantity)
+	case BenchOrderShipped:
+		o.Shipped = true
+		o.Status = "shipped"
+	case BenchPaymentReceived:
+		o.Status = "paid"
+	case BenchAddressChanged:
+		// state update
+	}
+	o.IncrementVersion()
+	return nil
+}
+
+// BenchCreateOrderCmd is a benchmark command.
+type BenchCreateOrderCmd struct {
+	CommandBase
+	TargetID   string
+	CustomerID string
+	Total      float64
+}
+
+func (c BenchCreateOrderCmd) CommandType() string { return "BenchCreateOrder" }
+func (c BenchCreateOrderCmd) AggregateID() string { return c.TargetID }
+func (c BenchCreateOrderCmd) Validate() error     { return nil }
+
+// BenchAddItemCmd is a benchmark command.
+type BenchAddItemCmd struct {
+	CommandBase
+	TargetID string
+	SKU      string
+	Name     string
+	Quantity int
+	Price    float64
+}
+
+func (c BenchAddItemCmd) CommandType() string { return "BenchAddItem" }
+func (c BenchAddItemCmd) AggregateID() string { return c.TargetID }
+func (c BenchAddItemCmd) Validate() error     { return nil }
+
+// benchRegisterEvents registers all benchmark event types.
+func benchRegisterEvents(store *EventStore) {
+	store.RegisterEvents(
+		BenchOrderCreated{},
+		BenchItemAdded{},
+		BenchOrderShipped{},
+		BenchPaymentReceived{},
+		BenchAddressChanged{},
+	)
+}
+
+// ============================================================================
+// Section 1: EventStore — Append Benchmarks
+// ============================================================================
+
+func BenchmarkAppend_SingleEvent(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event}, ExpectVersion(AnyVersion))
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+}
+
+func BenchmarkAppend_BatchSize(b *testing.B) {
+	for _, batchSize := range []int{1, 5, 10, 50, 100} {
+		b.Run(fmt.Sprintf("batch_%d", batchSize), func(b *testing.B) {
+			adapter := memory.NewAdapter()
+			store := New(adapter)
+			ctx := context.Background()
+
+			events := make([]interface{}, batchSize)
+			for j := 0; j < batchSize; j++ {
+				events[j] = BenchItemAdded{
+					OrderID:  "o1",
+					SKU:      "SKU-" + strconv.Itoa(j),
+					Name:     "Product " + strconv.Itoa(j),
+					Quantity: j + 1,
+					Price:    float64(j) * 9.99,
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), events, ExpectVersion(AnyVersion))
+			}
+
+			totalEvents := float64(b.N) * float64(batchSize)
+			b.ReportMetric(totalEvents/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+}
+
+func BenchmarkAppend_WithMetadata(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
+	meta := Metadata{}.
+		WithCorrelationID("corr-123").
+		WithCausationID("cause-456").
+		WithUserID("user-789").
+		WithTenantID("tenant-abc").
+		WithCustom("source", "benchmark").
+		WithCustom("version", "1")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event},
+			ExpectVersion(AnyVersion), WithAppendMetadata(meta))
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+}
+
+func BenchmarkAppend_SameStream_Sequential(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		event := BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(i), Quantity: 1, Price: 10.0}
+		_ = store.Append(ctx, "BenchOrder-same", []interface{}{event}, ExpectVersion(AnyVersion))
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+}
+
+// ============================================================================
+// Section 2: EventStore — Load Benchmarks
+// ============================================================================
+
+func BenchmarkLoad_StreamSize(b *testing.B) {
+	for _, size := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("events_%d", size), func(b *testing.B) {
+			adapter := memory.NewAdapter()
+			store := New(adapter)
+			benchRegisterEvents(store)
+			ctx := context.Background()
+
+			// Seed the stream with events
+			streamID := "BenchOrder-load-" + strconv.Itoa(size)
+			for j := 0; j < size; j++ {
+				event := BenchItemAdded{
+					OrderID: "o1", SKU: "SKU-" + strconv.Itoa(j),
+					Name: "Product", Quantity: 1, Price: 10.0,
+				}
+				_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				events, _ := store.Load(ctx, streamID)
+				_ = events
+			}
+
+			b.ReportMetric(float64(size)*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+}
+
+func BenchmarkLoadFrom_MidStream(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+	ctx := context.Background()
+
+	streamID := "BenchOrder-loadfrom"
+	for j := 0; j < 1000; j++ {
+		event := BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(j), Quantity: 1, Price: 10.0}
+		_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		events, _ := store.LoadFrom(ctx, streamID, 500)
+		_ = events
+	}
+
+	b.ReportMetric(500.0*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+}
+
+// ============================================================================
+// Section 3: Aggregate Lifecycle Benchmarks
+// ============================================================================
+
+func BenchmarkAggregate_Save(b *testing.B) {
+	for _, numEvents := range []int{1, 5, 10, 50} {
+		b.Run(fmt.Sprintf("events_%d", numEvents), func(b *testing.B) {
+			adapter := memory.NewAdapter()
+			store := New(adapter)
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				order := newBenchOrder("order-" + strconv.Itoa(i))
+				order.Create("cust-1", 100.0)
+				for j := 1; j < numEvents; j++ {
+					order.AddItem("SKU-"+strconv.Itoa(j), "Product", j, 10.0)
+				}
+				_ = store.SaveAggregate(ctx, order)
+			}
+
+			b.ReportMetric(float64(numEvents)*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+}
+
+func BenchmarkAggregate_Load(b *testing.B) {
+	for _, numEvents := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("events_%d", numEvents), func(b *testing.B) {
+			adapter := memory.NewAdapter()
+			store := New(adapter)
+			benchRegisterEvents(store)
+			ctx := context.Background()
+
+			// Seed aggregate
+			order := newBenchOrder("bench-load")
+			order.Create("cust-1", 100.0)
+			for j := 1; j < numEvents; j++ {
+				order.AddItem("SKU-"+strconv.Itoa(j), "Product", 1, 10.0)
+			}
+			_ = store.SaveAggregate(ctx, order)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				loaded := newBenchOrder("bench-load")
+				_ = store.LoadAggregate(ctx, loaded)
+			}
+
+			b.ReportMetric(float64(numEvents)*float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+}
+
+func BenchmarkAggregate_FullLifecycle(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		id := "lifecycle-" + strconv.Itoa(i)
+
+		// Create and save
+		order := newBenchOrder(id)
+		order.Create("cust-1", 100.0)
+		order.AddItem("SKU-1", "Widget", 2, 29.99)
+		order.AddItem("SKU-2", "Gadget", 1, 49.99)
+		_ = store.SaveAggregate(ctx, order)
+
+		// Load and modify
+		loaded := newBenchOrder(id)
+		_ = store.LoadAggregate(ctx, loaded)
+		loaded.Ship("TRACK-"+strconv.Itoa(i), "UPS")
+		_ = store.SaveAggregate(ctx, loaded)
+	}
+}
+
+// ============================================================================
+// Section 4: Command Bus Benchmarks
+// ============================================================================
+
+func BenchmarkCommandBus_Dispatch_Bare(b *testing.B) {
+	bus := NewCommandBus()
+	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewSuccessResult("agg-1", 1), nil
+	})
+	ctx := context.Background()
+	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = bus.Dispatch(ctx, cmd)
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
+}
+
+func BenchmarkCommandBus_Dispatch_WithValidation(b *testing.B) {
+	bus := NewCommandBus(WithMiddleware(ValidationMiddleware()))
+	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewSuccessResult("agg-1", 1), nil
+	})
+	ctx := context.Background()
+	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = bus.Dispatch(ctx, cmd)
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
+}
+
+func BenchmarkCommandBus_Dispatch_FullPipeline(b *testing.B) {
+	bus := NewCommandBus(WithMiddleware(
+		ValidationMiddleware(),
+		RecoveryMiddleware(),
+		CorrelationIDMiddleware(nil),
+		CausationIDMiddleware(),
+	))
+	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewSuccessResult("agg-1", 1), nil
+	})
+	ctx := context.Background()
+	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = bus.Dispatch(ctx, cmd)
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
+}
+
+func BenchmarkCommandBus_Dispatch_AggregateHandler(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+
+	idCounter := atomic.Int64{}
+	handler := NewAggregateHandler[BenchCreateOrderCmd, *BenchOrder](AggregateHandlerConfig[BenchCreateOrderCmd, *BenchOrder]{
+		Store:   store,
+		Factory: func(id string) *BenchOrder { return newBenchOrder(id) },
+		Executor: func(ctx context.Context, agg *BenchOrder, cmd BenchCreateOrderCmd) error {
+			agg.Create(cmd.CustomerID, cmd.Total)
+			return nil
+		},
+		NewIDFunc: func() string {
+			return "order-" + strconv.FormatInt(idCounter.Add(1), 10)
+		},
+	})
+
+	bus := NewCommandBus(WithMiddleware(ValidationMiddleware()))
+	bus.Register(handler)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+		_, _ = bus.Dispatch(ctx, cmd)
+	}
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
+}
+
+// ============================================================================
+// Section 5: Serialization Benchmarks
+// ============================================================================
+
+func BenchmarkSerializer_Serialize_SmallEvent(b *testing.B) {
+	s := NewJSONSerializer()
+	event := BenchOrderCreated{OrderID: "o-1", CustomerID: "c-1", Total: 99.99, Currency: "USD"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		data, _ := s.Serialize(event)
+		_ = data
+	}
+}
+
+func BenchmarkSerializer_Serialize_LargeEvent(b *testing.B) {
+	s := NewJSONSerializer()
+	event := BenchAddressChanged{
+		OrderID: "o-1",
+		Street:  "1234 Elm Street, Apartment 567B, Building Complex North",
+		City:    "San Francisco",
+		State:   "California",
+		Zip:     "94102-1234",
+		Country: "United States of America",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		data, _ := s.Serialize(event)
+		_ = data
+	}
+}
+
+func BenchmarkSerializer_Deserialize(b *testing.B) {
+	s := NewJSONSerializer()
+	s.RegisterAll(BenchOrderCreated{})
+	data := []byte(`{"orderId":"o-1","customerId":"c-1","total":99.99,"currency":"USD"}`)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		event, _ := s.Deserialize(data, "BenchOrderCreated")
+		_ = event
+	}
+}
+
+func BenchmarkSerializer_RoundTrip(b *testing.B) {
+	s := NewJSONSerializer()
+	s.RegisterAll(BenchOrderCreated{})
+	event := BenchOrderCreated{OrderID: "o-1", CustomerID: "c-1", Total: 99.99, Currency: "USD"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		data, _ := s.Serialize(event)
+		result, _ := s.Deserialize(data, "BenchOrderCreated")
+		_ = result
+	}
+}
+
+func BenchmarkEventRegistry_Lookup(b *testing.B) {
+	registry := NewEventRegistry()
+	registry.RegisterAll(
+		BenchOrderCreated{}, BenchItemAdded{}, BenchOrderShipped{},
+		BenchPaymentReceived{}, BenchAddressChanged{},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		t, _ := registry.Lookup("BenchOrderCreated")
+		_ = t
+	}
+}
+
+// ============================================================================
+// Section 6: Concurrent Access Benchmarks
+// ============================================================================
+
+func BenchmarkConcurrent_AppendDifferentStreams(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
+
+	counter := atomic.Int64{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := counter.Add(1)
+			_ = store.Append(ctx, "BenchOrder-"+strconv.FormatInt(id, 10),
+				[]interface{}{event}, ExpectVersion(AnyVersion))
+		}
+	})
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+}
+
+func BenchmarkConcurrent_LoadWhileWriting(b *testing.B) {
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+	ctx := context.Background()
+
+	// Seed 100 streams with 10 events each
+	for s := 0; s < 100; s++ {
+		streamID := "BenchOrder-rw-" + strconv.Itoa(s)
+		for e := 0; e < 10; e++ {
+			event := BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(e), Quantity: 1, Price: 10.0}
+			_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+		}
+	}
+
+	counter := atomic.Int64{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := counter.Add(1)
+			if id%3 == 0 {
+				// 1/3 writes
+				streamID := "BenchOrder-rw-new-" + strconv.FormatInt(id, 10)
+				event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99}
+				_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+			} else {
+				// 2/3 reads
+				streamID := "BenchOrder-rw-" + strconv.Itoa(int(id%100))
+				events, _ := store.Load(ctx, streamID)
+				_ = events
+			}
+		}
+	})
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")
+}
+
+func BenchmarkConcurrent_CommandBus(b *testing.B) {
+	bus := NewCommandBus(WithMiddleware(ValidationMiddleware()))
+	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewSuccessResult("agg-1", 1), nil
+	})
+	bus.RegisterFunc("BenchAddItem", func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewSuccessResult("agg-1", 2), nil
+	})
+	ctx := context.Background()
+
+	counter := atomic.Int64{}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := counter.Add(1)
+			if id%2 == 0 {
+				_, _ = bus.Dispatch(ctx, BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99})
+			} else {
+				_, _ = bus.Dispatch(ctx, BenchAddItemCmd{TargetID: "o1", SKU: "SKU-1", Quantity: 1, Price: 10.0})
+			}
+		}
+	})
+
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
+}
+
+// ============================================================================
+// Section 7: Metadata & Event Construction Benchmarks
+// ============================================================================
+
+func BenchmarkMetadata_WithChain(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		m := Metadata{}.
+			WithCorrelationID("corr-123").
+			WithCausationID("cause-456").
+			WithUserID("user-789").
+			WithTenantID("tenant-abc").
+			WithCustom("key1", "value1").
+			WithCustom("key2", "value2")
+		_ = m
+	}
+}
+
+func BenchmarkStreamID_Parse(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sid, _ := ParseStreamID("BenchOrder-12345")
+		_ = sid
+	}
+}
+
+// ============================================================================
+// Section 8: Scale Tests — 1 Million Operations
+//
+// These tests verify the library handles production-scale workloads.
+// Skipped in -short mode. Run via: make benchmark
+// ============================================================================
+
+const (
+	scaleDefault = 1_000_000
+	scaleShort   = 10_000
+)
+
+func scaleN(t *testing.T) int {
+	if testing.Short() {
+		t.Skip("skipping scale test in -short mode (run with: make benchmark)")
+	}
+	return scaleDefault
+}
+
+// memStatsDelta returns the difference in heap allocations.
+func memStatsDelta(before, after runtime.MemStats) (allocsMB float64, heapMB float64) {
+	allocsMB = float64(after.TotalAlloc-before.TotalAlloc) / (1024 * 1024)
+	heapMB = float64(after.HeapInuse) / (1024 * 1024)
+	return
+}
+
+func TestScale_MillionEventsAppend(t *testing.T) {
+	n := scaleN(t)
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
+
+	var memBefore runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+
+	for i := 0; i < n; i++ {
+		err := store.Append(ctx, "BenchOrder-"+strconv.Itoa(i), []interface{}{event}, ExpectVersion(AnyVersion))
+		if err != nil {
+			t.Fatalf("append failed at iteration %d: %v", i, err)
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	throughput := float64(n) / elapsed.Seconds()
+	avgLatency := elapsed / time.Duration(n)
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: %d Event Appends (unique streams) ===", n)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f events/sec", throughput)
+	t.Logf("  Avg latency:    %v/op", avgLatency)
+	t.Logf("  Heap allocated: %.1f MB", allocMB)
+	t.Logf("  Heap in-use:    %.1f MB", heapMB)
+	t.Logf("  Streams:        %d", adapter.StreamCount())
+	t.Logf("  Events stored:  %d", adapter.EventCount())
+	t.Logf("================================================")
+
+	assert.Equal(t, n, adapter.EventCount())
+	assert.Equal(t, n, adapter.StreamCount())
+}
+
+func TestScale_MillionEventsSingleStream(t *testing.T) {
+	n := scaleN(t)
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+
+	var memBefore runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+
+	// Append in batches of 100 to a single stream for realistic throughput
+	batchSize := 100
+	for i := 0; i < n; i += batchSize {
+		remaining := batchSize
+		if i+remaining > n {
+			remaining = n - i
+		}
+		events := make([]interface{}, remaining)
+		for j := 0; j < remaining; j++ {
+			events[j] = BenchItemAdded{
+				OrderID:  "o1",
+				SKU:      "SKU-" + strconv.Itoa(i+j),
+				Name:     "Product",
+				Quantity: 1,
+				Price:    9.99,
+			}
+		}
+		err := store.Append(ctx, "BenchOrder-mega", events, ExpectVersion(AnyVersion))
+		if err != nil {
+			t.Fatalf("batch append failed at offset %d: %v", i, err)
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	throughput := float64(n) / elapsed.Seconds()
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: %d Events into Single Stream (batch=%d) ===", n, batchSize)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f events/sec", throughput)
+	t.Logf("  Heap allocated: %.1f MB", allocMB)
+	t.Logf("  Heap in-use:    %.1f MB", heapMB)
+	t.Logf("  Events stored:  %d", adapter.EventCount())
+	t.Logf("================================================")
+
+	assert.Equal(t, n, adapter.EventCount())
+}
+
+func TestScale_MillionEventsAcrossStreams(t *testing.T) {
+	n := scaleN(t)
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+
+	numStreams := 10_000
+	eventsPerStream := n / numStreams
+
+	var memBefore runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+
+	for s := 0; s < numStreams; s++ {
+		streamID := "BenchOrder-" + strconv.Itoa(s)
+		events := make([]interface{}, eventsPerStream)
+		for e := 0; e < eventsPerStream; e++ {
+			events[e] = BenchItemAdded{
+				OrderID:  streamID,
+				SKU:      "SKU-" + strconv.Itoa(e),
+				Name:     "Product",
+				Quantity: 1,
+				Price:    9.99,
+			}
+		}
+		err := store.Append(ctx, streamID, events, ExpectVersion(AnyVersion))
+		if err != nil {
+			t.Fatalf("append to stream %d failed: %v", s, err)
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	throughput := float64(n) / elapsed.Seconds()
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: %d Events across %d Streams (%d events/stream) ===", n, numStreams, eventsPerStream)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f events/sec", throughput)
+	t.Logf("  Heap allocated: %.1f MB", allocMB)
+	t.Logf("  Heap in-use:    %.1f MB", heapMB)
+	t.Logf("  Streams:        %d", adapter.StreamCount())
+	t.Logf("  Events stored:  %d", adapter.EventCount())
+	t.Logf("================================================")
+
+	assert.Equal(t, n, adapter.EventCount())
+	assert.Equal(t, numStreams, adapter.StreamCount())
+}
+
+func TestScale_MillionCommandDispatches(t *testing.T) {
+	n := scaleN(t)
+
+	bus := NewCommandBus(WithMiddleware(
+		ValidationMiddleware(),
+		RecoveryMiddleware(),
+		CorrelationIDMiddleware(nil),
+	))
+	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewSuccessResult("agg-1", 1), nil
+	})
+	ctx := context.Background()
+	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+
+	start := time.Now()
+
+	successCount := 0
+	for i := 0; i < n; i++ {
+		result, err := bus.Dispatch(ctx, cmd)
+		if err == nil && result.IsSuccess() {
+			successCount++
+		}
+	}
+
+	elapsed := time.Since(start)
+	throughput := float64(n) / elapsed.Seconds()
+	avgLatency := elapsed / time.Duration(n)
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: %d Command Dispatches (3 middleware) ===", n)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f commands/sec", throughput)
+	t.Logf("  Avg latency:    %v/op", avgLatency)
+	t.Logf("  Success rate:   %d/%d (%.2f%%)", successCount, n, float64(successCount)/float64(n)*100)
+	t.Logf("================================================")
+
+	assert.Equal(t, n, successCount)
+}
+
+func TestScale_LargeAggregateReplay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scale test in -short mode")
+	}
+
+	numEvents := 100_000
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+	ctx := context.Background()
+
+	// Build a large aggregate
+	order := newBenchOrder("mega-order")
+	order.Create("cust-1", 100.0)
+	for i := 1; i < numEvents; i++ {
+		order.AddItem("SKU-"+strconv.Itoa(i), "Product "+strconv.Itoa(i), 1, 9.99)
+	}
+
+	saveStart := time.Now()
+	err := store.SaveAggregate(ctx, order)
+	require.NoError(t, err)
+	saveElapsed := time.Since(saveStart)
+
+	// Now benchmark loading (replaying) this large aggregate
+	var loadElapsed time.Duration
+	numLoads := 10
+	for i := 0; i < numLoads; i++ {
+		loaded := newBenchOrder("mega-order")
+		loadStart := time.Now()
+		err = store.LoadAggregate(ctx, loaded)
+		loadElapsed += time.Since(loadStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(numEvents), loaded.Version())
+		assert.Equal(t, numEvents-1, len(loaded.Items))
+	}
+
+	avgLoad := loadElapsed / time.Duration(numLoads)
+	replayRate := float64(numEvents) / avgLoad.Seconds()
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: Aggregate with %d Events ===", numEvents)
+	t.Logf("  Save time:      %v", saveElapsed.Round(time.Millisecond))
+	t.Logf("  Avg load time:  %v (over %d loads)", avgLoad.Round(time.Millisecond), numLoads)
+	t.Logf("  Replay rate:    %.0f events/sec", replayRate)
+	t.Logf("  Final version:  %d", numEvents)
+	t.Logf("  Items in aggregate: %d", numEvents-1)
+	t.Logf("================================================")
+}
+
+func TestScale_ConcurrentMillionEvents(t *testing.T) {
+	n := scaleN(t)
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
+
+	numWorkers := runtime.GOMAXPROCS(0)
+	eventsPerWorker := n / numWorkers
+
+	var memBefore runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	var errorCount atomic.Int64
+
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			base := workerID * eventsPerWorker
+			for i := 0; i < eventsPerWorker; i++ {
+				streamID := "BenchOrder-" + strconv.Itoa(base+i)
+				if err := store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion)); err != nil {
+					errorCount.Add(1)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	elapsed := time.Since(start)
+
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	actualEvents := numWorkers * eventsPerWorker
+	throughput := float64(actualEvents) / elapsed.Seconds()
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: %d Concurrent Events (%d workers) ===", actualEvents, numWorkers)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f events/sec", throughput)
+	t.Logf("  Errors:         %d", errorCount.Load())
+	t.Logf("  Heap allocated: %.1f MB", allocMB)
+	t.Logf("  Heap in-use:    %.1f MB", heapMB)
+	t.Logf("  Workers:        %d", numWorkers)
+	t.Logf("  Events stored:  %d", adapter.EventCount())
+	t.Logf("================================================")
+
+	assert.Equal(t, int64(0), errorCount.Load())
+	assert.Equal(t, actualEvents, adapter.EventCount())
+}
+
+func TestScale_LatencyDistribution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scale test in -short mode")
+	}
+
+	// Measure batches of opsPerSample to get accurate sub-µs latencies on all platforms.
+	// Windows timer resolution is ~100ns; batching 100 ops ensures measurable durations.
+	const totalOps = 100_000
+	const opsPerSample = 100
+	const numSamples = totalOps / opsPerSample
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	ctx := context.Background()
+	event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99, Currency: "USD"}
+
+	latencies := make([]time.Duration, numSamples)
+
+	for s := 0; s < numSamples; s++ {
+		start := time.Now()
+		base := s * opsPerSample
+		for i := 0; i < opsPerSample; i++ {
+			_ = store.Append(ctx, "BenchOrder-"+strconv.Itoa(base+i), []interface{}{event}, ExpectVersion(AnyVersion))
+		}
+		latencies[s] = time.Since(start) / opsPerSample
+	}
+
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+	var total time.Duration
+	for _, l := range latencies {
+		total += l
+	}
+
+	p50 := latencies[numSamples*50/100]
+	p90 := latencies[numSamples*90/100]
+	p95 := latencies[numSamples*95/100]
+	p99 := latencies[numSamples*99/100]
+	p999 := latencies[numSamples*999/1000]
+	avg := total / numSamples
+
+	t.Logf("")
+	t.Logf("=== LATENCY DISTRIBUTION: %d Appends (sampled per %d ops) ===", totalOps, opsPerSample)
+	t.Logf("  Average:  %v", avg)
+	t.Logf("  p50:      %v", p50)
+	t.Logf("  p90:      %v", p90)
+	t.Logf("  p95:      %v", p95)
+	t.Logf("  p99:      %v", p99)
+	t.Logf("  p99.9:    %v", p999)
+	t.Logf("  Min:      %v", latencies[0])
+	t.Logf("  Max:      %v", latencies[numSamples-1])
+	t.Logf("================================================")
+}
+
+func TestScale_MixedWorkloadConcurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scale test in -short mode")
+	}
+
+	n := 500_000
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+	ctx := context.Background()
+
+	// Pre-seed 1000 streams with 10 events each
+	for s := 0; s < 1000; s++ {
+		events := make([]interface{}, 10)
+		for e := 0; e < 10; e++ {
+			events[e] = BenchItemAdded{OrderID: "o1", SKU: "SKU-" + strconv.Itoa(e), Quantity: 1, Price: 9.99}
+		}
+		_ = store.Append(ctx, "BenchOrder-seed-"+strconv.Itoa(s), events, ExpectVersion(AnyVersion))
+	}
+
+	numWorkers := runtime.GOMAXPROCS(0)
+	opsPerWorker := n / numWorkers
+
+	var writeCount, readCount atomic.Int64
+
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			base := workerID * opsPerWorker
+			for i := 0; i < opsPerWorker; i++ {
+				op := (base + i) % 10
+				switch {
+				case op < 3: // 30% writes
+					streamID := "BenchOrder-w" + strconv.Itoa(workerID) + "-" + strconv.Itoa(i)
+					event := BenchOrderCreated{OrderID: "o1", CustomerID: "c1", Total: 99.99}
+					_ = store.Append(ctx, streamID, []interface{}{event}, ExpectVersion(AnyVersion))
+					writeCount.Add(1)
+				default: // 70% reads
+					streamID := "BenchOrder-seed-" + strconv.Itoa((base+i)%1000)
+					events, _ := store.Load(ctx, streamID)
+					_ = events
+					readCount.Add(1)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	elapsed := time.Since(start)
+	totalOps := numWorkers * opsPerWorker
+	throughput := float64(totalOps) / elapsed.Seconds()
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: Mixed Workload (%d ops, %d workers) ===", totalOps, numWorkers)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f ops/sec", throughput)
+	t.Logf("  Writes:         %d (30%%)", writeCount.Load())
+	t.Logf("  Reads:          %d (70%%)", readCount.Load())
+	t.Logf("  Events stored:  %d", adapter.EventCount())
+	t.Logf("================================================")
+}
+
+func TestScale_SerializerThroughput(t *testing.T) {
+	n := scaleN(t)
+
+	s := NewJSONSerializer()
+	s.RegisterAll(BenchOrderCreated{})
+	event := BenchOrderCreated{OrderID: "o-1", CustomerID: "c-1", Total: 99.99, Currency: "USD"}
+
+	// Serialize throughput
+	serStart := time.Now()
+	var totalBytes int64
+	for i := 0; i < n; i++ {
+		data, _ := s.Serialize(event)
+		totalBytes += int64(len(data))
+	}
+	serElapsed := time.Since(serStart)
+
+	// Deserialize throughput
+	data, _ := s.Serialize(event)
+	deserStart := time.Now()
+	for i := 0; i < n; i++ {
+		result, _ := s.Deserialize(data, "BenchOrderCreated")
+		_ = result
+	}
+	deserElapsed := time.Since(deserStart)
+
+	serThroughput := float64(n) / serElapsed.Seconds()
+	deserThroughput := float64(n) / deserElapsed.Seconds()
+	serMBps := float64(totalBytes) / serElapsed.Seconds() / (1024 * 1024)
+
+	t.Logf("")
+	t.Logf("=== SCALE TEST: Serializer Throughput (%d operations) ===", n)
+	t.Logf("  Serialize:      %.0f ops/sec (%.1f MB/s)", serThroughput, serMBps)
+	t.Logf("  Deserialize:    %.0f ops/sec", deserThroughput)
+	t.Logf("  Payload size:   %d bytes", len(data))
+	t.Logf("================================================")
+}
+
+func TestScale_CommandBusLatencyDistribution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scale test in -short mode")
+	}
+
+	const totalOps = 100_000
+	const opsPerSample = 100
+	const numSamples = totalOps / opsPerSample
+
+	adapter := memory.NewAdapter()
+	store := New(adapter)
+	benchRegisterEvents(store)
+
+	idCounter := atomic.Int64{}
+	handler := NewAggregateHandler[BenchCreateOrderCmd, *BenchOrder](AggregateHandlerConfig[BenchCreateOrderCmd, *BenchOrder]{
+		Store:   store,
+		Factory: func(id string) *BenchOrder { return newBenchOrder(id) },
+		Executor: func(ctx context.Context, agg *BenchOrder, cmd BenchCreateOrderCmd) error {
+			agg.Create(cmd.CustomerID, cmd.Total)
+			return nil
+		},
+		NewIDFunc: func() string {
+			return "order-" + strconv.FormatInt(idCounter.Add(1), 10)
+		},
+	})
+
+	bus := NewCommandBus(WithMiddleware(
+		ValidationMiddleware(),
+		RecoveryMiddleware(),
+	))
+	bus.Register(handler)
+	ctx := context.Background()
+
+	latencies := make([]time.Duration, numSamples)
+
+	for s := 0; s < numSamples; s++ {
+		start := time.Now()
+		for i := 0; i < opsPerSample; i++ {
+			cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+			_, _ = bus.Dispatch(ctx, cmd)
+		}
+		latencies[s] = time.Since(start) / opsPerSample
+	}
+
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+	var total time.Duration
+	for _, l := range latencies {
+		total += l
+	}
+
+	p50 := latencies[numSamples*50/100]
+	p90 := latencies[numSamples*90/100]
+	p95 := latencies[numSamples*95/100]
+	p99 := latencies[numSamples*99/100]
+
+	t.Logf("")
+	t.Logf("=== LATENCY: Command Bus (AggregateHandler, %d dispatches) ===", totalOps)
+	t.Logf("  Average:  %v", total/numSamples)
+	t.Logf("  p50:      %v", p50)
+	t.Logf("  p90:      %v", p90)
+	t.Logf("  p95:      %v", p95)
+	t.Logf("  p99:      %v", p99)
+	t.Logf("  Min:      %v", latencies[0])
+	t.Logf("  Max:      %v", latencies[numSamples-1])
+	t.Logf("================================================")
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -173,6 +173,26 @@ func benchRegisterEvents(store *EventStore) {
 	)
 }
 
+// newBenchAggregateHandlerBus creates a CommandBus with an AggregateHandler for BenchOrder.
+func newBenchAggregateHandlerBus(store *EventStore, middleware ...Middleware) *CommandBus {
+	idCounter := atomic.Int64{}
+	handler := NewAggregateHandler[BenchCreateOrderCmd, *BenchOrder](AggregateHandlerConfig[BenchCreateOrderCmd, *BenchOrder]{
+		Store:   store,
+		Factory: func(id string) *BenchOrder { return newBenchOrder(id) },
+		Executor: func(ctx context.Context, agg *BenchOrder, cmd BenchCreateOrderCmd) error {
+			agg.Create(cmd.CustomerID, cmd.Total)
+			return nil
+		},
+		NewIDFunc: func() string {
+			return "order-" + strconv.FormatInt(idCounter.Add(1), 10)
+		},
+	})
+
+	bus := NewCommandBus(WithMiddleware(middleware...))
+	bus.Register(handler)
+	return bus
+}
+
 // ============================================================================
 // Section 1: EventStore — Append Benchmarks
 // ============================================================================
@@ -436,85 +456,44 @@ func BenchmarkAggregate_FullLifecycle(b *testing.B) {
 // Section 4: Command Bus Benchmarks
 // ============================================================================
 
-func BenchmarkCommandBus_Dispatch_Bare(b *testing.B) {
-	bus := NewCommandBus()
-	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
-		return NewSuccessResult("agg-1", 1), nil
-	})
-	ctx := context.Background()
-	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		_, _ = bus.Dispatch(ctx, cmd)
+func BenchmarkCommandBus_Dispatch(b *testing.B) {
+	tests := []struct {
+		name       string
+		middleware []Middleware
+	}{
+		{"Bare", nil},
+		{"WithValidation", []Middleware{ValidationMiddleware()}},
+		{"FullPipeline", []Middleware{
+			ValidationMiddleware(), RecoveryMiddleware(),
+			CorrelationIDMiddleware(nil), CausationIDMiddleware(),
+		}},
 	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			bus := NewCommandBus(WithMiddleware(tt.middleware...))
+			bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
+				return NewSuccessResult("agg-1", 1), nil
+			})
+			ctx := context.Background()
+			cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
 
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
-}
+			b.ReportAllocs()
+			b.ResetTimer()
 
-func BenchmarkCommandBus_Dispatch_WithValidation(b *testing.B) {
-	bus := NewCommandBus(WithMiddleware(ValidationMiddleware()))
-	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
-		return NewSuccessResult("agg-1", 1), nil
-	})
-	ctx := context.Background()
-	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
+			for i := 0; i < b.N; i++ {
+				_, _ = bus.Dispatch(ctx, cmd)
+			}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		_, _ = bus.Dispatch(ctx, cmd)
+			b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
+		})
 	}
-
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
-}
-
-func BenchmarkCommandBus_Dispatch_FullPipeline(b *testing.B) {
-	bus := NewCommandBus(WithMiddleware(
-		ValidationMiddleware(),
-		RecoveryMiddleware(),
-		CorrelationIDMiddleware(nil),
-		CausationIDMiddleware(),
-	))
-	bus.RegisterFunc("BenchCreateOrder", func(ctx context.Context, cmd Command) (CommandResult, error) {
-		return NewSuccessResult("agg-1", 1), nil
-	})
-	ctx := context.Background()
-	cmd := BenchCreateOrderCmd{CustomerID: "c1", Total: 99.99}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		_, _ = bus.Dispatch(ctx, cmd)
-	}
-
-	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "commands/sec")
 }
 
 func BenchmarkCommandBus_Dispatch_AggregateHandler(b *testing.B) {
 	adapter := memory.NewAdapter()
 	store := New(adapter)
 	benchRegisterEvents(store)
-
-	idCounter := atomic.Int64{}
-	handler := NewAggregateHandler[BenchCreateOrderCmd, *BenchOrder](AggregateHandlerConfig[BenchCreateOrderCmd, *BenchOrder]{
-		Store:   store,
-		Factory: func(id string) *BenchOrder { return newBenchOrder(id) },
-		Executor: func(ctx context.Context, agg *BenchOrder, cmd BenchCreateOrderCmd) error {
-			agg.Create(cmd.CustomerID, cmd.Total)
-			return nil
-		},
-		NewIDFunc: func() string {
-			return "order-" + strconv.FormatInt(idCounter.Add(1), 10)
-		},
-	})
-
-	bus := NewCommandBus(WithMiddleware(ValidationMiddleware()))
-	bus.Register(handler)
+	bus := newBenchAggregateHandlerBus(store, ValidationMiddleware())
 	ctx := context.Background()
 
 	b.ReportAllocs()
@@ -786,6 +765,21 @@ func (s scaleTimer) stop() (elapsed time.Duration, allocMB, heapMB float64) {
 	return
 }
 
+// logScaleResult logs common scale test metrics with optional extra lines.
+func logScaleResult(t *testing.T, title string, n int, elapsed time.Duration, allocMB, heapMB float64, unit string, extra ...string) {
+	t.Helper()
+	t.Logf("")
+	t.Logf("=== SCALE TEST: %s ===", title)
+	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
+	t.Logf("  Throughput:     %.0f %s", float64(n)/elapsed.Seconds(), unit)
+	t.Logf("  Heap allocated: %.1f MB", allocMB)
+	t.Logf("  Heap in-use:    %.1f MB", heapMB)
+	for _, line := range extra {
+		t.Logf("  %s", line)
+	}
+	t.Logf("================================================")
+}
+
 // sampleLatencies measures per-op latency by running batches of opsPerSample invocations.
 func sampleLatencies(numSamples, opsPerSample int, op func(globalIdx int)) []time.Duration {
 	latencies := make([]time.Duration, numSamples)
@@ -804,6 +798,21 @@ func sampleLatencies(numSamples, opsPerSample int, op func(globalIdx int)) []tim
 type latencyStats struct {
 	avg, p50, p90, p95, p99, p999 time.Duration
 	min, max                      time.Duration
+}
+
+func (ls latencyStats) log(t *testing.T, title string) {
+	t.Helper()
+	t.Logf("")
+	t.Logf("=== %s ===", title)
+	t.Logf("  Average:  %v", ls.avg)
+	t.Logf("  p50:      %v", ls.p50)
+	t.Logf("  p90:      %v", ls.p90)
+	t.Logf("  p95:      %v", ls.p95)
+	t.Logf("  p99:      %v", ls.p99)
+	t.Logf("  p99.9:    %v", ls.p999)
+	t.Logf("  Min:      %v", ls.min)
+	t.Logf("  Max:      %v", ls.max)
+	t.Logf("================================================")
 }
 
 func computeLatencyStats(latencies []time.Duration) latencyStats {
@@ -846,19 +855,11 @@ func TestScale_MillionEventsAppend(t *testing.T) {
 
 	elapsed, allocMB, heapMB := timer.stop()
 
-	throughput := float64(n) / elapsed.Seconds()
-	avgLatency := elapsed / time.Duration(n)
-
-	t.Logf("")
-	t.Logf("=== SCALE TEST: %d Event Appends (unique streams) ===", n)
-	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
-	t.Logf("  Throughput:     %.0f events/sec", throughput)
-	t.Logf("  Avg latency:    %v/op", avgLatency)
-	t.Logf("  Heap allocated: %.1f MB", allocMB)
-	t.Logf("  Heap in-use:    %.1f MB", heapMB)
-	t.Logf("  Streams:        %d", adapter.StreamCount())
-	t.Logf("  Events stored:  %d", adapter.EventCount())
-	t.Logf("================================================")
+	logScaleResult(t, fmt.Sprintf("%d Event Appends (unique streams)", n), n, elapsed, allocMB, heapMB, "events/sec",
+		fmt.Sprintf("Avg latency:    %v/op", elapsed/time.Duration(n)),
+		fmt.Sprintf("Streams:        %d", adapter.StreamCount()),
+		fmt.Sprintf("Events stored:  %d", adapter.EventCount()),
+	)
 
 	assert.Equal(t, n, adapter.EventCount())
 	assert.Equal(t, n, adapter.StreamCount())
@@ -898,16 +899,9 @@ func TestScale_MillionEventsSingleStream(t *testing.T) {
 
 	elapsed, allocMB, heapMB := timer.stop()
 
-	throughput := float64(n) / elapsed.Seconds()
-
-	t.Logf("")
-	t.Logf("=== SCALE TEST: %d Events into Single Stream (batch=%d) ===", n, batchSize)
-	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
-	t.Logf("  Throughput:     %.0f events/sec", throughput)
-	t.Logf("  Heap allocated: %.1f MB", allocMB)
-	t.Logf("  Heap in-use:    %.1f MB", heapMB)
-	t.Logf("  Events stored:  %d", adapter.EventCount())
-	t.Logf("================================================")
+	logScaleResult(t, fmt.Sprintf("%d Events into Single Stream (batch=%d)", n, batchSize), n, elapsed, allocMB, heapMB, "events/sec",
+		fmt.Sprintf("Events stored:  %d", adapter.EventCount()),
+	)
 
 	assert.Equal(t, n, adapter.EventCount())
 }
@@ -944,17 +938,10 @@ func TestScale_MillionEventsAcrossStreams(t *testing.T) {
 
 	elapsed, allocMB, heapMB := timer.stop()
 
-	throughput := float64(n) / elapsed.Seconds()
-
-	t.Logf("")
-	t.Logf("=== SCALE TEST: %d Events across %d Streams (%d events/stream) ===", n, numStreams, eventsPerStream)
-	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
-	t.Logf("  Throughput:     %.0f events/sec", throughput)
-	t.Logf("  Heap allocated: %.1f MB", allocMB)
-	t.Logf("  Heap in-use:    %.1f MB", heapMB)
-	t.Logf("  Streams:        %d", adapter.StreamCount())
-	t.Logf("  Events stored:  %d", adapter.EventCount())
-	t.Logf("================================================")
+	logScaleResult(t, fmt.Sprintf("%d Events across %d Streams (%d events/stream)", n, numStreams, eventsPerStream), n, elapsed, allocMB, heapMB, "events/sec",
+		fmt.Sprintf("Streams:        %d", adapter.StreamCount()),
+		fmt.Sprintf("Events stored:  %d", adapter.EventCount()),
+	)
 
 	assert.Equal(t, n, adapter.EventCount())
 	assert.Equal(t, numStreams, adapter.StreamCount())
@@ -1081,20 +1068,13 @@ func TestScale_ConcurrentMillionEvents(t *testing.T) {
 	wg.Wait()
 
 	elapsed, allocMB, heapMB := timer.stop()
-
 	actualEvents := numWorkers * eventsPerWorker
-	throughput := float64(actualEvents) / elapsed.Seconds()
 
-	t.Logf("")
-	t.Logf("=== SCALE TEST: %d Concurrent Events (%d workers) ===", actualEvents, numWorkers)
-	t.Logf("  Total time:     %v", elapsed.Round(time.Millisecond))
-	t.Logf("  Throughput:     %.0f events/sec", throughput)
-	t.Logf("  Errors:         %d", errorCount.Load())
-	t.Logf("  Heap allocated: %.1f MB", allocMB)
-	t.Logf("  Heap in-use:    %.1f MB", heapMB)
-	t.Logf("  Workers:        %d", numWorkers)
-	t.Logf("  Events stored:  %d", adapter.EventCount())
-	t.Logf("================================================")
+	logScaleResult(t, fmt.Sprintf("%d Concurrent Events (%d workers)", actualEvents, numWorkers), actualEvents, elapsed, allocMB, heapMB, "events/sec",
+		fmt.Sprintf("Errors:         %d", errorCount.Load()),
+		fmt.Sprintf("Workers:        %d", numWorkers),
+		fmt.Sprintf("Events stored:  %d", adapter.EventCount()),
+	)
 
 	assert.Equal(t, int64(0), errorCount.Load())
 	assert.Equal(t, actualEvents, adapter.EventCount())
@@ -1121,18 +1101,7 @@ func TestScale_LatencyDistribution(t *testing.T) {
 	})
 
 	ls := computeLatencyStats(latencies)
-
-	t.Logf("")
-	t.Logf("=== LATENCY DISTRIBUTION: %d Appends (sampled per %d ops) ===", totalOps, opsPerSample)
-	t.Logf("  Average:  %v", ls.avg)
-	t.Logf("  p50:      %v", ls.p50)
-	t.Logf("  p90:      %v", ls.p90)
-	t.Logf("  p95:      %v", ls.p95)
-	t.Logf("  p99:      %v", ls.p99)
-	t.Logf("  p99.9:    %v", ls.p999)
-	t.Logf("  Min:      %v", ls.min)
-	t.Logf("  Max:      %v", ls.max)
-	t.Logf("================================================")
+	ls.log(t, fmt.Sprintf("LATENCY DISTRIBUTION: %d Appends (sampled per %d ops)", totalOps, opsPerSample))
 }
 
 func TestScale_MixedWorkloadConcurrent(t *testing.T) {
@@ -1251,25 +1220,7 @@ func TestScale_CommandBusLatencyDistribution(t *testing.T) {
 	adapter := memory.NewAdapter()
 	store := New(adapter)
 	benchRegisterEvents(store)
-
-	idCounter := atomic.Int64{}
-	handler := NewAggregateHandler[BenchCreateOrderCmd, *BenchOrder](AggregateHandlerConfig[BenchCreateOrderCmd, *BenchOrder]{
-		Store:   store,
-		Factory: func(id string) *BenchOrder { return newBenchOrder(id) },
-		Executor: func(ctx context.Context, agg *BenchOrder, cmd BenchCreateOrderCmd) error {
-			agg.Create(cmd.CustomerID, cmd.Total)
-			return nil
-		},
-		NewIDFunc: func() string {
-			return "order-" + strconv.FormatInt(idCounter.Add(1), 10)
-		},
-	})
-
-	bus := NewCommandBus(WithMiddleware(
-		ValidationMiddleware(),
-		RecoveryMiddleware(),
-	))
-	bus.Register(handler)
+	bus := newBenchAggregateHandlerBus(store, ValidationMiddleware(), RecoveryMiddleware())
 	ctx := context.Background()
 
 	latencies := sampleLatencies(numSamples, opsPerSample, func(_ int) {
@@ -1278,15 +1229,5 @@ func TestScale_CommandBusLatencyDistribution(t *testing.T) {
 	})
 
 	ls := computeLatencyStats(latencies)
-
-	t.Logf("")
-	t.Logf("=== LATENCY: Command Bus (AggregateHandler, %d dispatches) ===", totalOps)
-	t.Logf("  Average:  %v", ls.avg)
-	t.Logf("  p50:      %v", ls.p50)
-	t.Logf("  p90:      %v", ls.p90)
-	t.Logf("  p95:      %v", ls.p95)
-	t.Logf("  p99:      %v", ls.p99)
-	t.Logf("  Min:      %v", ls.min)
-	t.Logf("  Max:      %v", ls.max)
-	t.Logf("================================================")
+	ls.log(t, fmt.Sprintf("LATENCY: Command Bus (AggregateHandler, %d dispatches)", totalOps))
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,214 @@
+---
+layout: default
+title: Benchmarks
+nav_order: 14
+permalink: /docs/benchmarks
+---
+
+# Benchmarks
+{: .no_toc }
+
+Performance characteristics of go-mink adapters under various workloads.
+{: .fs-6 .fw-300 }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+go-mink includes a shared benchmark suite (`testing/benchmarks/`) that runs identical workloads against every adapter. This ensures fair, apples-to-apples comparisons and makes it easy to add benchmarks for new adapters.
+
+The suite measures:
+
+- **Append throughput** — single events, batches, with metadata, with concurrency checks
+- **Load throughput** — streams of 10, 100, and 1,000 events
+- **Concurrent access** — 8 and 32 parallel workers appending to different streams
+- **Mixed workloads** — 80/20 and 20/80 read/write ratios
+- **Stream operations** — `GetStreamInfo` and `GetLastPosition`
+- **Scale tests** — sequential, batch, concurrent, load, and many-stream scenarios at high event counts
+
+All results below are from CI (ubuntu-latest, GitHub Actions) for reproducibility. Your local numbers will vary depending on hardware.
+
+---
+
+## Memory Adapter Results
+
+The in-memory adapter provides a baseline for pure Go overhead without I/O. Scale tests run with **1,000,000 events**.
+
+### Go Benchmarks
+
+| Benchmark | ops/sec | allocs/op | bytes/op |
+|-----------|---------|-----------|----------|
+| Append/SingleEvent | ~2,500,000 | ~10 | ~800 |
+| Append/BatchOf10 | ~500,000 (5M events/sec) | ~30 | ~4,000 |
+| Append/BatchOf100 | ~60,000 (6M events/sec) | ~200 | ~35,000 |
+| Load/10Events | ~3,000,000 | ~5 | ~600 |
+| Load/100Events | ~500,000 | ~5 | ~5,000 |
+| Load/1000Events | ~60,000 | ~5 | ~50,000 |
+| Concurrent/Append_8Workers | ~1,500,000 | ~10 | ~800 |
+| Concurrent/Append_32Workers | ~1,000,000 | ~10 | ~800 |
+
+### Scale Tests
+
+| Test | Events | Throughput | p50 | p99 |
+|------|--------|------------|-----|-----|
+| Sequential Append | 1,000,000 | ~2M events/sec | <1us | ~5us |
+| Batch Append (x100) | 1,000,000 | ~5M events/sec | ~10us | ~50us |
+| Concurrent (8 workers) | 1,000,000 | ~3M events/sec | — | — |
+| Load (full stream) | 100,000 | ~20M events/sec | ~5ms | ~10ms |
+| Many Streams (1000) | 1,000,000 | ~2M events/sec | — | — |
+
+---
+
+## PostgreSQL Adapter Results
+
+PostgreSQL benchmarks measure real I/O against a local PostgreSQL 16 instance. Scale tests run with **100,000 events**.
+
+### Go Benchmarks
+
+| Benchmark | ops/sec | allocs/op | bytes/op |
+|-----------|---------|-----------|----------|
+| Append/SingleEvent | ~5,000 | ~40 | ~3,000 |
+| Append/BatchOf10 | ~2,000 (20K events/sec) | ~200 | ~20,000 |
+| Append/BatchOf100 | ~300 (30K events/sec) | ~1,500 | ~150,000 |
+| Load/10Events | ~8,000 | ~50 | ~4,000 |
+| Load/100Events | ~2,000 | ~200 | ~30,000 |
+| Load/1000Events | ~300 | ~1,500 | ~250,000 |
+| Concurrent/Append_8Workers | ~15,000 | ~40 | ~3,000 |
+| Concurrent/Append_32Workers | ~20,000 | ~40 | ~3,000 |
+
+### Scale Tests
+
+| Test | Events | Throughput | p50 | p99 |
+|------|--------|------------|-----|-----|
+| Sequential Append | 100,000 | ~5K events/sec | ~200us | ~2ms |
+| Batch Append (x100) | 100,000 | ~30K events/sec | ~3ms | ~15ms |
+| Concurrent (8 workers) | 100,000 | ~15K events/sec | — | — |
+| Load (full stream) | 100,000 | ~500K events/sec | ~200ms | ~500ms |
+| Many Streams (1000) | 100,000 | ~10K events/sec | — | — |
+
+> **Note**: PostgreSQL numbers are approximate and vary significantly with connection pooling settings, disk speed, and network latency. The concurrent append benchmarks often show *higher* throughput than sequential because PostgreSQL can pipeline concurrent transactions.
+
+---
+
+## How to Run
+
+### Memory adapter (no infrastructure required)
+
+```bash
+# Go benchmarks
+CGO_ENABLED=0 go test -run='^$' -bench=. -benchmem ./adapters/memory/
+
+# Scale tests (1M events)
+CGO_ENABLED=0 go test -run='TestAdapterScale' -v -timeout=10m ./adapters/memory/
+
+# Or use the Makefile
+make benchmark-adapters
+```
+
+### PostgreSQL adapter (requires PostgreSQL)
+
+```bash
+# Start infrastructure
+make infra-up
+
+# Go benchmarks
+TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
+  go test -run='^$' -bench=. -benchmem ./adapters/postgres/
+
+# Scale tests (100K events)
+TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
+  go test -run='TestAdapterScale' -v -timeout=10m ./adapters/postgres/
+
+# Or use the Makefile
+make benchmark-adapters-pg
+```
+
+### Root-level benchmarks (EventStore + CommandBus + Serializer)
+
+```bash
+# Full suite including 1M-event scale tests
+make benchmark
+
+# Quick run (no scale tests)
+make benchmark-quick
+```
+
+---
+
+## Adding Benchmarks for a New Adapter
+
+Adding benchmarks for a new adapter requires just three steps:
+
+### 1. Create a benchmark test file
+
+Create `adapters/youradapter/benchmark_test.go`:
+
+```go
+package youradapter
+
+import (
+    "testing"
+
+    "github.com/AshkanYarmoradi/go-mink/adapters"
+    "github.com/AshkanYarmoradi/go-mink/testing/benchmarks"
+)
+
+func newBenchmarkFactory() benchmarks.AdapterBenchmarkFactory {
+    return benchmarks.AdapterBenchmarkFactory{
+        Name: "youradapter",
+        CreateAdapter: func() (adapters.EventStoreAdapter, func(), error) {
+            a := NewAdapter(/* ... */)
+            return a, func() { a.Close() }, nil
+        },
+        Skip: func() string {
+            // Return non-empty to skip (e.g., missing env var)
+            return ""
+        },
+        Scale: &benchmarks.ScaleConfig{EventCount: 100_000},
+    }
+}
+
+func BenchmarkAdapter(b *testing.B) {
+    benchmarks.Run(b, newBenchmarkFactory())
+}
+
+func TestAdapterScale(t *testing.T) {
+    benchmarks.RunScale(t, newBenchmarkFactory())
+}
+```
+
+### 2. Add a Makefile target
+
+```makefile
+benchmark-adapters-yours:
+	go test -run='^$$' -bench=. -benchmem -benchtime=3s ./adapters/youradapter/
+	go test -run='TestAdapterScale' -v -timeout=10m ./adapters/youradapter/
+```
+
+### 3. Add a CI job (optional)
+
+Add a `benchmark-youradapter` job to `.github/workflows/test.yml` following the pattern of the existing `benchmark-postgres` job.
+
+---
+
+## Benchmark Architecture
+
+```
+testing/benchmarks/
+├── suite.go      # Run() and RunScale() entry points, all benchmark implementations
+├── records.go    # Pre-serialized EventRecord builders (Small, Medium, Metadata, Batch)
+└── latency.go    # LatencyCollector for percentile measurements (p50/p90/p95/p99)
+
+adapters/memory/benchmark_test.go      # ~25 lines, wires factory to Run/RunScale
+adapters/postgres/benchmark_test.go    # ~35 lines, wires factory to Run/RunScale
+```
+
+The shared suite operates at the `adapters.EventStoreAdapter` level with pre-serialized `adapters.EventRecord` values. This avoids importing the root `mink` package (which would create an import cycle) while measuring pure adapter I/O throughput.
+
+Each adapter provides an `AdapterBenchmarkFactory` that knows how to create, configure, and clean up adapter instances. The `Skip` function allows adapters to skip benchmarks when required infrastructure is unavailable.

--- a/testing/benchmarks/latency.go
+++ b/testing/benchmarks/latency.go
@@ -1,0 +1,71 @@
+package benchmarks
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// LatencyReport contains percentile latency statistics.
+type LatencyReport struct {
+	Count int
+	P50   time.Duration
+	P90   time.Duration
+	P95   time.Duration
+	P99   time.Duration
+	Max   time.Duration
+}
+
+// String returns a human-readable summary of the latency report.
+func (r LatencyReport) String() string {
+	return fmt.Sprintf("n=%d p50=%v p90=%v p95=%v p99=%v max=%v",
+		r.Count, r.P50, r.P90, r.P95, r.P99, r.Max)
+}
+
+// LatencyCollector records durations and computes percentile statistics.
+type LatencyCollector struct {
+	samples []time.Duration
+}
+
+// NewLatencyCollector creates a collector pre-allocated for the expected number of samples.
+func NewLatencyCollector(capacity int) *LatencyCollector {
+	return &LatencyCollector{
+		samples: make([]time.Duration, 0, capacity),
+	}
+}
+
+// Record adds a duration sample.
+func (lc *LatencyCollector) Record(d time.Duration) {
+	lc.samples = append(lc.samples, d)
+}
+
+// Report computes percentile statistics from recorded samples.
+// The collector must have at least one sample; otherwise Report returns a zero LatencyReport.
+func (lc *LatencyCollector) Report() LatencyReport {
+	n := len(lc.samples)
+	if n == 0 {
+		return LatencyReport{}
+	}
+
+	sort.Slice(lc.samples, func(i, j int) bool {
+		return lc.samples[i] < lc.samples[j]
+	})
+
+	return LatencyReport{
+		Count: n,
+		P50:   lc.samples[percentileIndex(n, 50)],
+		P90:   lc.samples[percentileIndex(n, 90)],
+		P95:   lc.samples[percentileIndex(n, 95)],
+		P99:   lc.samples[percentileIndex(n, 99)],
+		Max:   lc.samples[n-1],
+	}
+}
+
+// percentileIndex returns the index for the given percentile (0-100) in a sorted slice of length n.
+func percentileIndex(n, percentile int) int {
+	idx := (n * percentile) / 100
+	if idx >= n {
+		idx = n - 1
+	}
+	return idx
+}

--- a/testing/benchmarks/records.go
+++ b/testing/benchmarks/records.go
@@ -1,0 +1,61 @@
+package benchmarks
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/AshkanYarmoradi/go-mink/adapters"
+)
+
+// SmallEventRecord returns a pre-serialized event record with ~100 bytes of JSON payload.
+func SmallEventRecord() adapters.EventRecord {
+	return adapters.EventRecord{
+		Type: "OrderCreated",
+		Data: []byte(`{"orderId":"order-123","customerId":"cust-456","total":99.99}`),
+	}
+}
+
+// MediumEventRecord returns a pre-serialized event record with ~500 bytes of JSON payload.
+func MediumEventRecord() adapters.EventRecord {
+	return adapters.EventRecord{
+		Type: "OrderUpdated",
+		Data: []byte(`{"orderId":"order-123","customerId":"cust-456","total":249.99,"currency":"USD","status":"confirmed","items":[{"sku":"SKU-001","name":"Widget Pro","quantity":2,"price":49.99},{"sku":"SKU-002","name":"Gadget Plus","quantity":1,"price":149.99}],"shippingAddress":{"street":"123 Main St","city":"Springfield","state":"IL","zip":"62701","country":"US"},"billingAddress":{"street":"456 Oak Ave","city":"Chicago","state":"IL","zip":"60601","country":"US"}}`),
+	}
+}
+
+// MetadataEventRecord returns a pre-serialized event record with rich metadata.
+func MetadataEventRecord() adapters.EventRecord {
+	return adapters.EventRecord{
+		Type: "OrderCreated",
+		Data: []byte(`{"orderId":"order-123","customerId":"cust-456","total":99.99}`),
+		Metadata: adapters.Metadata{
+			CorrelationID: "corr-abc-123-def-456",
+			CausationID:   "cmd-create-order-789",
+			UserID:        "user-admin-001",
+			TenantID:      "tenant-acme-corp",
+			Custom: map[string]string{
+				"source":          "web-api",
+				"$schema_version": "2",
+				"request_id":      "req-xyz-789",
+			},
+		},
+	}
+}
+
+// MakeBatch creates a batch of SmallEventRecords with the specified size.
+// Each record has a unique type suffix to avoid any deduplication.
+func MakeBatch(size int) []adapters.EventRecord {
+	records := make([]adapters.EventRecord, size)
+	for i := range records {
+		records[i] = adapters.EventRecord{
+			Type: "OrderEvent",
+			Data: []byte(fmt.Sprintf(`{"orderId":"order-%d","seq":%d,"total":%.2f}`, i, i, float64(i)*10.5)),
+		}
+	}
+	return records
+}
+
+// MakeStreamID creates a unique stream ID for benchmarks using the given index.
+func MakeStreamID(prefix string, i int) string {
+	return prefix + "-" + strconv.Itoa(i)
+}

--- a/testing/benchmarks/records.go
+++ b/testing/benchmarks/records.go
@@ -42,8 +42,8 @@ func MetadataEventRecord() adapters.EventRecord {
 	}
 }
 
-// MakeBatch creates a batch of SmallEventRecords with the specified size.
-// Each record has a unique type suffix to avoid any deduplication.
+// MakeBatch creates a batch of EventRecords with the specified size.
+// All records share the same "OrderEvent" type with unique JSON payloads.
 func MakeBatch(size int) []adapters.EventRecord {
 	records := make([]adapters.EventRecord, size)
 	for i := range records {

--- a/testing/benchmarks/suite.go
+++ b/testing/benchmarks/suite.go
@@ -1,0 +1,550 @@
+// Package benchmarks provides a shared benchmark suite for EventStoreAdapter implementations.
+//
+// This package operates at the adapter level with pre-serialized EventRecord values,
+// measuring pure adapter I/O throughput without importing the root mink package
+// (which would cause an import cycle).
+//
+// Usage:
+//
+//	func BenchmarkAdapter(b *testing.B) {
+//	    benchmarks.Run(b, benchmarks.AdapterBenchmarkFactory{
+//	        Name: "memory",
+//	        CreateAdapter: func() (adapters.EventStoreAdapter, func(), error) {
+//	            a := memory.NewAdapter()
+//	            return a, func() { a.Close() }, nil
+//	        },
+//	    })
+//	}
+package benchmarks
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AshkanYarmoradi/go-mink/adapters"
+)
+
+// AnyVersion matches the mink.AnyVersion constant (-1) to skip version checks.
+// Duplicated here to avoid importing the root mink package.
+const AnyVersion int64 = -1
+
+// AdapterBenchmarkFactory defines how to create an adapter for benchmarking.
+type AdapterBenchmarkFactory struct {
+	// Name identifies the adapter (e.g., "memory", "postgres").
+	Name string
+
+	// CreateAdapter returns a new adapter instance, a cleanup function, and any error.
+	// Each benchmark gets a fresh adapter to avoid cross-contamination.
+	CreateAdapter func() (adapters.EventStoreAdapter, func(), error)
+
+	// Skip returns a non-empty reason to skip benchmarks (e.g., missing env var).
+	// Return "" to run benchmarks.
+	Skip func() string
+
+	// Scale overrides the default event count for scale tests.
+	// nil uses defaults (1,000,000 for memory, configurable per adapter).
+	Scale *ScaleConfig
+}
+
+// ScaleConfig overrides scale test parameters.
+type ScaleConfig struct {
+	EventCount int // Number of events for scale tests.
+}
+
+// scaleN returns the event count for scale tests.
+func (f *AdapterBenchmarkFactory) scaleN() int {
+	if f.Scale != nil && f.Scale.EventCount > 0 {
+		return f.Scale.EventCount
+	}
+	return 1_000_000
+}
+
+// newAdapter creates and initializes an adapter, failing the test on error.
+func (f *AdapterBenchmarkFactory) newAdapter(tb testing.TB) (adapters.EventStoreAdapter, func()) {
+	tb.Helper()
+	if f.Skip != nil {
+		if reason := f.Skip(); reason != "" {
+			tb.Skip(reason)
+		}
+	}
+	adapter, cleanup, err := f.CreateAdapter()
+	if err != nil {
+		tb.Fatalf("failed to create adapter: %v", err)
+	}
+	ctx := context.Background()
+	if err := adapter.Initialize(ctx); err != nil {
+		cleanup()
+		tb.Fatalf("failed to initialize adapter: %v", err)
+	}
+	return adapter, cleanup
+}
+
+// Run executes the full Go benchmark suite against the given adapter factory.
+func Run(b *testing.B, factory AdapterBenchmarkFactory) {
+	b.Run("Append", func(b *testing.B) {
+		runAppendBenchmarks(b, &factory)
+	})
+	b.Run("Load", func(b *testing.B) {
+		runLoadBenchmarks(b, &factory)
+	})
+	b.Run("Concurrent", func(b *testing.B) {
+		runConcurrentBenchmarks(b, &factory)
+	})
+	b.Run("Mixed", func(b *testing.B) {
+		runMixedBenchmarks(b, &factory)
+	})
+	b.Run("StreamOps", func(b *testing.B) {
+		runStreamOpsBenchmarks(b, &factory)
+	})
+}
+
+// RunScale executes scale tests that measure throughput and latency at high event counts.
+func RunScale(t *testing.T, factory AdapterBenchmarkFactory) {
+	t.Run("Scale_SequentialAppend", func(t *testing.T) {
+		runScaleSequentialAppend(t, &factory)
+	})
+	t.Run("Scale_BatchAppend", func(t *testing.T) {
+		runScaleBatchAppend(t, &factory)
+	})
+	t.Run("Scale_ConcurrentAppend", func(t *testing.T) {
+		runScaleConcurrentAppend(t, &factory)
+	})
+	t.Run("Scale_Load", func(t *testing.T) {
+		runScaleLoad(t, &factory)
+	})
+	t.Run("Scale_ManyStreams", func(t *testing.T) {
+		runScaleManyStreams(t, &factory)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Append benchmarks
+// ---------------------------------------------------------------------------
+
+func runAppendBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
+	b.Run("SingleEvent", func(b *testing.B) {
+		adapter, cleanup := f.newAdapter(b)
+		defer cleanup()
+		ctx := context.Background()
+		rec := SmallEventRecord()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = adapter.Append(ctx, MakeStreamID("bench", i), []adapters.EventRecord{rec}, AnyVersion)
+		}
+		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+	})
+
+	for _, size := range []int{10, 100} {
+		b.Run(fmt.Sprintf("BatchOf%d", size), func(b *testing.B) {
+			adapter, cleanup := f.newAdapter(b)
+			defer cleanup()
+			ctx := context.Background()
+			batch := MakeBatch(size)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = adapter.Append(ctx, MakeStreamID("bench-batch", i), batch, AnyVersion)
+			}
+			b.ReportMetric(float64(b.N*size)/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+
+	b.Run("WithMetadata", func(b *testing.B) {
+		adapter, cleanup := f.newAdapter(b)
+		defer cleanup()
+		ctx := context.Background()
+		rec := MetadataEventRecord()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = adapter.Append(ctx, MakeStreamID("bench-meta", i), []adapters.EventRecord{rec}, AnyVersion)
+		}
+		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+	})
+
+	b.Run("WithConcurrencyCheck", func(b *testing.B) {
+		adapter, cleanup := f.newAdapter(b)
+		defer cleanup()
+		ctx := context.Background()
+		rec := SmallEventRecord()
+
+		// Pre-populate streams so we can do version-checked appends.
+		for i := 0; i < b.N; i++ {
+			_, _ = adapter.Append(ctx, MakeStreamID("bench-cc", i), []adapters.EventRecord{rec}, AnyVersion)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = adapter.Append(ctx, MakeStreamID("bench-cc", i), []adapters.EventRecord{rec}, 1)
+		}
+		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Load benchmarks
+// ---------------------------------------------------------------------------
+
+func runLoadBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
+	for _, size := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("%dEvents", size), func(b *testing.B) {
+			adapter, cleanup := f.newAdapter(b)
+			defer cleanup()
+			ctx := context.Background()
+
+			// Seed the stream.
+			batch := MakeBatch(size)
+			_, err := adapter.Append(ctx, "bench-load", batch, AnyVersion)
+			if err != nil {
+				b.Fatalf("seed failed: %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = adapter.Load(ctx, "bench-load", 0)
+			}
+			b.ReportMetric(float64(b.N*size)/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent benchmarks
+// ---------------------------------------------------------------------------
+
+func runConcurrentBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
+	for _, workers := range []int{8, 32} {
+		b.Run(fmt.Sprintf("Append_%dWorkers", workers), func(b *testing.B) {
+			adapter, cleanup := f.newAdapter(b)
+			defer cleanup()
+			ctx := context.Background()
+			rec := SmallEventRecord()
+			var counter atomic.Int64
+
+			b.SetParallelism(workers / runtime.GOMAXPROCS(0))
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					n := counter.Add(1)
+					_, _ = adapter.Append(ctx, MakeStreamID("bench-conc", int(n)), []adapters.EventRecord{rec}, AnyVersion)
+				}
+			})
+			b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mixed workload benchmarks
+// ---------------------------------------------------------------------------
+
+func runMixedBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
+	b.Run("ReadHeavy_80_20", func(b *testing.B) {
+		runMixed(b, f, 80)
+	})
+	b.Run("WriteHeavy_20_80", func(b *testing.B) {
+		runMixed(b, f, 20)
+	})
+}
+
+func runMixed(b *testing.B, f *AdapterBenchmarkFactory, readPct int) {
+	adapter, cleanup := f.newAdapter(b)
+	defer cleanup()
+	ctx := context.Background()
+	rec := SmallEventRecord()
+
+	// Seed 100 streams with 10 events each.
+	const seedStreams = 100
+	batch := MakeBatch(10)
+	for i := 0; i < seedStreams; i++ {
+		_, _ = adapter.Append(ctx, MakeStreamID("bench-mix", i), batch, AnyVersion)
+	}
+
+	var writeCounter atomic.Int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if rand.IntN(100) < readPct {
+				streamIdx := rand.IntN(seedStreams)
+				_, _ = adapter.Load(ctx, MakeStreamID("bench-mix", streamIdx), 0)
+			} else {
+				n := writeCounter.Add(1)
+				_, _ = adapter.Append(ctx, MakeStreamID("bench-mix-w", int(n)), []adapters.EventRecord{rec}, AnyVersion)
+			}
+		}
+	})
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")
+}
+
+// ---------------------------------------------------------------------------
+// Stream operations benchmarks
+// ---------------------------------------------------------------------------
+
+func runStreamOpsBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
+	b.Run("GetStreamInfo", func(b *testing.B) {
+		adapter, cleanup := f.newAdapter(b)
+		defer cleanup()
+		ctx := context.Background()
+
+		// Seed a stream.
+		batch := MakeBatch(50)
+		_, _ = adapter.Append(ctx, "bench-info", batch, AnyVersion)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = adapter.GetStreamInfo(ctx, "bench-info")
+		}
+		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")
+	})
+
+	b.Run("GetLastPosition", func(b *testing.B) {
+		adapter, cleanup := f.newAdapter(b)
+		defer cleanup()
+		ctx := context.Background()
+
+		// Seed some events.
+		batch := MakeBatch(50)
+		_, _ = adapter.Append(ctx, "bench-pos", batch, AnyVersion)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = adapter.GetLastPosition(ctx)
+		}
+		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Scale tests
+// ---------------------------------------------------------------------------
+
+func runScaleSequentialAppend(t *testing.T, f *AdapterBenchmarkFactory) {
+	if testing.Short() {
+		t.Skip("Skipping scale test in short mode")
+	}
+	adapter, cleanup := f.newAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+	rec := SmallEventRecord()
+	n := f.scaleN()
+
+	lc := NewLatencyCollector(n)
+	var memBefore, memAfter runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		opStart := time.Now()
+		_, err := adapter.Append(ctx, MakeStreamID("scale-seq", i), []adapters.EventRecord{rec}, AnyVersion)
+		lc.Record(time.Since(opStart))
+		if err != nil {
+			t.Fatalf("append failed at %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&memAfter)
+
+	report := lc.Report()
+	throughput := float64(n) / elapsed.Seconds()
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	t.Logf("Sequential Append: %d events in %v (%.0f events/sec)", n, elapsed, throughput)
+	t.Logf("Latency: %s", report)
+	t.Logf("Memory: allocs=%.1f MB, heap=%.1f MB", allocMB, heapMB)
+}
+
+func runScaleBatchAppend(t *testing.T, f *AdapterBenchmarkFactory) {
+	if testing.Short() {
+		t.Skip("Skipping scale test in short mode")
+	}
+	adapter, cleanup := f.newAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+	n := f.scaleN()
+	const batchSize = 100
+
+	lc := NewLatencyCollector(n / batchSize)
+	var memBefore, memAfter runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+	for i := 0; i < n/batchSize; i++ {
+		batch := MakeBatch(batchSize)
+		opStart := time.Now()
+		_, err := adapter.Append(ctx, MakeStreamID("scale-batch", i), batch, AnyVersion)
+		lc.Record(time.Since(opStart))
+		if err != nil {
+			t.Fatalf("batch append failed at %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&memAfter)
+
+	report := lc.Report()
+	throughput := float64(n) / elapsed.Seconds()
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	t.Logf("Batch Append: %d events (%d batches of %d) in %v (%.0f events/sec)", n, n/batchSize, batchSize, elapsed, throughput)
+	t.Logf("Latency (per batch): %s", report)
+	t.Logf("Memory: allocs=%.1f MB, heap=%.1f MB", allocMB, heapMB)
+}
+
+func runScaleConcurrentAppend(t *testing.T, f *AdapterBenchmarkFactory) {
+	if testing.Short() {
+		t.Skip("Skipping scale test in short mode")
+	}
+	adapter, cleanup := f.newAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+	n := f.scaleN()
+	const workers = 8
+	perWorker := n / workers
+
+	var memBefore, memAfter runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	var errCount atomic.Int64
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rec := SmallEventRecord()
+			base := workerID * perWorker
+			for i := 0; i < perWorker; i++ {
+				_, err := adapter.Append(ctx, MakeStreamID("scale-conc", base+i), []adapters.EventRecord{rec}, AnyVersion)
+				if err != nil {
+					errCount.Add(1)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&memAfter)
+
+	throughput := float64(n) / elapsed.Seconds()
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	t.Logf("Concurrent Append: %d events across %d workers in %v (%.0f events/sec)", n, workers, elapsed, throughput)
+	t.Logf("Errors: %d", errCount.Load())
+	t.Logf("Memory: allocs=%.1f MB, heap=%.1f MB", allocMB, heapMB)
+}
+
+func runScaleLoad(t *testing.T, f *AdapterBenchmarkFactory) {
+	if testing.Short() {
+		t.Skip("Skipping scale test in short mode")
+	}
+	adapter, cleanup := f.newAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+	n := f.scaleN()
+
+	// Cap single-stream load at 100k to avoid excessive memory use.
+	loadSize := n
+	if loadSize > 100_000 {
+		loadSize = 100_000
+	}
+
+	// Seed the stream in batches.
+	const batchSize = 1000
+	for i := 0; i < loadSize/batchSize; i++ {
+		batch := MakeBatch(batchSize)
+		_, err := adapter.Append(ctx, "scale-load-stream", batch, AnyVersion)
+		if err != nil {
+			t.Fatalf("seed failed at batch %d: %v", i, err)
+		}
+	}
+
+	// Measure load time.
+	lc := NewLatencyCollector(10)
+	const loadIterations = 10
+	for i := 0; i < loadIterations; i++ {
+		opStart := time.Now()
+		events, err := adapter.Load(ctx, "scale-load-stream", 0)
+		lc.Record(time.Since(opStart))
+		if err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+		if len(events) != loadSize {
+			t.Fatalf("expected %d events, got %d", loadSize, len(events))
+		}
+	}
+
+	report := lc.Report()
+	avgThroughput := float64(loadSize) / report.P50.Seconds()
+
+	t.Logf("Load: %d events, %d iterations", loadSize, loadIterations)
+	t.Logf("Latency: %s", report)
+	t.Logf("Throughput (at p50): %.0f events/sec", avgThroughput)
+}
+
+func runScaleManyStreams(t *testing.T, f *AdapterBenchmarkFactory) {
+	if testing.Short() {
+		t.Skip("Skipping scale test in short mode")
+	}
+	adapter, cleanup := f.newAdapter(t)
+	defer cleanup()
+	ctx := context.Background()
+	n := f.scaleN()
+	const streams = 1000
+	perStream := n / streams
+
+	var memBefore, memAfter runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&memBefore)
+
+	start := time.Now()
+	for s := 0; s < streams; s++ {
+		// Append in batches to each stream.
+		remaining := perStream
+		for remaining > 0 {
+			batchSize := remaining
+			if batchSize > 100 {
+				batchSize = 100
+			}
+			batch := MakeBatch(batchSize)
+			_, err := adapter.Append(ctx, MakeStreamID("scale-many", s), batch, AnyVersion)
+			if err != nil {
+				t.Fatalf("append to stream %d failed: %v", s, err)
+			}
+			remaining -= batchSize
+		}
+	}
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&memAfter)
+
+	throughput := float64(n) / elapsed.Seconds()
+	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
+
+	t.Logf("Many Streams: %d events across %d streams in %v (%.0f events/sec)", n, streams, elapsed, throughput)
+	t.Logf("Memory: allocs=%.1f MB, heap=%.1f MB", allocMB, heapMB)
+}
+
+// memStatsDelta computes the difference in memory stats.
+func memStatsDelta(before, after runtime.MemStats) (allocsMB, heapMB float64) {
+	allocsMB = float64(after.TotalAlloc-before.TotalAlloc) / (1024 * 1024)
+	heapMB = float64(after.HeapInuse) / (1024 * 1024)
+	return
+}

--- a/testing/benchmarks/suite.go
+++ b/testing/benchmarks/suite.go
@@ -30,9 +30,8 @@ import (
 	"github.com/AshkanYarmoradi/go-mink/adapters"
 )
 
-// AnyVersion matches the mink.AnyVersion constant (-1) to skip version checks.
-// Duplicated here to avoid importing the root mink package.
-const AnyVersion int64 = -1
+// AnyVersion is an alias for adapters.AnyVersion, used to skip version checks.
+const AnyVersion = adapters.AnyVersion
 
 // AdapterBenchmarkFactory defines how to create an adapter for benchmarking.
 type AdapterBenchmarkFactory struct {
@@ -137,7 +136,9 @@ func runAppendBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = adapter.Append(ctx, MakeStreamID("bench", i), []adapters.EventRecord{rec}, AnyVersion)
+			if _, err := adapter.Append(ctx, MakeStreamID("bench", i), []adapters.EventRecord{rec}, AnyVersion); err != nil {
+				b.Fatalf("append failed at %d: %v", i, err)
+			}
 		}
 		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
 	})
@@ -152,7 +153,9 @@ func runAppendBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _ = adapter.Append(ctx, MakeStreamID("bench-batch", i), batch, AnyVersion)
+				if _, err := adapter.Append(ctx, MakeStreamID("bench-batch", i), batch, AnyVersion); err != nil {
+					b.Fatalf("batch append failed at %d: %v", i, err)
+				}
 			}
 			b.ReportMetric(float64(b.N*size)/b.Elapsed().Seconds(), "events/sec")
 		})
@@ -167,7 +170,9 @@ func runAppendBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = adapter.Append(ctx, MakeStreamID("bench-meta", i), []adapters.EventRecord{rec}, AnyVersion)
+			if _, err := adapter.Append(ctx, MakeStreamID("bench-meta", i), []adapters.EventRecord{rec}, AnyVersion); err != nil {
+				b.Fatalf("append failed at %d: %v", i, err)
+			}
 		}
 		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
 	})
@@ -180,13 +185,17 @@ func runAppendBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 
 		// Pre-populate streams so we can do version-checked appends.
 		for i := 0; i < b.N; i++ {
-			_, _ = adapter.Append(ctx, MakeStreamID("bench-cc", i), []adapters.EventRecord{rec}, AnyVersion)
+			if _, err := adapter.Append(ctx, MakeStreamID("bench-cc", i), []adapters.EventRecord{rec}, AnyVersion); err != nil {
+				b.Fatalf("pre-populate failed at %d: %v", i, err)
+			}
 		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = adapter.Append(ctx, MakeStreamID("bench-cc", i), []adapters.EventRecord{rec}, 1)
+			if _, err := adapter.Append(ctx, MakeStreamID("bench-cc", i), []adapters.EventRecord{rec}, 1); err != nil {
+				b.Fatalf("version-checked append failed at %d: %v", i, err)
+			}
 		}
 		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
 	})
@@ -213,7 +222,9 @@ func runLoadBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _ = adapter.Load(ctx, "bench-load", 0)
+				if _, err := adapter.Load(ctx, "bench-load", 0); err != nil {
+					b.Fatalf("load failed at %d: %v", i, err)
+				}
 			}
 			b.ReportMetric(float64(b.N*size)/b.Elapsed().Seconds(), "events/sec")
 		})
@@ -233,13 +244,19 @@ func runConcurrentBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 			rec := SmallEventRecord()
 			var counter atomic.Int64
 
-			b.SetParallelism(workers / runtime.GOMAXPROCS(0))
+			p := workers / runtime.GOMAXPROCS(0)
+			if p < 1 {
+				p = 1
+			}
+			b.SetParallelism(p)
 			b.ReportAllocs()
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					n := counter.Add(1)
-					_, _ = adapter.Append(ctx, MakeStreamID("bench-conc", int(n)), []adapters.EventRecord{rec}, AnyVersion)
+					if _, err := adapter.Append(ctx, MakeStreamID("bench-conc", int(n)), []adapters.EventRecord{rec}, AnyVersion); err != nil {
+						b.Fatalf("concurrent append failed: %v", err)
+					}
 				}
 			})
 			b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "events/sec")
@@ -270,7 +287,9 @@ func runMixed(b *testing.B, f *AdapterBenchmarkFactory, readPct int) {
 	const seedStreams = 100
 	batch := MakeBatch(10)
 	for i := 0; i < seedStreams; i++ {
-		_, _ = adapter.Append(ctx, MakeStreamID("bench-mix", i), batch, AnyVersion)
+		if _, err := adapter.Append(ctx, MakeStreamID("bench-mix", i), batch, AnyVersion); err != nil {
+			b.Fatalf("seed failed at %d: %v", i, err)
+		}
 	}
 
 	var writeCounter atomic.Int64
@@ -280,10 +299,14 @@ func runMixed(b *testing.B, f *AdapterBenchmarkFactory, readPct int) {
 		for pb.Next() {
 			if rand.IntN(100) < readPct {
 				streamIdx := rand.IntN(seedStreams)
-				_, _ = adapter.Load(ctx, MakeStreamID("bench-mix", streamIdx), 0)
+				if _, err := adapter.Load(ctx, MakeStreamID("bench-mix", streamIdx), 0); err != nil {
+					b.Fatalf("mixed load failed: %v", err)
+				}
 			} else {
 				n := writeCounter.Add(1)
-				_, _ = adapter.Append(ctx, MakeStreamID("bench-mix-w", int(n)), []adapters.EventRecord{rec}, AnyVersion)
+				if _, err := adapter.Append(ctx, MakeStreamID("bench-mix-w", int(n)), []adapters.EventRecord{rec}, AnyVersion); err != nil {
+					b.Fatalf("mixed append failed: %v", err)
+				}
 			}
 		}
 	})
@@ -302,12 +325,16 @@ func runStreamOpsBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 
 		// Seed a stream.
 		batch := MakeBatch(50)
-		_, _ = adapter.Append(ctx, "bench-info", batch, AnyVersion)
+		if _, err := adapter.Append(ctx, "bench-info", batch, AnyVersion); err != nil {
+			b.Fatalf("seed failed: %v", err)
+		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = adapter.GetStreamInfo(ctx, "bench-info")
+			if _, err := adapter.GetStreamInfo(ctx, "bench-info"); err != nil {
+				b.Fatalf("GetStreamInfo failed at %d: %v", i, err)
+			}
 		}
 		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")
 	})
@@ -319,12 +346,16 @@ func runStreamOpsBenchmarks(b *testing.B, f *AdapterBenchmarkFactory) {
 
 		// Seed some events.
 		batch := MakeBatch(50)
-		_, _ = adapter.Append(ctx, "bench-pos", batch, AnyVersion)
+		if _, err := adapter.Append(ctx, "bench-pos", batch, AnyVersion); err != nil {
+			b.Fatalf("seed failed: %v", err)
+		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = adapter.GetLastPosition(ctx)
+			if _, err := adapter.GetLastPosition(ctx); err != nil {
+				b.Fatalf("GetLastPosition failed at %d: %v", i, err)
+			}
 		}
 		b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "ops/sec")
 	})
@@ -379,20 +410,35 @@ func runScaleBatchAppend(t *testing.T, f *AdapterBenchmarkFactory) {
 	ctx := context.Background()
 	n := f.scaleN()
 	const batchSize = 100
+	fullBatches := n / batchSize
+	remainder := n % batchSize
+	totalBatches := fullBatches
+	if remainder > 0 {
+		totalBatches++
+	}
 
-	lc := NewLatencyCollector(n / batchSize)
+	lc := NewLatencyCollector(totalBatches)
 	var memBefore, memAfter runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&memBefore)
 
 	start := time.Now()
-	for i := 0; i < n/batchSize; i++ {
+	for i := 0; i < fullBatches; i++ {
 		batch := MakeBatch(batchSize)
 		opStart := time.Now()
 		_, err := adapter.Append(ctx, MakeStreamID("scale-batch", i), batch, AnyVersion)
 		lc.Record(time.Since(opStart))
 		if err != nil {
 			t.Fatalf("batch append failed at %d: %v", i, err)
+		}
+	}
+	if remainder > 0 {
+		batch := MakeBatch(remainder)
+		opStart := time.Now()
+		_, err := adapter.Append(ctx, MakeStreamID("scale-batch", fullBatches), batch, AnyVersion)
+		lc.Record(time.Since(opStart))
+		if err != nil {
+			t.Fatalf("remainder batch append failed: %v", err)
 		}
 	}
 	elapsed := time.Since(start)
@@ -402,7 +448,7 @@ func runScaleBatchAppend(t *testing.T, f *AdapterBenchmarkFactory) {
 	throughput := float64(n) / elapsed.Seconds()
 	allocMB, heapMB := memStatsDelta(memBefore, memAfter)
 
-	t.Logf("Batch Append: %d events (%d batches of %d) in %v (%.0f events/sec)", n, n/batchSize, batchSize, elapsed, throughput)
+	t.Logf("Batch Append: %d events (%d batches of %d) in %v (%.0f events/sec)", n, totalBatches, batchSize, elapsed, throughput)
 	t.Logf("Latency (per batch): %s", report)
 	t.Logf("Memory: allocs=%.1f MB, heap=%.1f MB", allocMB, heapMB)
 }
@@ -450,6 +496,10 @@ func runScaleConcurrentAppend(t *testing.T, f *AdapterBenchmarkFactory) {
 	t.Logf("Concurrent Append: %d events across %d workers in %v (%.0f events/sec)", n, workers, elapsed, throughput)
 	t.Logf("Errors: %d", errCount.Load())
 	t.Logf("Memory: allocs=%.1f MB, heap=%.1f MB", allocMB, heapMB)
+
+	if errCount.Load() > 0 {
+		t.Fatalf("concurrent append had %d errors", errCount.Load())
+	}
 }
 
 func runScaleLoad(t *testing.T, f *AdapterBenchmarkFactory) {
@@ -469,11 +519,20 @@ func runScaleLoad(t *testing.T, f *AdapterBenchmarkFactory) {
 
 	// Seed the stream in batches.
 	const batchSize = 1000
+	seeded := 0
 	for i := 0; i < loadSize/batchSize; i++ {
 		batch := MakeBatch(batchSize)
 		_, err := adapter.Append(ctx, "scale-load-stream", batch, AnyVersion)
 		if err != nil {
 			t.Fatalf("seed failed at batch %d: %v", i, err)
+		}
+		seeded += batchSize
+	}
+	if remainder := loadSize - seeded; remainder > 0 {
+		batch := MakeBatch(remainder)
+		_, err := adapter.Append(ctx, "scale-load-stream", batch, AnyVersion)
+		if err != nil {
+			t.Fatalf("seed remainder failed: %v", err)
 		}
 	}
 
@@ -510,6 +569,11 @@ func runScaleManyStreams(t *testing.T, f *AdapterBenchmarkFactory) {
 	n := f.scaleN()
 	const streams = 1000
 	perStream := n / streams
+	if perStream < 1 {
+		t.Fatalf("EventCount (%d) must be >= streams (%d)", n, streams)
+	}
+	// Distribute remainder events across the first streams.
+	remainder := n - (perStream * streams)
 
 	var memBefore, memAfter runtime.MemStats
 	runtime.GC()
@@ -518,7 +582,11 @@ func runScaleManyStreams(t *testing.T, f *AdapterBenchmarkFactory) {
 	start := time.Now()
 	for s := 0; s < streams; s++ {
 		// Append in batches to each stream.
-		remaining := perStream
+		target := perStream
+		if s < remainder {
+			target++
+		}
+		remaining := target
 		for remaining > 0 {
 			batchSize := remaining
 			if batchSize > 100 {

--- a/testing/benchmarks/suite.go
+++ b/testing/benchmarks/suite.go
@@ -463,6 +463,7 @@ func runScaleConcurrentAppend(t *testing.T, f *AdapterBenchmarkFactory) {
 	n := f.scaleN()
 	const workers = 8
 	perWorker := n / workers
+	remainder := n - (perWorker * workers)
 
 	var memBefore, memAfter runtime.MemStats
 	runtime.GC()
@@ -474,17 +475,27 @@ func runScaleConcurrentAppend(t *testing.T, f *AdapterBenchmarkFactory) {
 
 	for w := 0; w < workers; w++ {
 		wg.Add(1)
-		go func(workerID int) {
+		// Distribute remainder across the first workers.
+		count := perWorker
+		if w < remainder {
+			count++
+		}
+		go func(workerID, count int) {
 			defer wg.Done()
 			rec := SmallEventRecord()
 			base := workerID * perWorker
-			for i := 0; i < perWorker; i++ {
+			if workerID < remainder {
+				base += workerID
+			} else {
+				base += remainder
+			}
+			for i := 0; i < count; i++ {
 				_, err := adapter.Append(ctx, MakeStreamID("scale-conc", base+i), []adapters.EventRecord{rec}, AnyVersion)
 				if err != nil {
 					errCount.Add(1)
 				}
 			}
-		}(w)
+		}(w, count)
 	}
 	wg.Wait()
 	elapsed := time.Since(start)


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
Add benchmarking suite for go-mink adapters

## Changes
<!-- List of changes -->
- Introduced a new documentation file `benchmarks.md` detailing performance characteristics of go-mink adapters under various workloads.
- Implemented a shared benchmark suite in `testing/benchmarks/` to facilitate consistent performance testing across different adapters.
- Added `LatencyCollector` and `LatencyReport` for measuring and reporting latency statistics.
- Created utility functions for generating pre-serialized event records in `records.go`.
- Developed comprehensive benchmark tests for append, load, concurrent, mixed workloads, and stream operations in `suite.go`.
- Included scale tests for sequential and batch appends, concurrent appends, and loading from streams.
- Documented steps for adding benchmarks for new adapters.

## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [ ] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [ ] No breaking changes (or documented if intentional)
