### PR TITLE
Add branch protection workflow

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,17 @@
+name: Enforce PR Source Branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR comes from develop
+        if: github.head_ref != 'develop'
+        run: |
+          echo "❌ ERROR: Pull requests to 'main' must originate from the 'develop' branch."
+          echo "Current source branch is '${{ github.head_ref }}'."
+          exit 1


### PR DESCRIPTION
## Summary
<!-- Brief description of changes -->
This pull request introduces a new GitHub Actions workflow to enforce branch protection rules. Specifically, it ensures that all pull requests targeting the `main` branch must originate from the `develop` branch.

Branch protection automation:

* Added `.github/workflows/branch-protection.yml` to automatically check that pull requests to `main` only come from the `develop` branch, and fail the workflow with an error message if not.

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
