### PR TITLE
[readmodel] Error on malformed IN/NOT IN filters; fix docs interface

### DIFF
--- a/adapters/postgres/readmodel.go
+++ b/adapters/postgres/readmodel.go
@@ -595,17 +595,17 @@ var filterOpToSQL = map[mink.FilterOp]string{
 // slice of arguments. It returns an error when the value is not a slice or is
 // an empty slice: a non-slice would otherwise silently drop the condition
 // (yielding an over-broad query), and an empty slice would emit invalid SQL
-// (IN () / NOT IN ()). The keyword ("IN" or "NOT IN") is only used for the
-// error message.
+// (IN () / NOT IN ()). Slice-ness is checked with reflection so that a typed
+// nil slice (e.g. []interface{}(nil)) is reported as empty rather than as a
+// non-slice. The keyword ("IN" or "NOT IN") is only used for the error message.
 func requireNonEmptySlice(f mink.Filter, keyword string) ([]interface{}, error) {
-	vals := toInterfaceSlice(f.Value)
-	if vals == nil {
+	if reflect.ValueOf(f.Value).Kind() != reflect.Slice {
 		return nil, fmt.Errorf("mink/postgres/readmodel: %s filter on field %q requires a slice value, got %T", keyword, f.Field, f.Value)
 	}
-	if len(vals) == 0 {
-		return nil, fmt.Errorf("mink/postgres/readmodel: %s filter on field %q requires a non-empty slice", keyword, f.Field)
+	if vals := toInterfaceSlice(f.Value); len(vals) > 0 {
+		return vals, nil
 	}
-	return vals, nil
+	return nil, fmt.Errorf("mink/postgres/readmodel: %s filter on field %q requires a non-empty slice", keyword, f.Field)
 }
 
 // buildInClause builds an IN or NOT IN clause from a slice of values.

--- a/adapters/postgres/readmodel.go
+++ b/adapters/postgres/readmodel.go
@@ -591,6 +591,23 @@ var filterOpToSQL = map[mink.FilterOp]string{
 	mink.FilterOpLike: "LIKE",
 }
 
+// requireNonEmptySlice resolves an IN / NOT IN filter value to a non-empty
+// slice of arguments. It returns an error when the value is not a slice or is
+// an empty slice: a non-slice would otherwise silently drop the condition
+// (yielding an over-broad query), and an empty slice would emit invalid SQL
+// (IN () / NOT IN ()). The keyword ("IN" or "NOT IN") is only used for the
+// error message.
+func requireNonEmptySlice(f mink.Filter, keyword string) ([]interface{}, error) {
+	vals := toInterfaceSlice(f.Value)
+	if vals == nil {
+		return nil, fmt.Errorf("mink/postgres/readmodel: %s filter on field %q requires a slice value, got %T", keyword, f.Field, f.Value)
+	}
+	if len(vals) == 0 {
+		return nil, fmt.Errorf("mink/postgres/readmodel: %s filter on field %q requires a non-empty slice", keyword, f.Field)
+	}
+	return vals, nil
+}
+
 // buildInClause builds an IN or NOT IN clause from a slice of values.
 func buildInClause(quotedCol, keyword string, values []interface{}, paramIdx *int, args *[]interface{}) string {
 	placeholders := make([]string, len(values))
@@ -635,13 +652,17 @@ func (r *PostgresRepository[T]) buildWhereClause(filters []mink.Filter) (string,
 		// Handle special operators
 		switch f.Op {
 		case mink.FilterOpIn:
-			if vals := toInterfaceSlice(f.Value); vals != nil {
-				conditions = append(conditions, buildInClause(quotedCol, "IN", vals, &paramIdx, &args))
+			vals, err := requireNonEmptySlice(f, "IN")
+			if err != nil {
+				return "", nil, err
 			}
+			conditions = append(conditions, buildInClause(quotedCol, "IN", vals, &paramIdx, &args))
 		case mink.FilterOpNotIn:
-			if vals := toInterfaceSlice(f.Value); vals != nil {
-				conditions = append(conditions, buildInClause(quotedCol, "NOT IN", vals, &paramIdx, &args))
+			vals, err := requireNonEmptySlice(f, "NOT IN")
+			if err != nil {
+				return "", nil, err
 			}
+			conditions = append(conditions, buildInClause(quotedCol, "NOT IN", vals, &paramIdx, &args))
 		case mink.FilterOpIsNull:
 			conditions = append(conditions, fmt.Sprintf("%s IS NULL", quotedCol))
 		case mink.FilterOpIsNotNull:

--- a/adapters/postgres/readmodel_test.go
+++ b/adapters/postgres/readmodel_test.go
@@ -1200,6 +1200,40 @@ func TestToInterfaceSlice(t *testing.T) {
 	})
 }
 
+// TestRequireNonEmptySlice verifies how IN / NOT IN filter values are
+// classified: a genuine non-slice yields the "requires a slice value" error,
+// while any empty slice — including a typed nil slice — yields the "non-empty
+// slice" error rather than being misreported as a non-slice.
+func TestRequireNonEmptySlice(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       interface{}
+		wantErr     bool
+		errContains string
+	}{
+		{"non-empty string slice", []string{"a"}, false, ""},
+		{"non-empty interface slice", []interface{}{1, 2}, false, ""},
+		{"non-slice string", "a", true, "requires a slice value"},
+		{"nil value", nil, true, "requires a slice value"},
+		{"empty string slice", []string{}, true, "non-empty slice"},
+		{"typed nil interface slice", []interface{}(nil), true, "non-empty slice"},
+		{"typed nil string slice", []string(nil), true, "non-empty slice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals, err := requireNonEmptySlice(
+				mink.Filter{Field: "status", Op: mink.FilterOpIn, Value: tt.value}, "IN")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, vals)
+		})
+	}
+}
+
 // TestBuildWhereClause verifies SQL generation for every filter operator
 // without requiring a live database. The repository is constructed with a
 // known column set and schema so buildWhereClause can be exercised directly.

--- a/adapters/postgres/readmodel_test.go
+++ b/adapters/postgres/readmodel_test.go
@@ -1287,6 +1287,26 @@ func TestBuildWhereClause(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "in with non-slice value returns an error",
+			filters: []mink.Filter{{Field: "status", Op: mink.FilterOpIn, Value: "a"}},
+			wantErr: true,
+		},
+		{
+			name:    "in with empty slice returns an error",
+			filters: []mink.Filter{{Field: "status", Op: mink.FilterOpIn, Value: []string{}}},
+			wantErr: true,
+		},
+		{
+			name:    "not in with non-slice value returns an error",
+			filters: []mink.Filter{{Field: "status", Op: mink.FilterOpNotIn, Value: "a"}},
+			wantErr: true,
+		},
+		{
+			name:    "not in with empty slice returns an error",
+			filters: []mink.Filter{{Field: "status", Op: mink.FilterOpNotIn, Value: []int{}}},
+			wantErr: true,
+		},
+		{
 			name:      "contains on text column does substring match",
 			filters:   []mink.Filter{{Field: "status", Op: mink.FilterOpContains, Value: "end"}},
 			wantWhere: ` WHERE "status" LIKE '%' || $1 || '%'`,

--- a/website/docs/core/read-models.md
+++ b/website/docs/core/read-models.md
@@ -271,17 +271,21 @@ Generic repository for read model storage:
 ```go
 // Interface definition
 type ReadModelRepository[T any] interface {
-    Insert(ctx context.Context, model *T) error
     Get(ctx context.Context, id string) (*T, error)
-    Update(ctx context.Context, id string, fn func(*T)) error
-    Delete(ctx context.Context, id string) error
+    GetMany(ctx context.Context, ids []string) ([]*T, error)
     Find(ctx context.Context, query Query) ([]*T, error)
     FindOne(ctx context.Context, query Query) (*T, error)
     Count(ctx context.Context, query Query) (int64, error)
-    Exists(ctx context.Context, id string) (bool, error)
-    GetAll(ctx context.Context) ([]*T, error)
+    Insert(ctx context.Context, model *T) error
+    Update(ctx context.Context, id string, fn func(*T)) error
+    Upsert(ctx context.Context, model *T) error
+    Delete(ctx context.Context, id string) error
+    DeleteMany(ctx context.Context, query Query) (int64, error)
     Clear(ctx context.Context) error
 }
+
+// Both the in-memory and PostgreSQL repositories also provide Exists(ctx, id)
+// and GetAll(ctx) helpers beyond the interface above.
 
 // In-memory implementation (great for testing)
 repo := mink.NewInMemoryRepository[OrderSummary](func(o *OrderSummary) string {


### PR DESCRIPTION
## Summary

Follow-up to the second Copilot review on #129. Applies the same
"never silently drop a filter" contract to `IN` / `NOT IN`, and corrects the
read-model documentation's interface block.

## Problem

In `buildWhereClause` (PostgreSQL adapter):

- `FilterOpIn` / `FilterOpNotIn` with a **non-slice** value were silently
  dropped (`toInterfaceSlice` returns `nil`), producing an over-broad /
  unfiltered query.
- An **empty slice** generated invalid SQL — `IN ()` / `NOT IN ()`.

Both are the failure modes #128/#130 already addressed for unsupported
operators and `BETWEEN`; `IN` / `NOT IN` were left inconsistent.

The docs' `ReadModelRepository[T]` interface block had also drifted from
`repository.go`.

## Changes

- `adapters/postgres/readmodel.go` — `IN` / `NOT IN` now return a clear error
  when the value is not a slice or is an empty slice, via a shared
  `requireNonEmptySlice` helper (consistent with the `BETWEEN` check).
- `adapters/postgres/readmodel_test.go` — unit cases for the non-slice and
  empty-slice inputs on both `IN` and `NOT IN`.
- `website/docs/core/read-models.md` — corrected the interface block to match
  `repository.go` (added `GetMany`, `Upsert`, `DeleteMany`; moved `Exists` /
  `GetAll` out of the interface, since they are concrete-type helpers on the
  in-memory and PostgreSQL repositories, not part of the interface).

## Testing

- `go build ./...`, `go vet ./adapters/postgres/`, `gofmt` clean
- `go test -short -run TestBuildWhereClause ./adapters/postgres/` passes
  (22 subtests, including the new IN / NOT IN error cases)
