### PR TITLE
[readmodel] Implement FilterOpContains and complete PostgreSQL filter operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI test workflow now triggers on `develop` branch (push and pull request)
 - Stable release workflow uses stable-only tag filter to ignore RC tags when calculating next version
 
+### Fixed
+- **Read model filters (PostgreSQL):** `FilterOpContains` was defined but never handled by the PostgreSQL repository, so a `CONTAINS` filter was silently ignored and the query returned unfiltered rows. It is now implemented as a case-sensitive substring match on text columns (LIKE metacharacters in the value are escaped) and as a JSONB containment check (`@>`) on JSONB columns.
+- `FilterOpBetween` now accepts typed slices (`[]int`, `[]float64`, `[]string`, …) in addition to `[]interface{}`, matching the behavior of `FilterOpIn`.
+- The PostgreSQL repository now returns an error for an unrecognized filter operator instead of silently dropping the condition.
+- Corrected the read-models documentation, which referenced non-existent symbols (`mink.Eq`, `mink.Contains`, `repo.Query`) instead of the real `mink.FilterOp*` constants and `repo.Find`.
+
 ## [1.0.0] - 2026-03-02
 
 First stable release consolidating all features from the development phases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FilterOpBetween` now accepts typed slices (`[]int`, `[]float64`, `[]string`, …) in addition to `[]interface{}`, matching the behavior of `FilterOpIn`.
 - The PostgreSQL repository now returns an error for an unrecognized filter operator instead of silently dropping the condition.
 - Corrected the read-models documentation, which referenced non-existent symbols (`mink.Eq`, `mink.Contains`, `repo.Query`) instead of the real `mink.FilterOp*` constants and `repo.Find`.
+- **Data race (PostgreSQL adapter):** the `WithHealthCheck` goroutine read the adapter's `closed` flag on every tick while `Close()` wrote it without synchronization. The flag is now an `atomic.Bool`, removing the race flagged by the race detector.
 
 ## [1.0.0] - 2026-03-02
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -112,7 +113,7 @@ type PostgresAdapter struct {
 	db                *sql.DB
 	schema            string
 	schemaQ           string // Pre-validated and quoted schema identifier
-	closed            bool
+	closed            atomic.Bool
 	healthCheckCancel context.CancelFunc
 }
 
@@ -363,7 +364,7 @@ func (a *PostgresAdapter) MigrationVersion(ctx context.Context) (int, error) {
 
 // Append stores events to the specified stream with optimistic concurrency control.
 func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []adapters.EventRecord, expectedVersion int64) ([]adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -395,7 +396,7 @@ func (a *PostgresAdapter) Append(ctx context.Context, streamID string, events []
 
 // AppendWithOutbox atomically appends events and schedules outbox messages in a single transaction.
 func (a *PostgresAdapter) AppendWithOutbox(ctx context.Context, streamID string, events []adapters.EventRecord, expectedVersion int64, outboxMessages []*adapters.OutboxMessage) ([]adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -521,7 +522,7 @@ func (a *PostgresAdapter) appendInTx(ctx context.Context, tx *sql.Tx, streamID s
 
 // Load retrieves all events from a stream starting from the specified version.
 func (a *PostgresAdapter) Load(ctx context.Context, streamID string, fromVersion int64) ([]adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -545,7 +546,7 @@ func (a *PostgresAdapter) Load(ctx context.Context, streamID string, fromVersion
 
 // GetStreamInfo returns metadata about a stream.
 func (a *PostgresAdapter) GetStreamInfo(ctx context.Context, streamID string) (*adapters.StreamInfo, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -577,7 +578,7 @@ func (a *PostgresAdapter) GetStreamInfo(ctx context.Context, streamID string) (*
 
 // GetLastPosition returns the global position of the last stored event.
 func (a *PostgresAdapter) GetLastPosition(ctx context.Context) (uint64, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return 0, ErrAdapterClosed
 	}
 
@@ -602,7 +603,7 @@ func (a *PostgresAdapter) GetLastPosition(ctx context.Context) (uint64, error) {
 
 // Close releases the database connection and stops health checking.
 func (a *PostgresAdapter) Close() error {
-	a.closed = true
+	a.closed.Store(true)
 	if a.healthCheckCancel != nil {
 		a.healthCheckCancel()
 	}
@@ -611,7 +612,7 @@ func (a *PostgresAdapter) Close() error {
 
 // SaveSnapshot stores a snapshot for the given stream.
 func (a *PostgresAdapter) SaveSnapshot(ctx context.Context, streamID string, version int64, data []byte) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -632,7 +633,7 @@ func (a *PostgresAdapter) SaveSnapshot(ctx context.Context, streamID string, ver
 
 // LoadSnapshot retrieves the latest snapshot for the given stream (SnapshotAdapter implementation).
 func (a *PostgresAdapter) LoadSnapshot(ctx context.Context, streamID string) (*adapters.SnapshotRecord, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -659,7 +660,7 @@ func (a *PostgresAdapter) LoadSnapshot(ctx context.Context, streamID string) (*a
 
 // DeleteSnapshot removes the snapshot for the given stream.
 func (a *PostgresAdapter) DeleteSnapshot(ctx context.Context, streamID string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -675,7 +676,7 @@ func (a *PostgresAdapter) DeleteSnapshot(ctx context.Context, streamID string) e
 
 // GetCheckpoint returns the last processed position for a projection.
 func (a *PostgresAdapter) GetCheckpoint(ctx context.Context, projectionName string) (uint64, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return 0, ErrAdapterClosed
 	}
 
@@ -705,7 +706,7 @@ func (a *PostgresAdapter) GetCheckpoint(ctx context.Context, projectionName stri
 
 // SetCheckpoint stores the last processed position for a projection.
 func (a *PostgresAdapter) SetCheckpoint(ctx context.Context, projectionName string, position uint64) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -726,7 +727,7 @@ func (a *PostgresAdapter) SetCheckpoint(ctx context.Context, projectionName stri
 // DeleteCheckpoint removes the checkpoint for a projection.
 // This implements mink.CheckpointStore interface.
 func (a *PostgresAdapter) DeleteCheckpoint(ctx context.Context, projectionName string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -744,7 +745,7 @@ func (a *PostgresAdapter) DeleteCheckpoint(ctx context.Context, projectionName s
 // GetAllCheckpoints returns checkpoints for all projections.
 // This implements mink.CheckpointStore interface.
 func (a *PostgresAdapter) GetAllCheckpoints(ctx context.Context) (map[string]uint64, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -779,7 +780,7 @@ func (a *PostgresAdapter) GetAllCheckpoints(ctx context.Context) (map[string]uin
 
 // Ping checks database connectivity.
 func (a *PostgresAdapter) Ping(ctx context.Context) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 	return a.db.PingContext(ctx)
@@ -795,7 +796,7 @@ func (a *PostgresAdapter) runHealthCheck(ctx context.Context, interval time.Dura
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if a.closed {
+			if a.closed.Load() {
 				return
 			}
 			// Ping validates the connection and removes stale connections from pool
@@ -841,7 +842,7 @@ var (
 
 // ListStreams returns a list of stream summaries for CLI display.
 func (a *PostgresAdapter) ListStreams(ctx context.Context, prefix string, limit int) ([]adapters.StreamSummary, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -889,7 +890,7 @@ func (a *PostgresAdapter) ListStreams(ctx context.Context, prefix string, limit 
 
 // GetStreamEvents returns events from a stream with pagination for CLI display.
 func (a *PostgresAdapter) GetStreamEvents(ctx context.Context, streamID string, fromVersion int64, limit int) ([]adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -911,7 +912,7 @@ func (a *PostgresAdapter) GetStreamEvents(ctx context.Context, streamID string, 
 
 // GetEventStoreStats returns aggregate statistics about the event store.
 func (a *PostgresAdapter) GetEventStoreStats(ctx context.Context) (*adapters.EventStoreStats, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -955,7 +956,7 @@ func (a *PostgresAdapter) GetEventStoreStats(ctx context.Context) (*adapters.Eve
 
 // ListProjections returns all registered projections.
 func (a *PostgresAdapter) ListProjections(ctx context.Context) ([]adapters.ProjectionInfo, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -987,7 +988,7 @@ func (a *PostgresAdapter) ListProjections(ctx context.Context) ([]adapters.Proje
 
 // GetProjection returns information about a specific projection.
 func (a *PostgresAdapter) GetProjection(ctx context.Context, name string) (*adapters.ProjectionInfo, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -1011,7 +1012,7 @@ func (a *PostgresAdapter) GetProjection(ctx context.Context, name string) (*adap
 
 // SetProjectionStatus updates a projection's status.
 func (a *PostgresAdapter) SetProjectionStatus(ctx context.Context, name string, status string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -1035,7 +1036,7 @@ func (a *PostgresAdapter) SetProjectionStatus(ctx context.Context, name string, 
 
 // ResetProjectionCheckpoint resets a projection's position to 0 for rebuild.
 func (a *PostgresAdapter) ResetProjectionCheckpoint(ctx context.Context, name string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -1054,7 +1055,7 @@ func (a *PostgresAdapter) ResetProjectionCheckpoint(ctx context.Context, name st
 
 // GetTotalEventCount returns the highest global position.
 func (a *PostgresAdapter) GetTotalEventCount(ctx context.Context) (int64, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return 0, ErrAdapterClosed
 	}
 
@@ -1066,7 +1067,7 @@ func (a *PostgresAdapter) GetTotalEventCount(ctx context.Context) (int64, error)
 
 // GetAppliedMigrations returns the list of applied migration names.
 func (a *PostgresAdapter) GetAppliedMigrations(ctx context.Context) ([]string, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -1097,7 +1098,7 @@ func (a *PostgresAdapter) GetAppliedMigrations(ctx context.Context) ([]string, e
 
 // RecordMigration marks a migration as applied.
 func (a *PostgresAdapter) RecordMigration(ctx context.Context, name string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -1112,7 +1113,7 @@ func (a *PostgresAdapter) RecordMigration(ctx context.Context, name string) erro
 
 // RemoveMigrationRecord removes a migration record (for rollback).
 func (a *PostgresAdapter) RemoveMigrationRecord(ctx context.Context, name string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -1127,7 +1128,7 @@ func (a *PostgresAdapter) RemoveMigrationRecord(ctx context.Context, name string
 
 // ExecuteSQL runs arbitrary SQL (for applying migrations).
 func (a *PostgresAdapter) ExecuteSQL(ctx context.Context, sql string) error {
-	if a.closed {
+	if a.closed.Load() {
 		return ErrAdapterClosed
 	}
 
@@ -1188,7 +1189,7 @@ func GenerateSchema(projectName, schemaName, tableName, snapshotTableName, outbo
 
 // GetDiagnosticInfo returns database version and connection status.
 func (a *PostgresAdapter) GetDiagnosticInfo(ctx context.Context) (*adapters.DiagnosticInfo, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -1223,7 +1224,7 @@ func (a *PostgresAdapter) GetDiagnosticInfo(ctx context.Context) (*adapters.Diag
 
 // CheckSchema verifies the event store schema exists.
 func (a *PostgresAdapter) CheckSchema(ctx context.Context, tableName string) (*adapters.SchemaCheckResult, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -1271,7 +1272,7 @@ func (a *PostgresAdapter) CheckSchema(ctx context.Context, tableName string) (*a
 
 // GetProjectionHealth returns projection health status.
 func (a *PostgresAdapter) GetProjectionHealth(ctx context.Context) (*adapters.ProjectionHealthResult, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 

--- a/adapters/postgres/readmodel.go
+++ b/adapters/postgres/readmodel.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -558,7 +559,10 @@ func (r *PostgresRepository[T]) buildSelectQuery(query mink.Query) (string, []in
 		selectCols[i] = quoteIdentifier(col)
 	}
 
-	whereClause, args := r.buildWhereClause(query.Filters)
+	whereClause, args, err := r.buildWhereClause(query.Filters)
+	if err != nil {
+		return "", nil, err
+	}
 	orderClause := r.buildOrderClause(query.OrderBy)
 	limitClause, err := r.buildLimitClauseWithValidation(query.Limit, query.Offset)
 	if err != nil {
@@ -599,9 +603,14 @@ func buildInClause(quotedCol, keyword string, values []interface{}, paramIdx *in
 }
 
 // buildWhereClause builds the WHERE clause from filters.
-func (r *PostgresRepository[T]) buildWhereClause(filters []mink.Filter) (string, []interface{}) {
+//
+// Every operator defined by mink.FilterOp is handled. A filter whose field
+// does not resolve to a known column is skipped, but an unrecognized operator
+// returns an error: a query must never silently ignore the caller's intent and
+// return rows it was asked to filter out.
+func (r *PostgresRepository[T]) buildWhereClause(filters []mink.Filter) (string, []interface{}, error) {
 	if len(filters) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 
 	var conditions []string
@@ -638,18 +647,68 @@ func (r *PostgresRepository[T]) buildWhereClause(filters []mink.Filter) (string,
 		case mink.FilterOpIsNotNull:
 			conditions = append(conditions, fmt.Sprintf("%s IS NOT NULL", quotedCol))
 		case mink.FilterOpBetween:
-			if vals, ok := f.Value.([]interface{}); ok && len(vals) == 2 {
+			if vals := toInterfaceSlice(f.Value); len(vals) == 2 {
 				conditions = append(conditions, fmt.Sprintf("%s BETWEEN $%d AND $%d", quotedCol, paramIdx, paramIdx+1))
 				args = append(args, vals[0], vals[1])
 				paramIdx += 2
 			}
+		case mink.FilterOpContains:
+			cond, arg, err := r.buildContainsCondition(quotedCol, colName, f.Value, paramIdx)
+			if err != nil {
+				return "", nil, err
+			}
+			conditions = append(conditions, cond)
+			args = append(args, arg)
+			paramIdx++
+		default:
+			return "", nil, fmt.Errorf("mink/postgres/readmodel: unsupported filter operator %q on field %q", f.Op, f.Field)
 		}
 	}
 
 	if len(conditions) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
-	return " WHERE " + strings.Join(conditions, " AND "), args
+	return " WHERE " + strings.Join(conditions, " AND "), args, nil
+}
+
+// buildContainsCondition builds a CONTAINS predicate that adapts to how the
+// column stores its data:
+//   - JSONB columns use the containment operator (@>), matching an array or
+//     object that contains the supplied value. The value is JSON-encoded, so a
+//     scalar matches array membership and a slice/map matches sub-containment.
+//   - All other columns use a case-sensitive substring match. The value is
+//     treated literally: LIKE metacharacters (% and _) are escaped so they are
+//     not interpreted as wildcards.
+func (r *PostgresRepository[T]) buildContainsCondition(quotedCol, colName string, value interface{}, paramIdx int) (string, interface{}, error) {
+	if strings.EqualFold(r.columnSQLType(colName), "JSONB") {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return "", nil, fmt.Errorf("mink/postgres/readmodel: cannot encode CONTAINS value for column %q: %w", colName, err)
+		}
+		return fmt.Sprintf("%s @> $%d::jsonb", quotedCol, paramIdx), string(encoded), nil
+	}
+	return fmt.Sprintf("%s LIKE '%%' || $%d || '%%'", quotedCol, paramIdx), escapeLikePattern(fmt.Sprintf("%v", value)), nil
+}
+
+// columnSQLType returns the configured SQL type for a resolved column name,
+// or an empty string if the column is unknown.
+func (r *PostgresRepository[T]) columnSQLType(colName string) string {
+	if r.tableSchema == nil {
+		return ""
+	}
+	for _, col := range r.tableSchema.Columns {
+		if col.Name == colName {
+			return col.SQLType
+		}
+	}
+	return ""
+}
+
+// escapeLikePattern escapes the LIKE metacharacters in s so that the value is
+// matched literally inside a substring (CONTAINS) predicate. PostgreSQL's LIKE
+// uses backslash as the default escape character.
+func escapeLikePattern(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
 }
 
 // toInterfaceSlice converts various slice types to []interface{}.
@@ -1302,12 +1361,15 @@ func (r *PostgresRepository[T]) findOneWithExecutor(ctx context.Context, exec db
 func (r *PostgresRepository[T]) countWithExecutor(ctx context.Context, exec dbExecutor, query mink.Query) (int64, error) {
 	tableQ := quoteQualifiedTable(r.config.schema, r.config.tableName)
 
-	whereClause, args := r.buildWhereClause(query.Filters)
+	whereClause, args, err := r.buildWhereClause(query.Filters)
+	if err != nil {
+		return 0, err
+	}
 
 	sqlQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s%s`, tableQ, whereClause)
 
 	var count int64
-	err := exec.QueryRowContext(ctx, sqlQuery, args...).Scan(&count)
+	err = exec.QueryRowContext(ctx, sqlQuery, args...).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("mink/postgres/readmodel: count failed: %w", err)
 	}
@@ -1319,7 +1381,10 @@ func (r *PostgresRepository[T]) countWithExecutor(ctx context.Context, exec dbEx
 func (r *PostgresRepository[T]) deleteManyWithExecutor(ctx context.Context, exec dbExecutor, query mink.Query) (int64, error) {
 	tableQ := quoteQualifiedTable(r.config.schema, r.config.tableName)
 
-	whereClause, args := r.buildWhereClause(query.Filters)
+	whereClause, args, err := r.buildWhereClause(query.Filters)
+	if err != nil {
+		return 0, err
+	}
 
 	sqlQuery := fmt.Sprintf(`DELETE FROM %s%s`, tableQ, whereClause)
 

--- a/adapters/postgres/readmodel_test.go
+++ b/adapters/postgres/readmodel_test.go
@@ -402,6 +402,31 @@ func TestPostgresRepository_Query(t *testing.T) {
 		assert.Len(t, results, 2)
 	})
 
+	t.Run("Find with CONTAINS substring filter", func(t *testing.T) {
+		// "pending" (statuses for order-1 and order-4) contains the substring "end".
+		query := mink.NewQuery().Where("status", mink.FilterOpContains, "end")
+		results, err := tr.repo.Find(tr.ctx, query.Build())
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("Find with CONTAINS escapes wildcards", func(t *testing.T) {
+		// No status contains a literal '%', so the wildcard must be escaped and
+		// match nothing rather than matching every row.
+		query := mink.NewQuery().Where("status", mink.FilterOpContains, "%")
+		results, err := tr.repo.Find(tr.ctx, query.Build())
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("Find with BETWEEN filter (typed slice)", func(t *testing.T) {
+		// total_amount values are 25, 50, 75, 100, 125; inclusive [50,100] -> 3.
+		query := mink.NewQuery().Where("total_amount", mink.FilterOpBetween, []float64{50.0, 100.0})
+		results, err := tr.repo.Find(tr.ctx, query.Build())
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
 	t.Run("Find with ordering", func(t *testing.T) {
 		query := mink.NewQuery().OrderByDesc("item_count")
 		results, err := tr.repo.Find(tr.ctx, query.Build())
@@ -1173,6 +1198,136 @@ func TestToInterfaceSlice(t *testing.T) {
 		result := toInterfaceSlice(nil)
 		assert.Nil(t, result)
 	})
+}
+
+// TestBuildWhereClause verifies SQL generation for every filter operator
+// without requiring a live database. The repository is constructed with a
+// known column set and schema so buildWhereClause can be exercised directly.
+func TestBuildWhereClause(t *testing.T) {
+	repo := &PostgresRepository[OrderSummary]{
+		columns: []string{"status", "total_amount", "tags"},
+		tableSchema: &TableSchema{
+			Columns: []ColumnType{
+				{Name: "status", SQLType: "TEXT"},
+				{Name: "total_amount", SQLType: "DOUBLE PRECISION"},
+				{Name: "tags", SQLType: "JSONB"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		filters   []mink.Filter
+		wantWhere string
+		wantArgs  []interface{}
+		wantErr   bool
+	}{
+		{
+			name:      "no filters",
+			filters:   nil,
+			wantWhere: "",
+			wantArgs:  nil,
+		},
+		{
+			name:      "equality",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpEq, Value: "pending"}},
+			wantWhere: ` WHERE "status" = $1`,
+			wantArgs:  []interface{}{"pending"},
+		},
+		{
+			name:      "not equal",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpNe, Value: "pending"}},
+			wantWhere: ` WHERE "status" != $1`,
+			wantArgs:  []interface{}{"pending"},
+		},
+		{
+			name:      "like passes pattern through unchanged",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpLike, Value: "p%"}},
+			wantWhere: ` WHERE "status" LIKE $1`,
+			wantArgs:  []interface{}{"p%"},
+		},
+		{
+			name:      "in",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpIn, Value: []string{"a", "b"}}},
+			wantWhere: ` WHERE "status" IN ($1, $2)`,
+			wantArgs:  []interface{}{"a", "b"},
+		},
+		{
+			name:      "not in",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpNotIn, Value: []string{"a", "b"}}},
+			wantWhere: ` WHERE "status" NOT IN ($1, $2)`,
+			wantArgs:  []interface{}{"a", "b"},
+		},
+		{
+			name:      "is null",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpIsNull, Value: nil}},
+			wantWhere: ` WHERE "status" IS NULL`,
+			wantArgs:  nil,
+		},
+		{
+			name:      "is not null",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpIsNotNull, Value: nil}},
+			wantWhere: ` WHERE "status" IS NOT NULL`,
+			wantArgs:  nil,
+		},
+		{
+			name:      "between accepts typed slices",
+			filters:   []mink.Filter{{Field: "total_amount", Op: mink.FilterOpBetween, Value: []float64{10, 20}}},
+			wantWhere: ` WHERE "total_amount" BETWEEN $1 AND $2`,
+			wantArgs:  []interface{}{float64(10), float64(20)},
+		},
+		{
+			name:      "contains on text column does substring match",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpContains, Value: "end"}},
+			wantWhere: ` WHERE "status" LIKE '%' || $1 || '%'`,
+			wantArgs:  []interface{}{"end"},
+		},
+		{
+			name:      "contains escapes like metacharacters",
+			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpContains, Value: "50%_x"}},
+			wantWhere: ` WHERE "status" LIKE '%' || $1 || '%'`,
+			wantArgs:  []interface{}{`50\%\_x`},
+		},
+		{
+			name:      "contains on jsonb column uses containment",
+			filters:   []mink.Filter{{Field: "tags", Op: mink.FilterOpContains, Value: "premium"}},
+			wantWhere: ` WHERE "tags" @> $1::jsonb`,
+			wantArgs:  []interface{}{`"premium"`},
+		},
+		{
+			name:      "unknown field is skipped",
+			filters:   []mink.Filter{{Field: "does_not_exist", Op: mink.FilterOpEq, Value: "x"}},
+			wantWhere: "",
+			wantArgs:  nil,
+		},
+		{
+			name: "multiple filters combine with AND and sequential params",
+			filters: []mink.Filter{
+				{Field: "status", Op: mink.FilterOpEq, Value: "pending"},
+				{Field: "total_amount", Op: mink.FilterOpGt, Value: 100.0},
+			},
+			wantWhere: ` WHERE "status" = $1 AND "total_amount" > $2`,
+			wantArgs:  []interface{}{"pending", 100.0},
+		},
+		{
+			name:    "unsupported operator returns an error",
+			filters: []mink.Filter{{Field: "status", Op: mink.FilterOp("BOGUS"), Value: "x"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			where, args, err := repo.buildWhereClause(tt.filters)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantWhere, where)
+			assert.Equal(t, tt.wantArgs, args)
+		})
+	}
 }
 
 // Benchmark tests

--- a/adapters/postgres/subscription.go
+++ b/adapters/postgres/subscription.go
@@ -135,7 +135,7 @@ func runPollingLoop[P any](
 // LoadFromPosition loads events starting from a global position.
 // This is used by projection engines to catch up on historical events.
 func (a *PostgresAdapter) LoadFromPosition(ctx context.Context, fromPosition uint64, limit int) ([]adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -163,7 +163,7 @@ func (a *PostgresAdapter) LoadFromPosition(ctx context.Context, fromPosition uin
 // This uses polling-based subscription with continuous updates.
 // Optional SubscriptionOptions can be provided to configure behavior.
 func (a *PostgresAdapter) SubscribeAll(ctx context.Context, fromPosition uint64, opts ...adapters.SubscriptionOptions) (<-chan adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -191,7 +191,7 @@ func (a *PostgresAdapter) SubscribeAll(ctx context.Context, fromPosition uint64,
 // Events are delivered starting from the specified version with continuous polling.
 // Optional SubscriptionOptions can be provided to configure behavior.
 func (a *PostgresAdapter) SubscribeStream(ctx context.Context, streamID string, fromVersion int64, opts ...adapters.SubscriptionOptions) (<-chan adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 
@@ -219,7 +219,7 @@ func (a *PostgresAdapter) SubscribeStream(ctx context.Context, streamID string, 
 // Events are delivered starting from the specified global position with continuous polling.
 // Optional SubscriptionOptions can be provided to configure behavior.
 func (a *PostgresAdapter) SubscribeCategory(ctx context.Context, category string, fromPosition uint64, opts ...adapters.SubscriptionOptions) (<-chan adapters.StoredEvent, error) {
-	if a.closed {
+	if a.closed.Load() {
 		return nil, ErrAdapterClosed
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -201,7 +201,10 @@ const (
 	// FilterOpIsNotNull matches non-null values.
 	FilterOpIsNotNull FilterOp = "IS NOT NULL"
 
-	// FilterOpContains matches arrays containing a value.
+	// FilterOpContains matches values that contain the given value.
+	// On JSONB columns it tests containment (the stored array or object
+	// contains the value); on text columns it performs a case-sensitive
+	// substring match with the value treated literally.
 	FilterOpContains FilterOp = "CONTAINS"
 
 	// FilterOpBetween matches values between two bounds.

--- a/website/docs/core/read-models.md
+++ b/website/docs/core/read-models.md
@@ -275,9 +275,9 @@ type ReadModelRepository[T any] interface {
     Get(ctx context.Context, id string) (*T, error)
     Update(ctx context.Context, id string, fn func(*T)) error
     Delete(ctx context.Context, id string) error
-    Query(ctx context.Context, query Query) ([]*T, error)
+    Find(ctx context.Context, query Query) ([]*T, error)
     FindOne(ctx context.Context, query Query) (*T, error)
-    Count(ctx context.Context, query Query) (int, error)
+    Count(ctx context.Context, query Query) (int64, error)
     Exists(ctx context.Context, id string) (bool, error)
     GetAll(ctx context.Context) ([]*T, error)
     Clear(ctx context.Context) error
@@ -424,36 +424,143 @@ err = repo.Migrate(ctx)
 Fluent query construction:
 
 ```go
-// Build a query
+// Build a query. NewQuery returns a *Query builder; pass query.Build() to the repo.
 query := mink.NewQuery().
-    Where("Status", mink.Eq, "Pending").
-    And("TotalAmount", mink.Gt, 100.0).
-    OrderByDesc("CreatedAt").
-    WithPagination(10, 0)  // limit 10, offset 0
+    Where("status", mink.FilterOpEq, "pending").
+    And("total_amount", mink.FilterOpGt, 100.0).
+    OrderByDesc("created_at").
+    WithPagination(1, 10) // page 1, page size 10
 
 // Execute query
-orders, err := repo.Query(ctx, query)
+orders, err := repo.Find(ctx, query.Build())
 
 // Find single result
-order, err := repo.FindOne(ctx, query)
+order, err := repo.FindOne(ctx, query.Build())
 
 // Count matching records
-count, err := repo.Count(ctx, query)
+count, err := repo.Count(ctx, query.Build())
 ```
 
 ### Filter Operators
 
 ```go
-// Available filter operators
-mink.Eq       // Equal
-mink.NotEq    // Not equal
-mink.Gt       // Greater than
-mink.Gte      // Greater than or equal
-mink.Lt       // Less than
-mink.Lte      // Less than or equal
-mink.In       // In list
-mink.Contains // Contains substring
+// Available filter operators (mink.FilterOp constants)
+mink.FilterOpEq        // =  (equal)
+mink.FilterOpNe        // != (not equal)
+mink.FilterOpGt        // >  (greater than)
+mink.FilterOpGte       // >= (greater than or equal)
+mink.FilterOpLt        // <  (less than)
+mink.FilterOpLte       // <= (less than or equal)
+mink.FilterOpIn        // IN     (value is one of a list/slice)
+mink.FilterOpNotIn     // NOT IN (value is not in a list/slice)
+mink.FilterOpLike      // LIKE   (SQL pattern; caller supplies % / _ wildcards)
+mink.FilterOpContains  // substring match on text, containment (@>) on JSONB
+mink.FilterOpBetween   // BETWEEN (inclusive range; value is a 2-element slice)
+mink.FilterOpIsNull    // IS NULL
+mink.FilterOpIsNotNull // IS NOT NULL
 ```
+
+Examples:
+
+```go
+// IN: status is one of the listed values (accepts []string, []int, etc.)
+mink.NewQuery().Where("status", mink.FilterOpIn, []string{"pending", "shipped"})
+
+// CONTAINS: substring match on a text column ('%' and '_' are escaped, not wildcards)
+mink.NewQuery().Where("name", mink.FilterOpContains, "smith")
+
+// CONTAINS: element/containment match on a JSONB column
+mink.NewQuery().Where("tags", mink.FilterOpContains, "premium")
+
+// BETWEEN: inclusive range
+mink.NewQuery().Where("total_amount", mink.FilterOpBetween, []float64{50, 100})
+
+// IS NULL / IS NOT NULL: the value is ignored
+mink.NewQuery().Where("shipped_at", mink.FilterOpIsNull, nil)
+```
+
+> **Backend support:** the PostgreSQL repository implements every operator
+> above. The in-memory repository (`mink.NewInMemoryRepository`) is a lightweight
+> testing helper that does **not** apply filters — use the PostgreSQL repository
+> (or another database-backed implementation) for real querying.
+
+### Case-insensitive matching
+
+All string operators (`FilterOpEq`, `FilterOpLike`, `FilterOpContains`) are
+**case-sensitive**. There is intentionally no `ILIKE` / case-insensitive
+operator (see the design note below). When you need case-insensitive search,
+make the *column* case-insensitive rather than reaching for a special operator.
+
+**Option 1 — `citext` column (transparent, no query changes).** Declare the
+column as PostgreSQL's case-insensitive text type. `FilterOpEq`,
+`FilterOpLike`, and `FilterOpContains` then match case-insensitively on that
+column automatically.
+
+```go
+type Customer struct {
+    ID   string `mink:"id,pk"`
+    Name string `mink:"name,type=citext"` // case-insensitive column
+}
+```
+
+```sql
+-- run once per database, before the table is created
+CREATE EXTENSION IF NOT EXISTS citext;
+```
+
+```go
+// matches "Smith", "SMITH", "smith"
+mink.NewQuery().Where("name", mink.FilterOpContains, "smith")
+```
+
+Because auto-migration emits `name citext`, the extension must already exist —
+create it first, or use `WithAutoMigrate(false)` and manage the DDL yourself.
+
+**Option 2 — lowercase shadow column (portable, index-friendly).** Keep a
+normalized copy and query it lowercased. Works on any backend and can be
+indexed for fast search.
+
+```go
+type Customer struct {
+    ID        string `mink:"id,pk"`
+    Name      string `mink:"name"`
+    NameLower string `mink:"name_lower,index"` // set to strings.ToLower(Name) in the projection
+}
+
+mink.NewQuery().Where("name_lower", mink.FilterOpContains, strings.ToLower(q))
+```
+
+**Option 3 — raw SQL for a one-off.** A read model is a plain table, so use the
+`*sql.DB` you already have together with `repo.TableName()`:
+
+```go
+rows, err := db.QueryContext(ctx,
+    `SELECT * FROM `+repo.TableName()+` WHERE name ILIKE $1`, "%"+q+"%")
+// note: you scan the rows yourself; the repository's typed scanner is internal
+```
+
+:::note Design note: why there is no `FilterOpILike`
+`FilterOp` is the **backend-neutral** query vocabulary shared by the
+`ReadModelRepository[T]` interface and *every* adapter. `ILIKE` is a
+PostgreSQL-specific keyword. Other engines support case-insensitive matching
+too, but express it at different layers — MongoDB via a `$regex` `i` flag or a
+collation, MySQL/SQL Server/SQLite often via a case-insensitive collation *by
+default* — so there is no shared *operator* to expose, and case-insensitivity is
+fundamentally a property of the **data and its collation**, not of the query
+operator.
+
+Adding `FilterOpILike` to the shared enum would (1) bake a vendor keyword into a
+cross-backend contract, (2) oblige every current and future adapter to emulate
+it faithfully or silently diverge — the exact "silently ignored operator" class
+of bug that motivated implementing `FilterOpContains` — and (3) invite a
+combinatorial explosion of case-insensitive variants (`IContains`, `IEq`,
+`IStartsWith`, …). The operator set is kept small and orthogonal, and
+case-folding is pushed to the schema (`citext`, a lowercased column, or a
+case-insensitive collation) where it belongs. If a portable case-insensitive
+match is ever added, it would be defined by its *semantics* — each adapter
+implementing it natively (PostgreSQL `ILIKE`, others `LOWER(col) LIKE LOWER(?)`)
+with cross-adapter tests — never as the raw `ILIKE` keyword.
+:::
 
 ## Subscription System
 


### PR DESCRIPTION
## Summary
`FilterOpContains` was part of the public `FilterOp` enum, but the PostgreSQL
read-model repository never handled it: `buildWhereClause` matched it in neither
the operator map nor the switch, so a `CONTAINS` filter produced **no WHERE
condition** and the query silently returned **unfiltered** rows. This PR
implements it, hardens `BETWEEN`, makes unknown operators fail loudly, and
corrects the documentation.

## Problem
- `Where("name", FilterOpContains, "x")` was silently ignored on the PostgreSQL
  repository → over-broad results (potential data exposure).
- `FilterOpBetween` only accepted `[]interface{}`; typed slices like `[]float64`
  were silently dropped.
- Unrecognized operators were silently skipped.
- The read-models docs referenced symbols that don't exist (`mink.Eq`,
  `mink.Contains`, `repo.Query`).

## Changes
**`adapters/postgres/readmodel.go`**
- Implement `FilterOpContains` as a type-aware predicate:
  - text columns → case-sensitive substring match `col LIKE '%' || $n || '%'`,
    with `%`/`_`/`\` in the value escaped so input is matched literally
  - JSONB columns → containment `col @> $n::jsonb` with the value JSON-encoded
- `FilterOpBetween` now accepts typed slices (`[]int`, `[]float64`, `[]string`,
  …) via `toInterfaceSlice`, consistent with `FilterOpIn`
- `buildWhereClause` returns an error for an unrecognized operator instead of
  silently dropping the condition

**Tests** (`adapters/postgres/readmodel_test.go`)
- New DB-free `TestBuildWhereClause` asserting exact SQL + args for every
  operator (CONTAINS on text vs JSONB, wildcard escaping, unknown-operator error)
- New integration cases for CONTAINS (substring + escaping) and BETWEEN

**Docs** (`website/docs/core/read-models.md`)
- Corrected the filter-operator list and query examples to the real API
- Added a "Case-insensitive matching" section (citext / lowercase column / raw
  SQL) and a design note on why there is no `FilterOpILike`

**`repository.go` / `CHANGELOG.md`**
- Updated the `FilterOpContains` doc comment; added a changelog entry

## Compatibility
Non-breaking — `CONTAINS` previously did nothing, so all behavior is additive.
No exported signatures changed.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean, `golangci-lint` → 0 issues
- `go test -short ./...` → all packages pass
- CONTAINS/BETWEEN integration cases run under `make test` with PostgreSQL