### PR TITLE
Fix linting issues

### DIFF
--- a/adapters/postgres/readmodel.go
+++ b/adapters/postgres/readmodel.go
@@ -138,7 +138,7 @@ func NewPostgresRepository[T any](db *sql.DB, opts ...ReadModelOption) (*Postgre
 	if config.tableName == "" {
 		var t T
 		typ := reflect.TypeOf(t)
-		if typ.Kind() == reflect.Ptr {
+		if typ.Kind() == reflect.Pointer {
 			typ = typ.Elem()
 		}
 		config.tableName = toSnakeCase(typ.Name())
@@ -187,7 +187,7 @@ func NewPostgresRepository[T any](db *sql.DB, opts ...ReadModelOption) (*Postgre
 func (r *PostgresRepository[T]) buildTableSchema() (*TableSchema, error) {
 	var t T
 	typ := reflect.TypeOf(t)
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	if typ.Kind() != reflect.Struct {
@@ -976,7 +976,7 @@ func goTypeToSQL(t reflect.Type) string {
 			return "TIMESTAMPTZ"
 		}
 		return "JSONB"
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return goTypeToSQL(t.Elem())
 	default:
 		return "TEXT"

--- a/handler.go
+++ b/handler.go
@@ -260,7 +260,7 @@ func GetCommandType(cmd interface{}) string {
 		return ""
 	}
 	t := reflect.TypeOf(cmd)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t.Name()

--- a/serializer.go
+++ b/serializer.go
@@ -39,7 +39,7 @@ func (r *EventRegistry) Register(eventType string, example interface{}) {
 
 	t := reflect.TypeOf(example)
 	// If a pointer was passed, get the element type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	r.types[eventType] = t
@@ -53,7 +53,7 @@ func (r *EventRegistry) RegisterAll(examples ...interface{}) {
 
 	for _, example := range examples {
 		t := reflect.TypeOf(example)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		r.types[t.Name()] = t
@@ -178,7 +178,7 @@ func GetEventType(event interface{}) string {
 	}
 
 	t := reflect.TypeOf(event)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t.Name()

--- a/serializer/msgpack/msgpack.go
+++ b/serializer/msgpack/msgpack.go
@@ -63,7 +63,7 @@ func (s *Serializer) Register(eventType string, example interface{}) {
 	defer s.mu.Unlock()
 
 	t := reflect.TypeOf(example)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	s.registry[eventType] = t
@@ -77,7 +77,7 @@ func (s *Serializer) RegisterAll(examples ...interface{}) {
 
 	for _, example := range examples {
 		t := reflect.TypeOf(example)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		s.registry[t.Name()] = t

--- a/serializer/protobuf/protobuf.go
+++ b/serializer/protobuf/protobuf.go
@@ -137,7 +137,7 @@ func (s *Serializer) Register(eventType string, event interface{}) error {
 	if _, ok := event.(proto.Message); !ok {
 		// Check if pointer implements proto.Message
 		v := reflect.ValueOf(event)
-		if v.Kind() != reflect.Ptr {
+		if v.Kind() != reflect.Pointer {
 			ptrType := reflect.PointerTo(reflect.TypeOf(event))
 			if !ptrType.Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
 				return &SerializationError{
@@ -153,7 +153,7 @@ func (s *Serializer) Register(eventType string, event interface{}) error {
 	defer s.mu.Unlock()
 
 	typ := reflect.TypeOf(event)
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	s.registry[eventType] = typ
@@ -165,7 +165,7 @@ func (s *Serializer) Register(eventType string, event interface{}) error {
 func (s *Serializer) RegisterAll(events ...interface{}) error {
 	for _, event := range events {
 		typ := reflect.TypeOf(event)
-		if typ.Kind() == reflect.Ptr {
+		if typ.Kind() == reflect.Pointer {
 			typ = typ.Elem()
 		}
 		eventType := typ.Name()
@@ -234,7 +234,7 @@ func (s *Serializer) Serialize(event interface{}) ([]byte, error) {
 	if !ok {
 		// Try to get proto.Message from pointer
 		v := reflect.ValueOf(event)
-		if v.Kind() == reflect.Ptr && !v.IsNil() {
+		if v.Kind() == reflect.Pointer && !v.IsNil() {
 			if pm, ok := v.Interface().(proto.Message); ok {
 				msg = pm
 			} else {

--- a/serializer/protobuf/protobuf_test.go
+++ b/serializer/protobuf/protobuf_test.go
@@ -575,7 +575,7 @@ func TestSerializer_ProtoCloneCompatibility(t *testing.T) {
 		// Get proto.Message for cloning - use reflect to get addressable pointer
 		var msg proto.Message
 		rv := reflect.ValueOf(result)
-		if rv.Kind() == reflect.Ptr {
+		if rv.Kind() == reflect.Pointer {
 			msg = result.(proto.Message)
 		} else {
 			// Create a new pointer and set its value

--- a/testing/assertions/assertions.go
+++ b/testing/assertions/assertions.go
@@ -263,7 +263,7 @@ func getTypeName(v interface{}) string {
 		return "<nil>"
 	}
 	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	return t.Name()


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request updates usage of the Go reflection API throughout the codebase to use the more modern and preferred `reflect.Pointer` constant instead of the deprecated `reflect.Ptr`. This change ensures compatibility with newer Go versions and improves code clarity. The updates are applied in various places where type introspection is performed, including repository, serializer, and testing logic.

**Reflection API modernization:**

* Replaced all instances of `reflect.Ptr` with `reflect.Pointer` in type checks and switch statements in `adapters/postgres/readmodel.go`, `handler.go`, `serializer.go`, `serializer/msgpack/msgpack.go`, and `serializer/protobuf/protobuf.go`. [[1]](diffhunk://#diff-3dc796aef914092c973474a7753490511c6b50f6e708c94ae9f73da93b20b6e4L141-R141) [[2]](diffhunk://#diff-3dc796aef914092c973474a7753490511c6b50f6e708c94ae9f73da93b20b6e4L190-R190) [[3]](diffhunk://#diff-3dc796aef914092c973474a7753490511c6b50f6e708c94ae9f73da93b20b6e4L979-R979) [[4]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L263-R263) [[5]](diffhunk://#diff-22539312577827eab0e99fb7e9900862f9443f612faada937179ade1652346e2L42-R42) [[6]](diffhunk://#diff-22539312577827eab0e99fb7e9900862f9443f612faada937179ade1652346e2L56-R56) [[7]](diffhunk://#diff-22539312577827eab0e99fb7e9900862f9443f612faada937179ade1652346e2L181-R181) [[8]](diffhunk://#diff-e25e5f0d03994a548aba0f60764464e5d3297f62d5b73f5349c9b77c02732832L66-R66) [[9]](diffhunk://#diff-e25e5f0d03994a548aba0f60764464e5d3297f62d5b73f5349c9b77c02732832L80-R80) [[10]](diffhunk://#diff-6c236ec8617d8621f2972b01bfe917c02c05bfb5f44412606adcc51e2450f601L140-R140) [[11]](diffhunk://#diff-6c236ec8617d8621f2972b01bfe917c02c05bfb5f44412606adcc51e2450f601L156-R156) [[12]](diffhunk://#diff-6c236ec8617d8621f2972b01bfe917c02c05bfb5f44412606adcc51e2450f601L168-R168) [[13]](diffhunk://#diff-6c236ec8617d8621f2972b01bfe917c02c05bfb5f44412606adcc51e2450f601L237-R237) [[14]](diffhunk://#diff-f68baa6cfd9c5c0d3adcb1bc3725a7ecf21fe194321b90d95d5d3b86db7ba7c1L578-R578) [[15]](diffhunk://#diff-12f8f13acdaf89b149c9a2f153f9348b1eb8ae1cbd1883297a55b8215ff7c47eL266-R266)

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
