### PR TITLE
[test] Integration coverage for recently-changed behaviors

### DIFF
--- a/adapters/postgres/idempotency_integration_test.go
+++ b/adapters/postgres/idempotency_integration_test.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go-mink.dev/adapters"
+)
+
+// TestPostgresIdempotencyStore_StoreIfAbsent_ConcurrentRace verifies that under a
+// real concurrent race on the same key, exactly one StoreIfAbsent wins. The DB
+// unique constraint — not application timing — is what enforces single execution,
+// which is the whole point of the reservation primitive.
+func TestPostgresIdempotencyStore_StoreIfAbsent_ConcurrentRace(t *testing.T) {
+	store := setupIdempotencyTestStore(t)
+	ctx := context.Background()
+	key := fmt.Sprintf("race-%d", time.Now().UnixNano())
+
+	const racers = 8
+	oks := make([]bool, racers)
+	errs := make([]error, racers)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rec := &adapters.IdempotencyRecord{
+				Key:         key,
+				CommandType: "RaceCommand",
+				Success:     true,
+				ProcessedAt: time.Now(),
+				ExpiresAt:   time.Now().Add(time.Hour),
+			}
+			<-start // release all racers together to maximize contention
+			oks[i], errs[i] = store.StoreIfAbsent(ctx, rec)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	wins := 0
+	for i := range errs {
+		require.NoError(t, errs[i])
+		if oks[i] {
+			wins++
+		}
+	}
+	assert.Equal(t, 1, wins, "exactly one racer may reserve the key")
+}

--- a/adapters/postgres/outbox_store_test.go
+++ b/adapters/postgres/outbox_store_test.go
@@ -90,6 +90,49 @@ func TestPostgresOutboxStore_ScheduleAndFetch(t *testing.T) {
 	assert.Len(t, fetched2, 0)
 }
 
+// TestPostgresOutboxStore_ReclaimStale verifies that a message stuck in the
+// processing state is reclaimed only once it exceeds the staleness threshold, is
+// left alone while still fresh, and becomes fetchable again afterwards without
+// duplication.
+func TestPostgresOutboxStore_ReclaimStale(t *testing.T) {
+	store, ctx := setupOutboxStore(t)
+
+	require.NoError(t, store.Schedule(ctx, []*adapters.OutboxMessage{
+		{AggregateID: "agg-stale", EventType: "E", Destination: "kafka:t", Payload: []byte(`{}`), MaxAttempts: 5},
+	}))
+
+	// FetchPending moves it into Processing and stamps last_attempt_at = now.
+	fetched, err := store.FetchPending(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, fetched, 1)
+	require.Equal(t, adapters.OutboxProcessing, fetched[0].Status)
+
+	// A fresh in-flight message must NOT be reclaimed by a large threshold.
+	reclaimed, err := store.ReclaimStale(ctx, time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), reclaimed, "a just-fetched message must not be reclaimed")
+
+	// It is still invisible to a normal fetch (still Processing).
+	none, err := store.FetchPending(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+
+	// Backdate the in-flight message deterministically (avoids sleep-based
+	// flakiness on slow/loaded CI), then it is reclaimed back to pending.
+	_, err = store.db.ExecContext(ctx,
+		"UPDATE "+store.fullTableName()+" SET last_attempt_at = NOW() - make_interval(secs => 3600)")
+	require.NoError(t, err)
+	reclaimed, err = store.ReclaimStale(ctx, time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), reclaimed, "a stale processing message must be reclaimed")
+
+	// And is fetchable again — exactly one row, no duplication.
+	refetched, err := store.FetchPending(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, refetched, 1)
+	assert.Equal(t, "agg-stale", refetched[0].AggregateID)
+}
+
 func TestPostgresOutboxStore_MarkCompletedAndFailed(t *testing.T) {
 	store, ctx := setupOutboxStore(t)
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1746,6 +1746,45 @@ func TestPostgresAdapter_AppendWithOutbox_Atomicity(t *testing.T) {
 		"version should start at 1, proving the earlier failed attempt left no trace")
 }
 
+// TestPostgresAdapter_AppendWithOutbox_VersionConflictRollsBackBoth verifies that
+// an optimistic-concurrency conflict on the event side rolls back the outbox
+// messages too: neither the events nor the outbox rows persist. Integration test
+// (skips without TEST_DATABASE_URL).
+func TestPostgresAdapter_AppendWithOutbox_VersionConflictRollsBackBoth(t *testing.T) {
+	adapter := setupIntegrationTest(t)
+	ctx := context.Background()
+
+	outbox := NewOutboxStoreFromAdapter(adapter)
+	require.NoError(t, outbox.Initialize(ctx))
+
+	streamID := fmt.Sprintf("Order-conflict-%d", time.Now().UnixNano())
+
+	// Seed the stream so it exists at version 1.
+	_, err := adapter.Append(ctx, streamID,
+		[]adapters.EventRecord{{Type: "OrderCreated", Data: []byte(`{"orderId":"c"}`)}}, mink.NoStream)
+	require.NoError(t, err)
+
+	// AppendWithOutbox with expectedVersion=NoStream now conflicts (the stream exists).
+	messages := []*adapters.OutboxMessage{
+		{AggregateID: "c", EventType: "OrderShipped", Destination: "kafka:orders", Payload: []byte(`{"ok":true}`)},
+	}
+	_, err = adapter.AppendWithOutbox(ctx, streamID,
+		[]adapters.EventRecord{{Type: "OrderShipped", Data: []byte(`{}`)}}, mink.NoStream, outbox, messages)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, adapters.ErrConcurrencyConflict),
+		"a version conflict must surface as ErrConcurrencyConflict")
+
+	// The stream must still be at version 1 — the conflicting event was not appended.
+	info, err := adapter.GetStreamInfo(ctx, streamID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), info.Version)
+
+	// And no outbox message was written: both sides rolled back together.
+	pending, err := outbox.FetchPending(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending, "the outbox message must roll back with the event-version conflict")
+}
+
 // TestPostgresAdapter_Append_UniqueViolationMapsToConflict verifies that a unique
 // violation on the event insert path surfaces as ErrConcurrencyConflict even when
 // the FOR UPDATE pre-check is bypassed. We simulate a lost race by inserting an

--- a/adapters/postgres/projection_integration_test.go
+++ b/adapters/postgres/projection_integration_test.go
@@ -1,0 +1,163 @@
+package postgres_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go-mink.dev"
+	"go-mink.dev/adapters/postgres"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
+)
+
+// projRebuildEvent is a dedicated event type for the projection rebuild test so a
+// global-position projection in a shared schema would not be affected by it.
+type projRebuildEvent struct {
+	Seq int `json:"seq"`
+}
+
+// countingProjection is a minimal async projection (with Clear, so it is
+// Clearable) that counts the events it applies, making a rebuild's clear+replay
+// observable.
+type countingProjection struct {
+	mink.AsyncProjectionBase
+	mu    sync.Mutex
+	count int
+}
+
+func newCountingProjection(name string) *countingProjection {
+	return &countingProjection{
+		AsyncProjectionBase: mink.NewAsyncProjectionBase(name, "projRebuildEvent"),
+	}
+}
+
+func (p *countingProjection) Apply(_ context.Context, _ mink.StoredEvent) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.count++
+	return nil
+}
+
+func (p *countingProjection) ApplyBatch(_ context.Context, events []mink.StoredEvent) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.count += len(events)
+	return nil
+}
+
+func (p *countingProjection) Clear(_ context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.count = 0
+	return nil
+}
+
+func (p *countingProjection) Count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.count
+}
+
+// memCheckpoints is an in-memory CheckpointStore. The events under test live in
+// real PostgreSQL; only the checkpoint bookkeeping is in memory.
+type memCheckpoints struct {
+	mu sync.Mutex
+	m  map[string]uint64
+}
+
+func newMemCheckpoints() *memCheckpoints { return &memCheckpoints{m: map[string]uint64{}} }
+
+func (c *memCheckpoints) GetCheckpoint(_ context.Context, name string) (uint64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.m[name], nil
+}
+
+func (c *memCheckpoints) SetCheckpoint(_ context.Context, name string, pos uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[name] = pos
+	return nil
+}
+
+func (c *memCheckpoints) DeleteCheckpoint(_ context.Context, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.m, name)
+	return nil
+}
+
+func (c *memCheckpoints) GetAllCheckpoints(_ context.Context) (map[string]uint64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]uint64, len(c.m))
+	for k, v := range c.m {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// setupProjectionStore creates an event store over a throwaway PostgreSQL schema
+// (so a global-position projection only ever sees this test's events) and drops
+// the schema on cleanup.
+func setupProjectionStore(t *testing.T) (*mink.EventStore, context.Context) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping PostgreSQL integration test in short mode")
+	}
+	connStr := getTestDatabaseURL(t)
+
+	schema := fmt.Sprintf("proj_it_%d", time.Now().UnixNano())
+	adapter, err := postgres.NewAdapter(connStr, postgres.WithSchema(schema))
+	require.NoError(t, err)
+	require.NoError(t, adapter.Initialize(context.Background()))
+
+	t.Cleanup(func() {
+		if db, derr := sql.Open("pgx", connStr); derr == nil {
+			_, _ = db.Exec(`DROP SCHEMA IF EXISTS "` + schema + `" CASCADE`)
+			_ = db.Close()
+		}
+		_ = adapter.Close()
+	})
+
+	return mink.New(adapter), context.Background()
+}
+
+// TestPostgresIntegration_ProjectionRebuild_ReplaysFromRealStore verifies that an
+// async projection catches up against a real PostgreSQL store and that Rebuild
+// clears and replays the full history, resuming the worker from the rebuilt
+// checkpoint without double-applying. Run with -race to exercise the worker/
+// rebuild serialization (processingMu).
+func TestPostgresIntegration_ProjectionRebuild_ReplaysFromRealStore(t *testing.T) {
+	store, ctx := setupProjectionStore(t)
+	store.RegisterEvents(&projRebuildEvent{})
+
+	const n = 12
+	events := make([]interface{}, n)
+	for i := range events {
+		events[i] = &projRebuildEvent{Seq: i + 1}
+	}
+	require.NoError(t, store.Append(ctx, "ProjStream-1", events))
+
+	engine := mink.NewProjectionEngine(store, mink.WithCheckpointStore(newMemCheckpoints()))
+	proj := newCountingProjection(fmt.Sprintf("Counter-%d", time.Now().UnixNano()))
+	require.NoError(t, engine.RegisterAsync(proj))
+
+	require.NoError(t, engine.Start(ctx))
+	t.Cleanup(func() { _ = engine.Stop(context.Background()) })
+
+	// Catch up against the real store.
+	require.Eventually(t, func() bool { return proj.Count() == n }, 15*time.Second, 50*time.Millisecond,
+		"projection should catch up to all events")
+
+	// Rebuild clears and replays from the real store; the worker resumes from the
+	// rebuilt checkpoint, so the count settles back at exactly n (no double-apply).
+	require.NoError(t, engine.Rebuild(ctx, proj.Name()))
+	require.Eventually(t, func() bool { return proj.Count() == n }, 15*time.Second, 50*time.Millisecond,
+		"projection should hold exactly n events after rebuild")
+}

--- a/adapters/postgres/saga_recompensation_integration_test.go
+++ b/adapters/postgres/saga_recompensation_integration_test.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go-mink.dev"
+)
+
+// TestSagaStore_E2E_FindByRunningExcludesCompensating verifies the store-level
+// guarantee that the saga manager's re-compensation prevention relies on: the
+// timeout sweep queries for Running sagas, so a saga already Compensating is never
+// returned (hence never re-swept and never re-dispatched for compensation).
+func TestSagaStore_E2E_FindByRunningExcludesCompensating(t *testing.T) {
+	store, cleanup := setupTestSagaStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sagaType := "RecompSaga-" + time.Now().Format("20060102150405.000000")
+
+	running := &mink.SagaState{
+		ID:            "running-" + sagaType,
+		Type:          sagaType,
+		CorrelationID: "corr-running",
+		Status:        mink.SagaStatusRunning,
+		StartedAt:     time.Now(),
+	}
+	compensating := &mink.SagaState{
+		ID:            "compensating-" + sagaType,
+		Type:          sagaType,
+		CorrelationID: "corr-compensating",
+		Status:        mink.SagaStatusCompensating,
+		StartedAt:     time.Now(),
+	}
+	require.NoError(t, store.Save(ctx, running))
+	require.NoError(t, store.Save(ctx, compensating))
+
+	// The timeout sweep looks for Running sagas only.
+	found, err := store.FindByType(ctx, sagaType, mink.SagaStatusRunning)
+	require.NoError(t, err)
+
+	ids := make(map[string]bool, len(found))
+	for _, s := range found {
+		ids[s.ID] = true
+	}
+	assert.True(t, ids[running.ID], "the Running saga must be returned to the sweep")
+	assert.False(t, ids[compensating.ID],
+		"a Compensating saga must not be returned by a Running-status query (no re-compensation)")
+}

--- a/adapters/postgres/subscription_integration_test.go
+++ b/adapters/postgres/subscription_integration_test.go
@@ -1,0 +1,148 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go-mink.dev"
+)
+
+// subSeqEvent is a minimal event type for subscription integration tests.
+type subSeqEvent struct {
+	Seq int `json:"seq"`
+}
+
+// subUniqueStream returns a stream id unique to this test run so integration
+// tests sharing the schema do not observe each other's events.
+func subUniqueStream(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// subCollect reads up to n events from the subscription, returning early once
+// timeout elapses so a missing event fails the assertion loudly instead of
+// hanging the test.
+func subCollect(t *testing.T, sub mink.Subscription, n int, timeout time.Duration) []mink.StoredEvent {
+	t.Helper()
+	got := make([]mink.StoredEvent, 0, n)
+	deadline := time.After(timeout)
+	for len(got) < n {
+		select {
+		case e, ok := <-sub.Events():
+			if !ok {
+				return got
+			}
+			got = append(got, e)
+		case <-deadline:
+			return got
+		}
+	}
+	return got
+}
+
+// drainUntilClosed reads and discards events until Events() closes, failing the
+// test (rather than hanging CI) if the subscription does not close within timeout.
+func drainUntilClosed(t *testing.T, sub mink.Subscription, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case _, ok := <-sub.Events():
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("subscription did not close within %s", timeout)
+		}
+	}
+}
+
+// TestPostgresIntegration_SubscribeStream_FromVersionIsExclusive verifies that
+// fromVersion is exclusive against a real adapter-native subscription: subscribing
+// from version 1 delivers v2 and v3, not v1 (consistent with Load).
+func TestPostgresIntegration_SubscribeStream_FromVersionIsExclusive(t *testing.T) {
+	store, ctx := setupE2EStore(t)
+	store.RegisterEvents(&subSeqEvent{})
+	streamID := subUniqueStream("ExclBoundary")
+
+	require.NoError(t, store.Append(ctx, streamID, []interface{}{
+		&subSeqEvent{Seq: 1}, &subSeqEvent{Seq: 2}, &subSeqEvent{Seq: 3},
+	}))
+
+	sub, err := store.SubscribeStream(ctx, streamID, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Close() })
+
+	got := subCollect(t, sub, 2, 5*time.Second)
+	require.Len(t, got, 2, "exclusive fromVersion=1 must deliver exactly v2 and v3")
+	assert.Equal(t, int64(2), got[0].Version)
+	assert.Equal(t, int64(3), got[1].Version)
+}
+
+// TestPostgresIntegration_SubscribeStream_CleanCloseLeavesErrNil verifies the
+// Err() contract against the real PostgreSQL subscription: a consumer Close() is
+// a clean shutdown and must leave Err() nil.
+func TestPostgresIntegration_SubscribeStream_CleanCloseLeavesErrNil(t *testing.T) {
+	store, ctx := setupE2EStore(t)
+	store.RegisterEvents(&subSeqEvent{})
+	streamID := subUniqueStream("CloseNil")
+
+	require.NoError(t, store.Append(ctx, streamID, []interface{}{&subSeqEvent{Seq: 1}}))
+
+	sub, err := store.SubscribeStream(ctx, streamID, 0)
+	require.NoError(t, err)
+
+	require.Len(t, subCollect(t, sub, 1, 5*time.Second), 1)
+
+	require.NoError(t, sub.Close())
+	// Draining until Events() closes guarantees the bridge goroutine has exited
+	// (bounded so a Close/drain regression fails fast instead of hanging CI).
+	drainUntilClosed(t, sub, 5*time.Second)
+	assert.NoError(t, sub.Err(), "a consumer Close() is a clean shutdown")
+}
+
+// TestPostgresIntegration_SubscribeStream_ExternalCancelSurfacesErr verifies that
+// cancelling the caller's context (an external stop) is surfaced via Err().
+func TestPostgresIntegration_SubscribeStream_ExternalCancelSurfacesErr(t *testing.T) {
+	store, _ := setupE2EStore(t)
+	store.RegisterEvents(&subSeqEvent{})
+	streamID := subUniqueStream("CancelErr")
+
+	subCtx, cancel := context.WithCancel(context.Background())
+	sub, err := store.SubscribeStream(subCtx, streamID, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Close() })
+
+	cancel()
+	drainUntilClosed(t, sub, 5*time.Second)
+	assert.ErrorIs(t, sub.Err(), context.Canceled, "external cancellation must surface via Err()")
+}
+
+// TestPostgresIntegration_SubscribeStream_HonorsBufferSizeWithoutDropping verifies
+// that a burst delivered through a buffered subscription arrives complete and in
+// order (the caller's BufferSize is forwarded to the adapter, not just the bridge).
+func TestPostgresIntegration_SubscribeStream_HonorsBufferSizeWithoutDropping(t *testing.T) {
+	store, ctx := setupE2EStore(t)
+	store.RegisterEvents(&subSeqEvent{})
+	streamID := subUniqueStream("BufferAll")
+
+	const n = 25
+	events := make([]interface{}, n)
+	for i := range events {
+		events[i] = &subSeqEvent{Seq: i + 1}
+	}
+	require.NoError(t, store.Append(ctx, streamID, events))
+
+	sub, err := store.SubscribeStream(ctx, streamID, 0, mink.SubscriptionOptions{BufferSize: n})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Close() })
+
+	got := subCollect(t, sub, n, 10*time.Second)
+	require.Len(t, got, n, "all buffered events must be delivered without loss")
+	for i, e := range got {
+		assert.Equal(t, int64(i+1), e.Version, "events must arrive in version order")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the integration-test gaps identified for the recently-merged "complete and
harden" work. Adds real-PostgreSQL coverage for behaviors that were previously
only unit/memory-tested or untested, and verifies two suspected projection-engine
bugs (both turned out to be non-bugs).

## Suspected bugs — verified, no fix needed
- **Live-projection "silent drop":** `NotifyLiveProjections` uses a *blocking*
  select (no `default:`) and `drainLiveWorker` flushes buffered events at stop, so
  it back-pressures correctly. False positive.
- **Poison-batch "over-skip":** skipping the whole opaque `ApplyBatch` batch is the
  safe choice — a per-event fallback would re-apply events `ApplyBatch` may have
  partially applied (double-apply on non-idempotent projections). Documented and
  correct.

## New integration tests (real PostgreSQL)
- `SubscribeStream` `fromVersion` is exclusive (delivers v2,v3 after fromVersion=1)
- `Subscription.Err()` nil after a clean `Close()`; `context.Canceled` on external cancel
- a buffered subscription delivers a burst without loss, in version order
- outbox `ReclaimStale`: fresh in-flight not reclaimed, stale reclaimed + re-fetchable once
- idempotency `StoreIfAbsent`: exactly one winner under a real concurrent DB race
- `AppendWithOutbox`: an event-version conflict rolls back events **and** outbox together
- projection `Rebuild` replays from the real store and resumes without double-applying
- saga store: a Running-status query excludes Compensating sagas (re-compensation guarantee)

## Validation
All pass against **PostgreSQL 17**; the rebuild + idempotency-race tests are
`-race`-clean across repeated runs. Full `adapters/postgres` integration suite is
green; whole-repo `-short` is green; `gofmt` and `golangci-lint` are clean.

Test-only — no production code changes.
