### PR TITLE
[readmodel] Error on malformed BETWEEN filter bounds

### DIFF
--- a/adapters/postgres/readmodel.go
+++ b/adapters/postgres/readmodel.go
@@ -647,11 +647,13 @@ func (r *PostgresRepository[T]) buildWhereClause(filters []mink.Filter) (string,
 		case mink.FilterOpIsNotNull:
 			conditions = append(conditions, fmt.Sprintf("%s IS NOT NULL", quotedCol))
 		case mink.FilterOpBetween:
-			if vals := toInterfaceSlice(f.Value); len(vals) == 2 {
-				conditions = append(conditions, fmt.Sprintf("%s BETWEEN $%d AND $%d", quotedCol, paramIdx, paramIdx+1))
-				args = append(args, vals[0], vals[1])
-				paramIdx += 2
+			vals := toInterfaceSlice(f.Value)
+			if len(vals) != 2 {
+				return "", nil, fmt.Errorf("mink/postgres/readmodel: BETWEEN filter on field %q requires exactly 2 bounds, got %d", f.Field, len(vals))
 			}
+			conditions = append(conditions, fmt.Sprintf("%s BETWEEN $%d AND $%d", quotedCol, paramIdx, paramIdx+1))
+			args = append(args, vals[0], vals[1])
+			paramIdx += 2
 		case mink.FilterOpContains:
 			cond, arg, err := r.buildContainsCondition(quotedCol, colName, f.Value, paramIdx)
 			if err != nil {

--- a/adapters/postgres/readmodel_test.go
+++ b/adapters/postgres/readmodel_test.go
@@ -1277,6 +1277,16 @@ func TestBuildWhereClause(t *testing.T) {
 			wantArgs:  []interface{}{float64(10), float64(20)},
 		},
 		{
+			name:    "between with wrong bound count returns an error",
+			filters: []mink.Filter{{Field: "total_amount", Op: mink.FilterOpBetween, Value: []int{1, 2, 3}}},
+			wantErr: true,
+		},
+		{
+			name:    "between with non-slice value returns an error",
+			filters: []mink.Filter{{Field: "total_amount", Op: mink.FilterOpBetween, Value: 5}},
+			wantErr: true,
+		},
+		{
 			name:      "contains on text column does substring match",
 			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpContains, Value: "end"}},
 			wantWhere: ` WHERE "status" LIKE '%' || $1 || '%'`,


### PR DESCRIPTION
## Summary

Follow-up to #128 / #129. A `BETWEEN` filter whose value did not resolve to a
2-element slice (wrong length, or not a slice at all) silently produced **no SQL
condition**, so malformed caller input could broaden the result set to an
unfiltered query — the same failure mode the unsupported-operator guard in #128
already prevents.

`buildWhereClause` now returns a clear error when a `BETWEEN` filter does not
resolve to exactly two bounds, instead of dropping the condition.

This was flagged by the Copilot review on both #128 and #129. The original fix
landed one commit after #128 was merged, so it never reached `develop`; this PR
brings it onto `develop` (and thus into #129).

## Changes

- `adapters/postgres/readmodel.go` — `FilterOpBetween` returns an error unless
  the value yields exactly two bounds.
- `adapters/postgres/readmodel_test.go` — unit cases for the wrong-count slice
  and the non-slice inputs.

## Testing

- `go build ./...`, `go vet ./adapters/postgres/`, `gofmt` clean
- `go test -short -run TestBuildWhereClause ./adapters/postgres/` passes
