### PR TITLE
[docs] Document IdempotencyConfig.ReservationTTL

### DIFF
--- a/website/docs/advanced/advanced-patterns.md
+++ b/website/docs/advanced/advanced-patterns.md
@@ -256,12 +256,13 @@ func (c CreateOrder) IdempotencyKey() string {
 ```go
 // IdempotencyConfig controls middleware behavior
 type IdempotencyConfig struct {
-    Store        IdempotencyStore     // Required: storage backend
-    TTL          time.Duration        // Optional: result expiration (default: 24h)
-    KeyGenerator func(Command) string // Optional: custom key generator (default: GetIdempotencyKey)
-    StoreErrors  bool                 // Optional: replay stored failures instead of retrying (default: false)
-    FailClosed   bool                 // Optional: fail the command if the store is down (default: false)
-    SkipCommands []string             // Optional: command types that bypass the idempotency check
+    Store          IdempotencyStore     // Required: storage backend
+    TTL            time.Duration        // Optional: result expiration (default: 24h)
+    ReservationTTL time.Duration        // Optional: in-flight reservation lease, bounds how long a duplicate is blocked (default: 5m)
+    KeyGenerator   func(Command) string // Optional: custom key generator (default: GetIdempotencyKey)
+    StoreErrors    bool                 // Optional: replay stored failures instead of retrying (default: false)
+    FailClosed     bool                 // Optional: fail the command if the store is down (default: false)
+    SkipCommands   []string             // Optional: command types that bypass the idempotency check
 }
 
 // Use default configuration

--- a/website/docs/advanced/api-design.md
+++ b/website/docs/advanced/api-design.md
@@ -248,12 +248,13 @@ type IdempotencyStore interface {
 
 // IdempotencyConfig configures idempotency middleware
 type IdempotencyConfig struct {
-    Store        IdempotencyStore     // Required: storage backend
-    TTL          time.Duration        // Result expiration (default: 24h)
-    KeyGenerator func(Command) string // Custom key generator (default: GetIdempotencyKey)
-    StoreErrors  bool                 // Replay stored failures instead of retrying (default: false)
-    FailClosed   bool                 // Fail the command on store outage (default: false = fail-open)
-    SkipCommands []string             // Command types that bypass the idempotency check
+    Store          IdempotencyStore     // Required: storage backend
+    TTL            time.Duration        // Result expiration (default: 24h)
+    ReservationTTL time.Duration        // In-flight reservation lease; bounds how long a duplicate is blocked (default: 5m)
+    KeyGenerator   func(Command) string // Custom key generator (default: GetIdempotencyKey)
+    StoreErrors    bool                 // Replay stored failures instead of retrying (default: false)
+    FailClosed     bool                 // Fail the command on store outage (default: false = fail-open)
+    SkipCommands   []string             // Command types that bypass the idempotency check
 }
 
 func DefaultIdempotencyConfig(store IdempotencyStore) IdempotencyConfig


### PR DESCRIPTION
## Summary

The in-flight reservation lease (`ReservationTTL`, default 5m) became part of the
public `IdempotencyConfig`, but the docs still showed the struct without it. This
adds the field to both snippets so readers can discover and tune the lease that
bounds how long a duplicate command is blocked while one is already in progress.

Addresses the Copilot review feedback on #141.

## Changes
- `website/docs/advanced/api-design.md` — add `ReservationTTL` to the `IdempotencyConfig` struct
- `website/docs/advanced/advanced-patterns.md` — same, in the config snippet

Docs-only; no code changes.
