### PR TITLE
Align and deduplicate PostgreSQL schema generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Start test infrastructure
@@ -204,7 +204,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.22', '1.23', '1.24', '1.25', '1.26']
+        go-version: ['1.25', '1.26']
 
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,24 @@ go-mink.dev/
                                #   sagas, cqrs, metrics, tracing, encryption, export, etc.)
 ```
 
+### Repository Mental Model for Agents
+
+Use this as the working map before making changes:
+
+- The root `mink` package is the public developer API. Core entry points are `EventStore`, `AggregateBase`, `CommandBus`, `ProjectionEngine`, `SagaManager`, `EventStoreWithOutbox`, `DataExporter`, upcasting, and field encryption.
+- `adapters/adapter.go` is the backend contract layer. Keep adapter interfaces small and add capabilities through optional interfaces such as `SubscriptionAdapter`, `SnapshotAdapter`, `CheckpointAdapter`, `IdempotencyStore`, `SagaStore`, `OutboxStore`, `OutboxAppender`, diagnostic, migration, and schema interfaces.
+- Event writes flow through `EventStore.Append` or `SaveAggregate`: serialize event, stamp schema version if upcasters are configured, encrypt configured JSON fields if field encryption is configured, then call the adapter. Aggregate saves use the aggregate version as the expected stream version.
+- Event reads flow through the adapter, then optional decryption, optional upcasting, and finally deserialization. Reuse `ProcessStoredEvent` when a subsystem needs the full read pipeline for raw stored events.
+- Projections are explicit. The event store does not automatically run projections after every append. Inline projections are invoked through `ProjectionEngine.ProcessInlineProjections`, async projections poll through `LoadEventsFromPosition`, and live projections are notified through `NotifyLiveProjections`.
+- PostgreSQL subscriptions are polling-based. Do not assume LISTEN/NOTIFY semantics unless that support is explicitly added.
+- The memory adapter is for tests and development. It is thread-safe and implements many optional interfaces, but it is not durable and includes package-level CLI projection/migration state.
+- The PostgreSQL adapter owns production storage, optimistic concurrency via row locking and unique `(stream_id, version)`, snapshots, checkpoints, polling subscriptions, CLI inspection, diagnostics, idempotency, saga storage, read model repositories, and atomic event-plus-outbox writes through `OutboxAppender`.
+- Field-level encryption is JSON-only because it edits JSON object fields before storage. MessagePack and Protobuf serializers are useful alternatives, but they are not compatible with field-level encryption.
+- Outbox writes are atomic only when the adapter implements `OutboxAppender` (PostgreSQL does). The fallback path appends events first and schedules outbox messages separately.
+- Sagas use persisted `SagaState`, per-saga in-memory locks, processed-event tracking for idempotency, and optimistic concurrency retries. Keep saga changes careful around terminal states and version updates.
+- Integration tests rely on `TEST_DATABASE_URL` and `TEST_KAFKA_BROKERS`; short tests skip infrastructure-heavy paths. The local quick health check is `go test -short ./...`.
+- Keep version and schema declarations synchronized: `go.mod`, the README badge, and the CI matrix should agree on Go support, and PostgreSQL generated DDL should stay aligned with runtime migrations.
+
 ---
 
 ## Implemented Features (v1.0.0)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/AshkanYarmoradi/go-mink/actions/workflows/test.yml"><img src="https://github.com/AshkanYarmoradi/go-mink/actions/workflows/test.yml/badge.svg" alt="Build Status"></a>
   <a href="https://codecov.io/gh/AshkanYarmoradi/go-mink"><img src="https://codecov.io/gh/AshkanYarmoradi/go-mink/graph/badge.svg?token=ZCB3IDSI2Q" alt="codecov"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
-  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go" alt="Go Version"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go" alt="Go Version"></a>
 </p>
 
 <p align="center">

--- a/adapters/postgres/idempotency.go
+++ b/adapters/postgres/idempotency.go
@@ -77,25 +77,7 @@ func (s *IdempotencyStore) Initialize(ctx context.Context) error {
 		return err
 	}
 
-	tableQ := s.fullTableName()
-	query := `
-		CREATE TABLE IF NOT EXISTS ` + tableQ + ` (
-			key VARCHAR(255) PRIMARY KEY,
-			command_type VARCHAR(255) NOT NULL,
-			aggregate_id VARCHAR(255),
-			version BIGINT,
-			response JSONB,
-			error TEXT,
-			success BOOLEAN NOT NULL DEFAULT false,
-			processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			expires_at TIMESTAMPTZ NOT NULL
-		);
-
-		CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+s.table+"_expires_at") + ` ON ` + tableQ + ` (expires_at);
-		CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+s.table+"_processed_at") + ` ON ` + tableQ + ` (processed_at);
-	`
-
-	_, err := s.db.ExecContext(ctx, query)
+	_, err := s.db.ExecContext(ctx, joinSQLStatements(idempotencySchemaStatements(s.schema, s.table)))
 	if err != nil {
 		return fmt.Errorf("mink/postgres/idempotency: failed to create table: %w", err)
 	}

--- a/adapters/postgres/outbox_store.go
+++ b/adapters/postgres/outbox_store.go
@@ -77,30 +77,7 @@ func (s *OutboxStore) Initialize(ctx context.Context) error {
 		return err
 	}
 
-	tableQ := s.fullTableName()
-	query := `
-		CREATE TABLE IF NOT EXISTS ` + tableQ + ` (
-			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-			aggregate_id VARCHAR(255) NOT NULL,
-			event_type VARCHAR(255) NOT NULL,
-			destination VARCHAR(255) NOT NULL,
-			payload JSONB NOT NULL,
-			headers JSONB DEFAULT '{}',
-			status INT NOT NULL DEFAULT 0,
-			attempts INT NOT NULL DEFAULT 0,
-			max_attempts INT NOT NULL DEFAULT 5,
-			last_error TEXT,
-			scheduled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			last_attempt_at TIMESTAMPTZ,
-			processed_at TIMESTAMPTZ,
-			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		);
-
-		CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+s.table+"_pending") + ` ON ` + tableQ + ` (scheduled_at) WHERE status = 0;
-		CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+s.table+"_dead_letter") + ` ON ` + tableQ + ` (created_at) WHERE status = 4;
-	`
-
-	_, err := s.db.ExecContext(ctx, query)
+	_, err := s.db.ExecContext(ctx, joinSQLStatements(outboxSchemaStatements(s.schema, s.table)))
 	if err != nil {
 		return fmt.Errorf("mink/postgres/outbox: failed to create table: %w", err)
 	}

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -300,6 +300,7 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.checkpoints (
 			projection_name VARCHAR(500) PRIMARY KEY,
 			position        BIGINT NOT NULL DEFAULT 0,
+			status          VARCHAR(50) DEFAULT 'active',
 			updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`
 
@@ -1116,47 +1117,82 @@ func (a *PostgresAdapter) ExecuteSQL(ctx context.Context, sql string) error {
 
 // GenerateSchema returns the DDL for the PostgreSQL event store schema.
 func (a *PostgresAdapter) GenerateSchema(projectName, tableName, snapshotTableName, outboxTableName string) string {
-	return fmt.Sprintf(`-- Mink Event Store Schema (PostgreSQL)
+	return GenerateSchema(projectName, a.schema, tableName, snapshotTableName, outboxTableName)
+}
+
+// GenerateSchema returns PostgreSQL DDL aligned with the runtime adapter schema.
+func GenerateSchema(projectName, schemaName, tableName, snapshotTableName, outboxTableName string) string {
+	if schemaName == "" {
+		schemaName = "mink"
+	}
+	if tableName == "" {
+		tableName = "events"
+	}
+	if snapshotTableName == "" {
+		snapshotTableName = "snapshots"
+	}
+	if outboxTableName == "" {
+		outboxTableName = "mink_outbox"
+	}
+
+	schemaQ := quoteIdentifier(schemaName)
+	streamsTable := quoteQualifiedTable(schemaName, "streams")
+	eventsTable := quoteQualifiedTable(schemaName, tableName)
+	snapshotsTable := quoteQualifiedTable(schemaName, snapshotTableName)
+	checkpointsTable := quoteQualifiedTable(schemaName, "checkpoints")
+	migrationsTable := quoteQualifiedTable(schemaName, "migrations")
+	outboxTable := quoteQualifiedTable(schemaName, outboxTableName)
+	idempotencyTable := quoteQualifiedTable(schemaName, "mink_idempotency")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, `-- Mink Event Store Schema (PostgreSQL)
 -- Generated for: %s
+
+CREATE SCHEMA IF NOT EXISTS %s;
+
+-- Streams table
+CREATE TABLE IF NOT EXISTS %s (
+    id BIGSERIAL PRIMARY KEY,
+    stream_id VARCHAR(500) NOT NULL UNIQUE,
+    category VARCHAR(250) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS %s ON %s (category);
 
 -- Events table
 CREATE TABLE IF NOT EXISTS %s (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    stream_id VARCHAR(255) NOT NULL,
+    global_position BIGSERIAL PRIMARY KEY,
+    stream_id VARCHAR(500) NOT NULL,
     version BIGINT NOT NULL,
-    type VARCHAR(255) NOT NULL,
+    event_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    event_type VARCHAR(500) NOT NULL,
     data JSONB NOT NULL,
-    metadata JSONB DEFAULT '{}',
-    global_position BIGSERIAL,
-    timestamp TIMESTAMPTZ DEFAULT NOW(),
+    metadata JSONB,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE(stream_id, version)
 );
 
--- Indexes for events
-CREATE INDEX IF NOT EXISTS idx_%s_stream_id ON %s(stream_id, version);
-CREATE INDEX IF NOT EXISTS idx_%s_global_position ON %s(global_position);
-CREATE INDEX IF NOT EXISTS idx_%s_type ON %s(type);
-CREATE INDEX IF NOT EXISTS idx_%s_timestamp ON %s(timestamp);
+CREATE INDEX IF NOT EXISTS %s ON %s (stream_id, version);
+CREATE INDEX IF NOT EXISTS %s ON %s (event_type);
+CREATE INDEX IF NOT EXISTS %s ON %s (timestamp);
 
 -- Snapshots table
 CREATE TABLE IF NOT EXISTS %s (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    stream_id VARCHAR(255) NOT NULL,
+    stream_id VARCHAR(500) PRIMARY KEY,
     version BIGINT NOT NULL,
-    type VARCHAR(255) NOT NULL,
-    data JSONB NOT NULL,
-    timestamp TIMESTAMPTZ DEFAULT NOW(),
-    UNIQUE(stream_id)
+    data BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_%s_stream_id ON %s(stream_id);
-
 -- Projection checkpoints
-CREATE TABLE IF NOT EXISTS mink_checkpoints (
-    projection_name VARCHAR(255) PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS %s (
+    projection_name VARCHAR(500) PRIMARY KEY,
     position BIGINT NOT NULL DEFAULT 0,
     status VARCHAR(50) DEFAULT 'active',
-    updated_at TIMESTAMPTZ DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 -- Outbox table (transactional outbox for reliable messaging)
@@ -1177,125 +1213,62 @@ CREATE TABLE IF NOT EXISTS %s (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Partial index for efficient polling of pending messages
-CREATE INDEX IF NOT EXISTS idx_%s_pending ON %s(scheduled_at) WHERE status = 0;
--- Index for dead letter queries
-CREATE INDEX IF NOT EXISTS idx_%s_dead_letter ON %s(created_at) WHERE status = 4;
+CREATE INDEX IF NOT EXISTS %s ON %s (scheduled_at) WHERE status = 0;
+CREATE INDEX IF NOT EXISTS %s ON %s (created_at) WHERE status = 4;
 
 -- Migrations tracking
-CREATE TABLE IF NOT EXISTS mink_migrations (
+CREATE TABLE IF NOT EXISTS %s (
     name VARCHAR(255) PRIMARY KEY,
     applied_at TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Idempotency keys
-CREATE TABLE IF NOT EXISTS mink_idempotency (
+CREATE TABLE IF NOT EXISTS %s (
     key VARCHAR(255) PRIMARY KEY,
-    result JSONB,
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    expires_at TIMESTAMPTZ
+    command_type VARCHAR(255) NOT NULL,
+    aggregate_id VARCHAR(255),
+    version BIGINT,
+    response JSONB,
+    error TEXT,
+    success BOOLEAN NOT NULL DEFAULT false,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_mink_idempotency_expires ON mink_idempotency(expires_at);
+CREATE INDEX IF NOT EXISTS %s ON %s (expires_at);
+CREATE INDEX IF NOT EXISTS %s ON %s (processed_at);
 
--- Function for appending events with optimistic concurrency
-CREATE OR REPLACE FUNCTION mink_append_events(
-    p_stream_id VARCHAR(255),
-    p_expected_version BIGINT,
-    p_events JSONB
-) RETURNS TABLE(
-    id UUID,
-    stream_id VARCHAR(255),
-    version BIGINT,
-    type VARCHAR(255),
-    data JSONB,
-    metadata JSONB,
-    global_position BIGINT,
-    timestamp TIMESTAMPTZ
-) AS $$
-DECLARE
-    v_current_version BIGINT;
-    v_event JSONB;
-    v_version BIGINT;
-BEGIN
-    -- Lock and get current version
-    SELECT COALESCE(MAX(e.version), 0) INTO v_current_version
-    FROM %s e
-    WHERE e.stream_id = p_stream_id
-    FOR UPDATE;
-
-    -- Check expected version
-    -- -1 = AnyVersion, 0 = NoStream, -2 = StreamExists
-    IF p_expected_version >= 0 AND v_current_version != p_expected_version THEN
-        RAISE EXCEPTION 'mink: concurrency conflict on stream %% expected %% got %%',
-            p_stream_id, p_expected_version, v_current_version;
-    ELSIF p_expected_version = 0 AND v_current_version > 0 THEN
-        RAISE EXCEPTION 'mink: stream %% already exists', p_stream_id;
-    ELSIF p_expected_version = -2 AND v_current_version = 0 THEN
-        RAISE EXCEPTION 'mink: stream %% does not exist', p_stream_id;
-    END IF;
-
-    v_version := v_current_version;
-
-    -- Insert events
-    FOR v_event IN SELECT * FROM jsonb_array_elements(p_events)
-    LOOP
-        v_version := v_version + 1;
-
-        INSERT INTO %s (stream_id, version, type, data, metadata)
-        VALUES (
-            p_stream_id,
-            v_version,
-            v_event->>'type',
-            v_event->'data',
-            COALESCE(v_event->'metadata', '{}'::jsonb)
-        )
-        RETURNING
-            %s.id,
-            %s.stream_id,
-            %s.version,
-            %s.type,
-            %s.data,
-            %s.metadata,
-            %s.global_position,
-            %s.timestamp
-        INTO id, stream_id, version, type, data, metadata, global_position, timestamp;
-
-        RETURN NEXT;
-    END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
+COMMENT ON TABLE %s IS 'Mink event store streams';
 COMMENT ON TABLE %s IS 'Mink event store - immutable event log';
 COMMENT ON TABLE %s IS 'Aggregate snapshots for optimization';
-COMMENT ON TABLE mink_checkpoints IS 'Projection checkpoint positions';
+COMMENT ON TABLE %s IS 'Projection checkpoint positions';
 COMMENT ON TABLE %s IS 'Transactional outbox for reliable messaging';
 `,
 		projectName,
-		tableName,
-		tableName, tableName,
-		tableName, tableName,
-		tableName, tableName,
-		tableName, tableName,
-		snapshotTableName,
-		snapshotTableName, snapshotTableName,
-		outboxTableName,
-		outboxTableName, outboxTableName,
-		outboxTableName, outboxTableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		tableName,
-		snapshotTableName,
-		outboxTableName,
+		schemaQ,
+		streamsTable,
+		quoteIdentifier("idx_streams_category"), streamsTable,
+		eventsTable,
+		quoteIdentifier("idx_"+tableName+"_stream"), eventsTable,
+		quoteIdentifier("idx_"+tableName+"_type"), eventsTable,
+		quoteIdentifier("idx_"+tableName+"_timestamp"), eventsTable,
+		snapshotsTable,
+		checkpointsTable,
+		outboxTable,
+		quoteIdentifier("idx_"+outboxTableName+"_pending"), outboxTable,
+		quoteIdentifier("idx_"+outboxTableName+"_dead_letter"), outboxTable,
+		migrationsTable,
+		idempotencyTable,
+		quoteIdentifier("idx_mink_idempotency_expires_at"), idempotencyTable,
+		quoteIdentifier("idx_mink_idempotency_processed_at"), idempotencyTable,
+		streamsTable,
+		eventsTable,
+		snapshotsTable,
+		checkpointsTable,
+		outboxTable,
 	)
+
+	return b.String()
 }
 
 // ============================================================================
@@ -1344,15 +1317,21 @@ func (a *PostgresAdapter) CheckSchema(ctx context.Context, tableName string) (*a
 	}
 
 	result := &adapters.SchemaCheckResult{}
+	tableSchema := a.schema
+	if strings.Contains(tableName, ".") {
+		parts := strings.SplitN(tableName, ".", 2)
+		tableSchema = strings.Trim(parts[0], `"`)
+		tableName = strings.Trim(parts[1], `"`)
+	}
 
 	// Check if events table exists
 	var exists bool
 	err := a.db.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1 FROM information_schema.tables 
-			WHERE table_name = $1
+			WHERE table_schema = $1 AND table_name = $2
 		)
-	`, tableName).Scan(&exists)
+	`, tableSchema, tableName).Scan(&exists)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to check schema: %w", err)
@@ -1365,9 +1344,8 @@ func (a *PostgresAdapter) CheckSchema(ctx context.Context, tableName string) (*a
 		return result, nil
 	}
 
-	// Count events - use quoted identifier if needed
 	var count int64
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteIdentifier(tableName))
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteQualifiedTable(tableSchema, tableName))
 	err = a.db.QueryRowContext(ctx, query).Scan(&count)
 	if err != nil {
 		result.Message = fmt.Sprintf("Table exists but couldn't count events: %v", err)
@@ -1393,9 +1371,9 @@ func (a *PostgresAdapter) GetProjectionHealth(ctx context.Context) (*adapters.Pr
 	err := a.db.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1 FROM information_schema.tables 
-			WHERE table_name = 'mink_checkpoints'
+			WHERE table_schema = $1 AND table_name = 'checkpoints'
 		)
-	`).Scan(&exists)
+	`, a.schema).Scan(&exists)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to check checkpoints table: %w", err)
@@ -1407,7 +1385,8 @@ func (a *PostgresAdapter) GetProjectionHealth(ctx context.Context) (*adapters.Pr
 	}
 
 	// Count total projections
-	err = a.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM mink_checkpoints").Scan(&result.TotalProjections)
+	checkpointsTable := quoteQualifiedTable(a.schema, "checkpoints")
+	err = a.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", checkpointsTable)).Scan(&result.TotalProjections)
 	if err != nil {
 		return nil, fmt.Errorf("failed to count projections: %w", err)
 	}
@@ -1425,7 +1404,7 @@ func (a *PostgresAdapter) GetProjectionHealth(ctx context.Context) (*adapters.Pr
 	// Count projections behind
 	if result.MaxPosition > 0 {
 		err = a.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM mink_checkpoints WHERE position < $1",
+			fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE position < $1", checkpointsTable),
 			result.MaxPosition,
 		).Scan(&result.ProjectionsBehind)
 		if err != nil {

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -220,34 +220,34 @@ func (a *PostgresAdapter) Initialize(ctx context.Context) error {
 
 // Migrate runs database migrations.
 func (a *PostgresAdapter) Migrate(ctx context.Context) error {
-	// Use pre-validated schemaQ from constructor
-	schemaQ := a.schemaQ
-
-	// Create schema
-	_, err := a.db.ExecContext(ctx, `CREATE SCHEMA IF NOT EXISTS `+schemaQ)
-	if err != nil {
-		return fmt.Errorf("mink/postgres: failed to create schema: %w", err)
+	for _, stmt := range eventStoreSchemaStatements(a.schema, "events", "snapshots") {
+		if _, err := a.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("mink/postgres: failed to initialize schema: %w", err)
+		}
 	}
 
-	// Create streams table
-	streamsSQL := `
-		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.streams (
+	return nil
+}
+
+func eventStoreSchemaStatements(schemaName, tableName, snapshotTableName string) []string {
+	schemaQ := quoteIdentifier(schemaName)
+	streamsTable := quoteQualifiedTable(schemaName, "streams")
+	eventsTable := quoteQualifiedTable(schemaName, tableName)
+	snapshotsTable := quoteQualifiedTable(schemaName, snapshotTableName)
+	checkpointsTable := quoteQualifiedTable(schemaName, "checkpoints")
+
+	return []string{
+		`CREATE SCHEMA IF NOT EXISTS ` + schemaQ,
+		`CREATE TABLE IF NOT EXISTS ` + streamsTable + ` (
 			id              BIGSERIAL PRIMARY KEY,
 			stream_id       VARCHAR(500) NOT NULL UNIQUE,
 			category        VARCHAR(250) NOT NULL,
 			version         BIGINT NOT NULL DEFAULT 0,
 			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`
-
-	_, err = a.db.ExecContext(ctx, streamsSQL)
-	if err != nil {
-		return fmt.Errorf("mink/postgres: failed to create streams table: %w", err)
-	}
-
-	// Create events table
-	eventsSQL := `
-		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.events (
+		)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_streams_category") + ` ON ` + streamsTable + ` (category)`,
+		`CREATE TABLE IF NOT EXISTS ` + eventsTable + ` (
 			global_position BIGSERIAL PRIMARY KEY,
 			stream_id       VARCHAR(500) NOT NULL,
 			version         BIGINT NOT NULL,
@@ -257,59 +257,88 @@ func (a *PostgresAdapter) Migrate(ctx context.Context) error {
 			metadata        JSONB,
 			timestamp       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			UNIQUE(stream_id, version)
-		)`
-
-	_, err = a.db.ExecContext(ctx, eventsSQL)
-	if err != nil {
-		return fmt.Errorf("mink/postgres: failed to create events table: %w", err)
-	}
-
-	// Create indexes
-	streamsTableQ := quoteQualifiedTable(a.schema, "streams")
-	eventsTableQ := quoteQualifiedTable(a.schema, "events")
-	indexes := []string{
-		`CREATE INDEX IF NOT EXISTS idx_streams_category ON ` + streamsTableQ + `(category)`,
-		`CREATE INDEX IF NOT EXISTS idx_events_stream ON ` + eventsTableQ + `(stream_id, version)`,
-		`CREATE INDEX IF NOT EXISTS idx_events_type ON ` + eventsTableQ + `(event_type)`,
-		`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON ` + eventsTableQ + `(timestamp)`,
-	}
-
-	for _, idx := range indexes {
-		_, err = a.db.ExecContext(ctx, idx)
-		if err != nil {
-			return fmt.Errorf("mink/postgres: failed to create index: %w", err)
-		}
-	}
-
-	// Create snapshots table
-	snapshotsSQL := `
-		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.snapshots (
+		)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_stream") + ` ON ` + eventsTable + ` (stream_id, version)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_type") + ` ON ` + eventsTable + ` (event_type)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_timestamp") + ` ON ` + eventsTable + ` (timestamp)`,
+		`CREATE TABLE IF NOT EXISTS ` + snapshotsTable + ` (
 			stream_id       VARCHAR(500) PRIMARY KEY,
 			version         BIGINT NOT NULL,
 			data            BYTEA NOT NULL,
 			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`
-
-	_, err = a.db.ExecContext(ctx, snapshotsSQL)
-	if err != nil {
-		return fmt.Errorf("mink/postgres: failed to create snapshots table: %w", err)
-	}
-
-	// Create checkpoints table
-	checkpointsSQL := `
-		CREATE TABLE IF NOT EXISTS ` + schemaQ + `.checkpoints (
+		)`,
+		`CREATE TABLE IF NOT EXISTS ` + checkpointsTable + ` (
 			projection_name VARCHAR(500) PRIMARY KEY,
 			position        BIGINT NOT NULL DEFAULT 0,
 			status          VARCHAR(50) DEFAULT 'active',
 			updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`
-
-	_, err = a.db.ExecContext(ctx, checkpointsSQL)
-	if err != nil {
-		return fmt.Errorf("mink/postgres: failed to create checkpoints table: %w", err)
+		)`,
 	}
+}
 
-	return nil
+func migrationSchemaStatements(schemaName string) []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS ` + quoteQualifiedTable(schemaName, "migrations") + ` (
+			name VARCHAR(255) PRIMARY KEY,
+			applied_at TIMESTAMPTZ DEFAULT NOW()
+		)`,
+	}
+}
+
+func outboxSchemaStatements(schemaName, tableName string) []string {
+	tableQ := quoteQualifiedTable(schemaName, tableName)
+	return []string{
+		`CREATE TABLE IF NOT EXISTS ` + tableQ + ` (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			aggregate_id VARCHAR(255) NOT NULL,
+			event_type VARCHAR(255) NOT NULL,
+			destination VARCHAR(255) NOT NULL,
+			payload JSONB NOT NULL,
+			headers JSONB DEFAULT '{}',
+			status INT NOT NULL DEFAULT 0,
+			attempts INT NOT NULL DEFAULT 0,
+			max_attempts INT NOT NULL DEFAULT 5,
+			last_error TEXT,
+			scheduled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			last_attempt_at TIMESTAMPTZ,
+			processed_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_pending") + ` ON ` + tableQ + ` (scheduled_at) WHERE status = 0`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_dead_letter") + ` ON ` + tableQ + ` (created_at) WHERE status = 4`,
+	}
+}
+
+func idempotencySchemaStatements(schemaName, tableName string) []string {
+	tableQ := quoteQualifiedTable(schemaName, tableName)
+	return []string{
+		`CREATE TABLE IF NOT EXISTS ` + tableQ + ` (
+			key VARCHAR(255) PRIMARY KEY,
+			command_type VARCHAR(255) NOT NULL,
+			aggregate_id VARCHAR(255),
+			version BIGINT,
+			response JSONB,
+			error TEXT,
+			success BOOLEAN NOT NULL DEFAULT false,
+			processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			expires_at TIMESTAMPTZ NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_expires_at") + ` ON ` + tableQ + ` (expires_at)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_processed_at") + ` ON ` + tableQ + ` (processed_at)`,
+	}
+}
+
+func appendSQLStatements(b *strings.Builder, statements []string) {
+	for _, stmt := range statements {
+		b.WriteString(stmt)
+		b.WriteString(";\n\n")
+	}
+}
+
+func joinSQLStatements(statements []string) string {
+	var b strings.Builder
+	appendSQLStatements(&b, statements)
+	return b.String()
 }
 
 // MigrationVersion returns the current migration version.
@@ -1042,15 +1071,10 @@ func (a *PostgresAdapter) GetAppliedMigrations(ctx context.Context) ([]string, e
 	}
 
 	schemaQ := a.schemaQ
-	// Ensure migrations table exists
-	_, err := a.db.ExecContext(ctx, `
-		CREATE TABLE IF NOT EXISTS `+schemaQ+`.migrations (
-			name VARCHAR(255) PRIMARY KEY,
-			applied_at TIMESTAMPTZ DEFAULT NOW()
-		)
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("mink/postgres: failed to create migrations table: %w", err)
+	for _, stmt := range migrationSchemaStatements(a.schema) {
+		if _, err := a.db.ExecContext(ctx, stmt); err != nil {
+			return nil, fmt.Errorf("mink/postgres: failed to create migrations table: %w", err)
+		}
 	}
 
 	rows, err := a.db.QueryContext(ctx, "SELECT name FROM "+schemaQ+".migrations ORDER BY name")
@@ -1135,138 +1159,25 @@ func GenerateSchema(projectName, schemaName, tableName, snapshotTableName, outbo
 		outboxTableName = "mink_outbox"
 	}
 
-	schemaQ := quoteIdentifier(schemaName)
-	streamsTable := quoteQualifiedTable(schemaName, "streams")
-	eventsTable := quoteQualifiedTable(schemaName, tableName)
-	snapshotsTable := quoteQualifiedTable(schemaName, snapshotTableName)
-	checkpointsTable := quoteQualifiedTable(schemaName, "checkpoints")
-	migrationsTable := quoteQualifiedTable(schemaName, "migrations")
-	outboxTable := quoteQualifiedTable(schemaName, outboxTableName)
-	idempotencyTable := quoteQualifiedTable(schemaName, "mink_idempotency")
-
 	var b strings.Builder
 	fmt.Fprintf(&b, `-- Mink Event Store Schema (PostgreSQL)
 -- Generated for: %s
 
-CREATE SCHEMA IF NOT EXISTS %s;
-
--- Streams table
-CREATE TABLE IF NOT EXISTS %s (
-    id BIGSERIAL PRIMARY KEY,
-    stream_id VARCHAR(500) NOT NULL UNIQUE,
-    category VARCHAR(250) NOT NULL,
-    version BIGINT NOT NULL DEFAULT 0,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS %s ON %s (category);
-
--- Events table
-CREATE TABLE IF NOT EXISTS %s (
-    global_position BIGSERIAL PRIMARY KEY,
-    stream_id VARCHAR(500) NOT NULL,
-    version BIGINT NOT NULL,
-    event_id UUID NOT NULL DEFAULT gen_random_uuid(),
-    event_type VARCHAR(500) NOT NULL,
-    data JSONB NOT NULL,
-    metadata JSONB,
-    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE(stream_id, version)
-);
-
-CREATE INDEX IF NOT EXISTS %s ON %s (stream_id, version);
-CREATE INDEX IF NOT EXISTS %s ON %s (event_type);
-CREATE INDEX IF NOT EXISTS %s ON %s (timestamp);
-
--- Snapshots table
-CREATE TABLE IF NOT EXISTS %s (
-    stream_id VARCHAR(500) PRIMARY KEY,
-    version BIGINT NOT NULL,
-    data BYTEA NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
--- Projection checkpoints
-CREATE TABLE IF NOT EXISTS %s (
-    projection_name VARCHAR(500) PRIMARY KEY,
-    position BIGINT NOT NULL DEFAULT 0,
-    status VARCHAR(50) DEFAULT 'active',
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
--- Outbox table (transactional outbox for reliable messaging)
-CREATE TABLE IF NOT EXISTS %s (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    aggregate_id VARCHAR(255) NOT NULL,
-    event_type VARCHAR(255) NOT NULL,
-    destination VARCHAR(255) NOT NULL,
-    payload JSONB NOT NULL,
-    headers JSONB DEFAULT '{}',
-    status INT NOT NULL DEFAULT 0,
-    attempts INT NOT NULL DEFAULT 0,
-    max_attempts INT NOT NULL DEFAULT 5,
-    last_error TEXT,
-    scheduled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    last_attempt_at TIMESTAMPTZ,
-    processed_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS %s ON %s (scheduled_at) WHERE status = 0;
-CREATE INDEX IF NOT EXISTS %s ON %s (created_at) WHERE status = 4;
-
--- Migrations tracking
-CREATE TABLE IF NOT EXISTS %s (
-    name VARCHAR(255) PRIMARY KEY,
-    applied_at TIMESTAMPTZ DEFAULT NOW()
-);
-
--- Idempotency keys
-CREATE TABLE IF NOT EXISTS %s (
-    key VARCHAR(255) PRIMARY KEY,
-    command_type VARCHAR(255) NOT NULL,
-    aggregate_id VARCHAR(255),
-    version BIGINT,
-    response JSONB,
-    error TEXT,
-    success BOOLEAN NOT NULL DEFAULT false,
-    processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    expires_at TIMESTAMPTZ NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS %s ON %s (expires_at);
-CREATE INDEX IF NOT EXISTS %s ON %s (processed_at);
-
-COMMENT ON TABLE %s IS 'Mink event store streams';
-COMMENT ON TABLE %s IS 'Mink event store - immutable event log';
-COMMENT ON TABLE %s IS 'Aggregate snapshots for optimization';
-COMMENT ON TABLE %s IS 'Projection checkpoint positions';
-COMMENT ON TABLE %s IS 'Transactional outbox for reliable messaging';
 `,
 		projectName,
-		schemaQ,
-		streamsTable,
-		quoteIdentifier("idx_streams_category"), streamsTable,
-		eventsTable,
-		quoteIdentifier("idx_"+tableName+"_stream"), eventsTable,
-		quoteIdentifier("idx_"+tableName+"_type"), eventsTable,
-		quoteIdentifier("idx_"+tableName+"_timestamp"), eventsTable,
-		snapshotsTable,
-		checkpointsTable,
-		outboxTable,
-		quoteIdentifier("idx_"+outboxTableName+"_pending"), outboxTable,
-		quoteIdentifier("idx_"+outboxTableName+"_dead_letter"), outboxTable,
-		migrationsTable,
-		idempotencyTable,
-		quoteIdentifier("idx_mink_idempotency_expires_at"), idempotencyTable,
-		quoteIdentifier("idx_mink_idempotency_processed_at"), idempotencyTable,
-		streamsTable,
-		eventsTable,
-		snapshotsTable,
-		checkpointsTable,
-		outboxTable,
 	)
+
+	appendSQLStatements(&b, eventStoreSchemaStatements(schemaName, tableName, snapshotTableName))
+	appendSQLStatements(&b, outboxSchemaStatements(schemaName, outboxTableName))
+	appendSQLStatements(&b, migrationSchemaStatements(schemaName))
+	appendSQLStatements(&b, idempotencySchemaStatements(schemaName, "mink_idempotency"))
+	appendSQLStatements(&b, []string{
+		fmt.Sprintf("COMMENT ON TABLE %s IS 'Mink event store streams'", quoteQualifiedTable(schemaName, "streams")),
+		fmt.Sprintf("COMMENT ON TABLE %s IS 'Mink event store - immutable event log'", quoteQualifiedTable(schemaName, tableName)),
+		fmt.Sprintf("COMMENT ON TABLE %s IS 'Aggregate snapshots for optimization'", quoteQualifiedTable(schemaName, snapshotTableName)),
+		fmt.Sprintf("COMMENT ON TABLE %s IS 'Projection checkpoint positions'", quoteQualifiedTable(schemaName, "checkpoints")),
+		fmt.Sprintf("COMMENT ON TABLE %s IS 'Transactional outbox for reliable messaging'", quoteQualifiedTable(schemaName, outboxTableName)),
+	})
 
 	return b.String()
 }

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1501,9 +1501,45 @@ func TestPostgresAdapter_GenerateSchema(t *testing.T) {
 	t.Run("generates schema SQL", func(t *testing.T) {
 		schema := adapter.GenerateSchema("test-project", "events", "snapshots", "outbox")
 		assert.Contains(t, schema, "CREATE TABLE")
-		assert.Contains(t, schema, "events")
+		assert.Contains(t, schema, `CREATE SCHEMA IF NOT EXISTS "mink"`)
+		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."streams"`)
+		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."events"`)
+		assert.Contains(t, schema, `global_position BIGSERIAL PRIMARY KEY`)
+		assert.Contains(t, schema, `event_id UUID NOT NULL DEFAULT gen_random_uuid()`)
+		assert.Contains(t, schema, `event_type VARCHAR(500) NOT NULL`)
+		assert.Contains(t, schema, `metadata JSONB`)
+		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."snapshots"`)
+		assert.Contains(t, schema, `data BYTEA NOT NULL`)
+		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."checkpoints"`)
+		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."migrations"`)
+		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."mink_idempotency"`)
+		assert.NotContains(t, schema, "    type VARCHAR")
+		assert.NotContains(t, schema, "mink_checkpoints")
+		assert.NotContains(t, schema, "mink_append_events")
 		assert.Contains(t, schema, "test-project")
 	})
+}
+
+func TestGenerateSchema(t *testing.T) {
+	schema := GenerateSchema("test-project", "mink", "events", "snapshots", "mink_outbox")
+
+	assert.Contains(t, schema, "CREATE TABLE")
+	assert.Contains(t, schema, `CREATE SCHEMA IF NOT EXISTS "mink"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."streams"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."events"`)
+	assert.Contains(t, schema, `global_position BIGSERIAL PRIMARY KEY`)
+	assert.Contains(t, schema, `event_id UUID NOT NULL DEFAULT gen_random_uuid()`)
+	assert.Contains(t, schema, `event_type VARCHAR(500) NOT NULL`)
+	assert.Contains(t, schema, `metadata JSONB`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."snapshots"`)
+	assert.Contains(t, schema, `data BYTEA NOT NULL`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."checkpoints"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."migrations"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."mink_idempotency"`)
+	assert.NotContains(t, schema, "    type VARCHAR")
+	assert.NotContains(t, schema, "mink_checkpoints")
+	assert.NotContains(t, schema, "mink_append_events")
+	assert.Contains(t, schema, "test-project")
 }
 
 func TestPostgresAdapter_GetDiagnosticInfo(t *testing.T) {
@@ -1538,15 +1574,6 @@ func TestPostgresAdapter_GetProjectionHealth(t *testing.T) {
 	})
 
 	t.Run("returns health with projections behind", func(t *testing.T) {
-		// Create checkpoints table if it doesn't exist
-		_, _ = adapter.db.ExecContext(ctx, `
-			CREATE TABLE IF NOT EXISTS mink_checkpoints (
-				name VARCHAR(255) PRIMARY KEY,
-				position BIGINT NOT NULL DEFAULT 0,
-				updated_at TIMESTAMPTZ DEFAULT NOW()
-			)
-		`)
-
 		// Use a unique stream name
 		streamID := fmt.Sprintf("health-test-stream-%d", time.Now().UnixNano())
 
@@ -1558,8 +1585,9 @@ func TestPostgresAdapter_GetProjectionHealth(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a checkpoint that is behind
+		checkpointsTable := quoteQualifiedTable(adapter.schema, "checkpoints")
 		_, err = adapter.db.ExecContext(ctx,
-			"INSERT INTO mink_checkpoints (name, position, updated_at) VALUES ($1, $2, NOW()) ON CONFLICT (name) DO UPDATE SET position = $2",
+			fmt.Sprintf("INSERT INTO %s (projection_name, position, updated_at) VALUES ($1, $2, NOW()) ON CONFLICT (projection_name) DO UPDATE SET position = $2", checkpointsTable),
 			"health_test_projection", 0)
 		require.NoError(t, err)
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1500,46 +1500,35 @@ func TestPostgresAdapter_GenerateSchema(t *testing.T) {
 
 	t.Run("generates schema SQL", func(t *testing.T) {
 		schema := adapter.GenerateSchema("test-project", "events", "snapshots", "outbox")
-		assert.Contains(t, schema, "CREATE TABLE")
-		assert.Contains(t, schema, `CREATE SCHEMA IF NOT EXISTS "mink"`)
-		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."streams"`)
-		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."events"`)
-		assert.Contains(t, schema, `global_position BIGSERIAL PRIMARY KEY`)
-		assert.Contains(t, schema, `event_id UUID NOT NULL DEFAULT gen_random_uuid()`)
-		assert.Contains(t, schema, `event_type VARCHAR(500) NOT NULL`)
-		assert.Contains(t, schema, `metadata JSONB`)
-		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."snapshots"`)
-		assert.Contains(t, schema, `data BYTEA NOT NULL`)
-		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."checkpoints"`)
-		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."migrations"`)
-		assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."mink_idempotency"`)
-		assert.NotContains(t, schema, "    type VARCHAR")
-		assert.NotContains(t, schema, "mink_checkpoints")
-		assert.NotContains(t, schema, "mink_append_events")
+		assertRuntimeSchemaDDL(t, schema)
 		assert.Contains(t, schema, "test-project")
 	})
 }
 
 func TestGenerateSchema(t *testing.T) {
 	schema := GenerateSchema("test-project", "mink", "events", "snapshots", "mink_outbox")
+	assertRuntimeSchemaDDL(t, schema)
+	assert.Contains(t, schema, "test-project")
+}
 
+func assertRuntimeSchemaDDL(t *testing.T, schema string) {
+	t.Helper()
 	assert.Contains(t, schema, "CREATE TABLE")
 	assert.Contains(t, schema, `CREATE SCHEMA IF NOT EXISTS "mink"`)
 	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."streams"`)
 	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."events"`)
 	assert.Contains(t, schema, `global_position BIGSERIAL PRIMARY KEY`)
-	assert.Contains(t, schema, `event_id UUID NOT NULL DEFAULT gen_random_uuid()`)
-	assert.Contains(t, schema, `event_type VARCHAR(500) NOT NULL`)
-	assert.Contains(t, schema, `metadata JSONB`)
+	assert.Contains(t, schema, `event_id`)
+	assert.Contains(t, schema, `event_type`)
+	assert.Contains(t, schema, `metadata`)
 	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."snapshots"`)
-	assert.Contains(t, schema, `data BYTEA NOT NULL`)
+	assert.Contains(t, schema, `BYTEA NOT NULL`)
 	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."checkpoints"`)
 	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."migrations"`)
 	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."mink_idempotency"`)
 	assert.NotContains(t, schema, "    type VARCHAR")
 	assert.NotContains(t, schema, "mink_checkpoints")
 	assert.NotContains(t, schema, "mink_append_events")
-	assert.Contains(t, schema, "test-project")
 }
 
 func TestPostgresAdapter_GetDiagnosticInfo(t *testing.T) {

--- a/cli/commands/adapter.go
+++ b/cli/commands/adapter.go
@@ -49,7 +49,12 @@ func (f *AdapterFactory) CreateAdapter(ctx context.Context) (CLIAdapter, error) 
 
 	switch f.config.Database.Driver {
 	case "postgres", "postgresql":
-		adapter, err := postgres.NewAdapter(f.dbURL)
+		opts := make([]postgres.Option, 0, 1)
+		if f.config.Database.Schema != "" {
+			opts = append(opts, postgres.WithSchema(f.config.Database.Schema))
+		}
+
+		adapter, err := postgres.NewAdapter(f.dbURL, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create postgres adapter: %w", err)
 		}

--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -633,6 +633,8 @@ func TestGenerateSchema(t *testing.T) {
 	assert.Contains(t, schema, "my_outbox")
 	assert.Contains(t, schema, "CREATE TABLE")
 	assert.Contains(t, schema, "CREATE INDEX")
+	assert.Contains(t, schema, `event_type VARCHAR(500) NOT NULL`)
+	assert.NotContains(t, schema, "    type VARCHAR")
 }
 
 func TestExecute(t *testing.T) {
@@ -732,10 +734,11 @@ func TestGenerateSchemaContent(t *testing.T) {
 	assert.Contains(t, schema, "my_events")
 	assert.Contains(t, schema, "my_snapshots")
 	assert.Contains(t, schema, "my_outbox")
-	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS my_events")
-	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS my_snapshots")
-	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS mink_checkpoints")
-	assert.Contains(t, schema, "CREATE TABLE IF NOT EXISTS my_outbox")
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."streams"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."my_events"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."my_snapshots"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."checkpoints"`)
+	assert.Contains(t, schema, `CREATE TABLE IF NOT EXISTS "mink"."my_outbox"`)
 	assert.Contains(t, schema, "CREATE INDEX")
 }
 
@@ -1298,7 +1301,7 @@ func TestSchemaGenerateCommand_OutputFile(t *testing.T) {
 	content, err := os.ReadFile(outputFile)
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "CREATE TABLE")
-	assert.Contains(t, string(content), "mink_events")
+	assert.Contains(t, string(content), `"mink"."events"`)
 }
 
 func TestSchemaPrintCommand_Execute(t *testing.T) {
@@ -2623,7 +2626,7 @@ func TestGenerateFallbackSchema_Valid(t *testing.T) {
 	cfg := config.DefaultConfig()
 	schema := generateFallbackSchema(cfg)
 	assert.Contains(t, schema, "CREATE TABLE")
-	assert.Contains(t, schema, "mink_events")
+	assert.Contains(t, schema, `"mink"."events"`)
 }
 
 // Test ProjectionInfo struct initialization
@@ -4103,7 +4106,7 @@ func TestProjectionCommands_PostgreSQL_WithData(t *testing.T) {
 		{
 			name:           "list with projection",
 			projectionName: "test-projection",
-			setupSQL: `INSERT INTO mink_checkpoints (projection_name, position, status) 
+			setupSQL: `INSERT INTO mink.checkpoints (projection_name, position, status) 
 				VALUES ('test-projection', 0, 'active')
 				ON CONFLICT (projection_name) DO NOTHING;`,
 			args: []string{"list"},
@@ -4111,7 +4114,7 @@ func TestProjectionCommands_PostgreSQL_WithData(t *testing.T) {
 		{
 			name:           "status for projection",
 			projectionName: "test-status-projection",
-			setupSQL: `INSERT INTO mink_checkpoints (projection_name, position, status) 
+			setupSQL: `INSERT INTO mink.checkpoints (projection_name, position, status) 
 				VALUES ('test-status-projection', 5, 'active')
 				ON CONFLICT (projection_name) DO UPDATE SET position = 5, status = 'active';`,
 			args: []string{"status", "test-status-projection"},
@@ -4119,7 +4122,7 @@ func TestProjectionCommands_PostgreSQL_WithData(t *testing.T) {
 		{
 			name:           "rebuild projection",
 			projectionName: "test-rebuild-projection",
-			setupSQL: `INSERT INTO mink_checkpoints (projection_name, position, status) 
+			setupSQL: `INSERT INTO mink.checkpoints (projection_name, position, status) 
 				VALUES ('test-rebuild-projection', 10, 'active')
 				ON CONFLICT (projection_name) DO UPDATE SET position = 10, status = 'active';`,
 			args: []string{"rebuild", "test-rebuild-projection", "--yes"},
@@ -4158,7 +4161,7 @@ func TestStreamCommands_PostgreSQL_WithData(t *testing.T) {
 	}{
 		{
 			name: "list with events",
-			setupSQL: []string{`INSERT INTO mink_events (stream_id, version, type, data, metadata)
+			setupSQL: []string{`INSERT INTO mink.events (stream_id, version, event_type, data, metadata)
 				VALUES ('test-stream-list', 1, 'TestEvent', '{"test": true}', '{}')
 				ON CONFLICT (stream_id, version) DO NOTHING;`},
 			args: []string{"list"},
@@ -4166,10 +4169,10 @@ func TestStreamCommands_PostgreSQL_WithData(t *testing.T) {
 		{
 			name: "events with stream data",
 			setupSQL: []string{
-				`INSERT INTO mink_events (stream_id, version, type, data, metadata)
+				`INSERT INTO mink.events (stream_id, version, event_type, data, metadata)
 				VALUES ('test-stream-events', 1, 'TestEvent1', '{"order": 1}', '{"correlationId": "123"}')
 				ON CONFLICT (stream_id, version) DO NOTHING;`,
-				`INSERT INTO mink_events (stream_id, version, type, data, metadata)
+				`INSERT INTO mink.events (stream_id, version, event_type, data, metadata)
 				VALUES ('test-stream-events', 2, 'TestEvent2', '{"order": 2}', '{"correlationId": "456"}')
 				ON CONFLICT (stream_id, version) DO NOTHING;`,
 			},
@@ -4178,10 +4181,10 @@ func TestStreamCommands_PostgreSQL_WithData(t *testing.T) {
 		{
 			name: "stats with multiple streams",
 			setupSQL: []string{
-				`INSERT INTO mink_events (stream_id, version, type, data, metadata)
+				`INSERT INTO mink.events (stream_id, version, event_type, data, metadata)
 				VALUES ('stats-stream-1', 1, 'EventType1', '{"data": 1}', '{}')
 				ON CONFLICT (stream_id, version) DO NOTHING;`,
-				`INSERT INTO mink_events (stream_id, version, type, data, metadata)
+				`INSERT INTO mink.events (stream_id, version, event_type, data, metadata)
 				VALUES ('stats-stream-2', 1, 'EventType2', '{"data": 2}', '{}')
 				ON CONFLICT (stream_id, version) DO NOTHING;`,
 			},
@@ -4250,7 +4253,7 @@ func TestProjectionPauseResumeCommands_PostgreSQL(t *testing.T) {
 			if err == nil {
 				defer cleanup()
 				_ = adapter.ExecuteSQL(ctx, fmt.Sprintf(`
-					INSERT INTO mink_checkpoints (projection_name, position, status) 
+					INSERT INTO mink.checkpoints (projection_name, position, status) 
 					VALUES ('%s', 5, '%s')
 					ON CONFLICT (projection_name) DO UPDATE SET status = '%s';
 				`, tt.projectionName, tt.initialStatus, tt.initialStatus))
@@ -4313,7 +4316,7 @@ func TestStreamExportCommand_PostgreSQL_WithEvents(t *testing.T) {
 	if err == nil {
 		defer cleanup()
 		_ = adapter.ExecuteSQL(ctx, `
-			INSERT INTO mink_events (stream_id, version, type, data, metadata)
+			INSERT INTO mink.events (stream_id, version, event_type, data, metadata)
 			VALUES ('export-stream', 1, 'ExportEvent', '{"exported": true}', '{"user": "test"}')
 			ON CONFLICT (stream_id, version) DO NOTHING;
 		`)
@@ -7008,7 +7011,7 @@ func TestSchemaGenerate_ToFile(t *testing.T) {
 
 	content, err := os.ReadFile(outFile)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), "mink_events")
+	assert.Contains(t, string(content), `"mink"."events"`)
 }
 
 // TestSchemaPrint_Memory_AllPaths tests schema print with memory driver

--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -633,7 +633,7 @@ func TestGenerateSchema(t *testing.T) {
 	assert.Contains(t, schema, "my_outbox")
 	assert.Contains(t, schema, "CREATE TABLE")
 	assert.Contains(t, schema, "CREATE INDEX")
-	assert.Contains(t, schema, `event_type VARCHAR(500) NOT NULL`)
+	assert.Contains(t, schema, `event_type`)
 	assert.NotContains(t, schema, "    type VARCHAR")
 }
 

--- a/cli/commands/integration_test.go
+++ b/cli/commands/integration_test.go
@@ -744,9 +744,7 @@ func TestCheckEventStoreSchema_Integration(t *testing.T) {
 	result := checkEventStoreSchema()
 
 	assert.Equal(t, "Event Store Schema", result.Name)
-	// The check may return WARNING if it can't find the legacy mink_events table,
-	// but our test uses mink.events (in mink schema). Either status is acceptable.
-	assert.Contains(t, []CheckStatus{StatusOK, StatusWarning}, result.Status)
+	assert.Equal(t, StatusOK, result.Status)
 }
 
 // Test diagnose projections check

--- a/cli/commands/schema.go
+++ b/cli/commands/schema.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"go-mink.dev/adapters/postgres"
 	"go-mink.dev/cli/config"
 	"go-mink.dev/cli/styles"
 )
@@ -127,93 +128,9 @@ func generateSchemaFromAdapter(ctx context.Context, cfg *config.Config) (string,
 // generateFallbackSchema generates a basic PostgreSQL schema when adapter is not available.
 // This is used when DATABASE_URL is not set but user still wants to see the schema.
 func generateFallbackSchema(cfg *config.Config) string {
-	return fmt.Sprintf(`-- Mink Event Store Schema (PostgreSQL)
--- Generated for: %s
-
--- Events table
-CREATE TABLE IF NOT EXISTS %s (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    stream_id VARCHAR(255) NOT NULL,
-    version BIGINT NOT NULL,
-    type VARCHAR(255) NOT NULL,
-    data JSONB NOT NULL,
-    metadata JSONB DEFAULT '{}',
-    global_position BIGSERIAL,
-    timestamp TIMESTAMPTZ DEFAULT NOW(),
-    UNIQUE(stream_id, version)
-);
-
--- Indexes for events
-CREATE INDEX IF NOT EXISTS idx_%s_stream_id ON %s(stream_id, version);
-CREATE INDEX IF NOT EXISTS idx_%s_global_position ON %s(global_position);
-CREATE INDEX IF NOT EXISTS idx_%s_type ON %s(type);
-CREATE INDEX IF NOT EXISTS idx_%s_timestamp ON %s(timestamp);
-
--- Snapshots table
-CREATE TABLE IF NOT EXISTS %s (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    stream_id VARCHAR(255) NOT NULL,
-    version BIGINT NOT NULL,
-    type VARCHAR(255) NOT NULL,
-    data JSONB NOT NULL,
-    timestamp TIMESTAMPTZ DEFAULT NOW(),
-    UNIQUE(stream_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_%s_stream_id ON %s(stream_id);
-
--- Projection checkpoints
-CREATE TABLE IF NOT EXISTS mink_checkpoints (
-    projection_name VARCHAR(255) PRIMARY KEY,
-    position BIGINT NOT NULL DEFAULT 0,
-    status VARCHAR(50) DEFAULT 'active',
-    updated_at TIMESTAMPTZ DEFAULT NOW()
-);
-
--- Outbox table
-CREATE TABLE IF NOT EXISTS %s (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    event_type VARCHAR(255) NOT NULL,
-    payload JSONB NOT NULL,
-    destination VARCHAR(255),
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    processed_at TIMESTAMPTZ,
-    error TEXT
-);
-
-CREATE INDEX IF NOT EXISTS idx_%s_unprocessed ON %s(created_at) WHERE processed_at IS NULL;
-
--- Migrations tracking
-CREATE TABLE IF NOT EXISTS mink_migrations (
-    name VARCHAR(255) PRIMARY KEY,
-    applied_at TIMESTAMPTZ DEFAULT NOW()
-);
-
--- Idempotency keys
-CREATE TABLE IF NOT EXISTS mink_idempotency (
-    key VARCHAR(255) PRIMARY KEY,
-    result JSONB,
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    expires_at TIMESTAMPTZ
-);
-
-CREATE INDEX IF NOT EXISTS idx_mink_idempotency_expires ON mink_idempotency(expires_at);
-
-COMMENT ON TABLE %s IS 'Mink event store - immutable event log';
-COMMENT ON TABLE %s IS 'Aggregate snapshots for optimization';
-COMMENT ON TABLE mink_checkpoints IS 'Projection checkpoint positions';
-COMMENT ON TABLE %s IS 'Transactional outbox for reliable messaging';
-`,
+	return postgres.GenerateSchema(
 		cfg.Project.Name,
-		cfg.EventStore.TableName,
-		cfg.EventStore.TableName, cfg.EventStore.TableName,
-		cfg.EventStore.TableName, cfg.EventStore.TableName,
-		cfg.EventStore.TableName, cfg.EventStore.TableName,
-		cfg.EventStore.TableName, cfg.EventStore.TableName,
-		cfg.EventStore.SnapshotTableName,
-		cfg.EventStore.SnapshotTableName, cfg.EventStore.SnapshotTableName,
-		cfg.EventStore.OutboxTableName,
-		cfg.EventStore.OutboxTableName, cfg.EventStore.OutboxTableName,
+		cfg.Database.Schema,
 		cfg.EventStore.TableName,
 		cfg.EventStore.SnapshotTableName,
 		cfg.EventStore.OutboxTableName,

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -95,8 +95,8 @@ func DefaultConfig() *Config {
 			MigrationsDir: "migrations",
 		},
 		EventStore: EventStoreConfig{
-			TableName:         "mink_events",
-			SnapshotTableName: "mink_snapshots",
+			TableName:         "events",
+			SnapshotTableName: "snapshots",
 			OutboxTableName:   "mink_outbox",
 		},
 		Generation: GenerationConfig{

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -16,7 +16,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "my-mink-app", cfg.Project.Name)
 	assert.Equal(t, "postgres", cfg.Database.Driver)
 	assert.Equal(t, "mink", cfg.Database.Schema)
-	assert.Equal(t, "mink_events", cfg.EventStore.TableName)
+	assert.Equal(t, "events", cfg.EventStore.TableName)
 }
 
 func TestConfig_Validate(t *testing.T) {
@@ -164,7 +164,7 @@ func TestGenerateYAML(t *testing.T) {
 	assert.Contains(t, yaml, "test-app")
 	assert.Contains(t, yaml, "github.com/test/app")
 	assert.Contains(t, yaml, "postgres")
-	assert.Contains(t, yaml, "mink_events")
+	assert.Contains(t, yaml, "events")
 	assert.Contains(t, yaml, "# Mink Configuration File")
 }
 

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -613,23 +613,8 @@ $ mink schema print
 
 CREATE SCHEMA IF NOT EXISTS "mink";
 
-CREATE TABLE IF NOT EXISTS "mink"."events" (
-    global_position BIGSERIAL PRIMARY KEY,
-    stream_id VARCHAR(500) NOT NULL,
-    version BIGINT NOT NULL,
-    event_id UUID NOT NULL DEFAULT gen_random_uuid(),
-    event_type VARCHAR(500) NOT NULL,
-    data JSONB NOT NULL,
-    metadata JSONB,
-    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE(stream_id, version)
-);
-
-CREATE INDEX IF NOT EXISTS "idx_events_stream" ON "mink"."events" (stream_id, version);
-CREATE INDEX IF NOT EXISTS "idx_events_type" ON "mink"."events" (event_type);
-CREATE INDEX IF NOT EXISTS "idx_events_timestamp" ON "mink"."events" (timestamp);
-
--- ... additional tables for streams, snapshots, checkpoints
+-- Includes streams, events, snapshots, checkpoints, migrations,
+-- outbox, and idempotency tables using schema-qualified names.
 ```
 
 ---

--- a/website/docs/guide/cli.md
+++ b/website/docs/guide/cli.md
@@ -124,11 +124,13 @@ project:
 database:
   driver: postgres
   url: ${DATABASE_URL}
+  schema: mink
   migrations_dir: migrations
 
-eventstore:
-  table_name: mink_events
-  schema: mink
+event_store:
+  table_name: events
+  snapshot_table_name: snapshots
+  outbox_table_name: mink_outbox
 
 generation:
   aggregate_package: internal/domain
@@ -556,7 +558,7 @@ Mink
 Running Diagnostics
 
   Checking Go Version... OK
-    go1.22.0
+    go1.25.0
   Checking Configuration... OK
     Project: minkshop, Driver: postgres
   Checking Database Connection... OK
@@ -606,27 +608,26 @@ $ mink schema print
 **Generated schema:**
 
 ```sql
--- Mink Event Store Schema
--- Generated for PostgreSQL
+-- Mink Event Store Schema (PostgreSQL)
+-- Generated for: minkshop
 
-CREATE SCHEMA IF NOT EXISTS mink;
+CREATE SCHEMA IF NOT EXISTS "mink";
 
-CREATE TABLE IF NOT EXISTS mink.events (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    stream_id VARCHAR(255) NOT NULL,
+CREATE TABLE IF NOT EXISTS "mink"."events" (
+    global_position BIGSERIAL PRIMARY KEY,
+    stream_id VARCHAR(500) NOT NULL,
     version BIGINT NOT NULL,
-    type VARCHAR(255) NOT NULL,
+    event_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    event_type VARCHAR(500) NOT NULL,
     data JSONB NOT NULL,
-    metadata JSONB DEFAULT '{}',
-    global_position BIGSERIAL,
-    timestamp TIMESTAMPTZ DEFAULT NOW(),
+    metadata JSONB,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE(stream_id, version)
 );
 
-CREATE INDEX idx_events_stream_id ON mink.events(stream_id);
-CREATE INDEX idx_events_type ON mink.events(type);
-CREATE INDEX idx_events_global_position ON mink.events(global_position);
-CREATE INDEX idx_events_timestamp ON mink.events(timestamp);
+CREATE INDEX IF NOT EXISTS "idx_events_stream" ON "mink"."events" (stream_id, version);
+CREATE INDEX IF NOT EXISTS "idx_events_type" ON "mink"."events" (event_type);
+CREATE INDEX IF NOT EXISTS "idx_events_timestamp" ON "mink"."events" (timestamp);
 
 -- ... additional tables for streams, snapshots, checkpoints
 ```
@@ -646,7 +647,7 @@ Mink
 │ Version   │ v1.0.0                      │
 │ Commit    │ abc123def                   │
 │ Built     │ 2026-01-07                  │
-│ Go        │ go1.22.0                    │
+│ Go        │ go1.25.0                    │
 │ OS/Arch   │ darwin/arm64                │
 └───────────┴─────────────────────────────┘
 ```
@@ -669,11 +670,13 @@ project:
 database:
   driver: postgres           # postgres or memory
   url: ${DATABASE_URL}       # Environment variable expansion
+  schema: mink
   migrations_dir: migrations
 
-eventstore:
-  table_name: mink_events
-  schema: mink
+event_store:
+  table_name: events
+  snapshot_table_name: snapshots
+  outbox_table_name: mink_outbox
 
 generation:
   aggregate_package: internal/domain


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request introduces several improvements and refactorings to the PostgreSQL adapter and schema management in the codebase, along with documentation and CI updates. The main focus is on centralizing and standardizing schema generation and migration logic, improving maintainability and alignment between runtime and generated DDL, and updating Go version support.

**PostgreSQL Schema Management and Refactoring:**

* Centralized all PostgreSQL schema and migration DDL generation into reusable functions (`eventStoreSchemaStatements`, `outboxSchemaStatements`, `idempotencySchemaStatements`, etc.), and updated all initialization and migration code paths to use these helpers for consistency and maintainability. This affects `Migrate`, `GetAppliedMigrations`, `Initialize` methods, and the schema generator. [[1]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L223-R250) [[2]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L260-R341) [[3]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L1044-R1078) [[4]](diffhunk://#diff-159caf805ef40164d8130d1126f0002efc4c4d1080aab00ddef44d179f52ce79L1119-R1182) [[5]](diffhunk://#diff-eee27b886a9d145e7be617aec4bf93cafa2597c0608aeef021035e8901580982L80-R80) [[6]](diffhunk://#diff-ce6f87df54364663ba5bd426bd238481c06a79fe55a686eda6a1db27555c779bL80-R80)

* Improved schema checking logic in `CheckSchema` to properly handle qualified table names (with schema), ensuring accurate existence checks in multi-schema setups.

**Documentation and Developer Guidance:**

* Added a "Repository Mental Model for Agents" section to `AGENTS.md`, providing a clear high-level map of the repository structure, adapter contracts, event flow, projection behavior, and testing conventions for contributors.

**Go Version and CI Support:**

* Updated the supported Go version badge in `README.md` to `1.25+` and reduced the CI matrix to test only supported Go versions (`1.25`, `1.26`), removing older versions from the matrix and using `go-version-file` for setup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L31-R31) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L207-R207)

## Testing
<!-- How did you test this? -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
