### PR TITLE
[audit] Nil-entry guards, context handling, and CorrelationID query

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -44,6 +44,9 @@ var (
 	// ErrNilOutboxStore indicates AppendWithOutbox was given outbox messages but no
 	// OutboxStore to schedule them into.
 	ErrNilOutboxStore = errors.New("mink: nil outbox store")
+
+	// ErrNilAuditEntry is returned by AuditStore.Append when the entry is nil.
+	ErrNilAuditEntry = errors.New("mink: nil audit entry")
 )
 
 // SagaNotFoundError provides detailed information about a missing saga.

--- a/adapters/audit.go
+++ b/adapters/audit.go
@@ -80,6 +80,9 @@ type AuditQuery struct {
 	// AggregateID filters by exact aggregate ID.
 	AggregateID string
 
+	// CorrelationID filters by exact correlation ID (e.g. all commands in one request flow).
+	CorrelationID string
+
 	// From filters entries with Timestamp >= From (inclusive). Zero means no lower bound.
 	From time.Time
 

--- a/adapters/memory/audit.go
+++ b/adapters/memory/audit.go
@@ -39,8 +39,26 @@ func (s *AuditStore) Close() error {
 
 // Append stores a copy of the audit entry.
 func (s *AuditStore) Append(ctx context.Context, entry *adapters.AuditEntry) error {
+	if entry == nil {
+		return adapters.ErrNilAuditEntry
+	}
+	// Fast-fail before contending for the lock.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Re-check once the lock is held: the context may have been cancelled while
+	// this call was blocked acquiring it, and a cancelled write must not append.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	s.entries = append(s.entries, adapters.CopyAuditEntry(entry))
 	return nil
@@ -58,6 +76,9 @@ func matchesAuditQuery(entry *adapters.AuditEntry, q adapters.AuditQuery) bool {
 		return false
 	}
 	if q.AggregateID != "" && entry.AggregateID != q.AggregateID {
+		return false
+	}
+	if q.CorrelationID != "" && entry.CorrelationID != q.CorrelationID {
 		return false
 	}
 	// From is inclusive: keep entries with Timestamp >= From.

--- a/adapters/memory/audit_test.go
+++ b/adapters/memory/audit_test.go
@@ -91,6 +91,65 @@ func TestAuditStore_Append_NilMetadataStaysNil(t *testing.T) {
 	assert.Nil(t, got[0].Metadata)
 }
 
+func TestAuditStore_Append_NilEntry(t *testing.T) {
+	store := NewAuditStore()
+	ctx := context.Background()
+
+	err := store.Append(ctx, nil)
+	require.ErrorIs(t, err, adapters.ErrNilAuditEntry)
+
+	// A nil entry must not be stored (and must not panic a later query).
+	got, err := store.Find(ctx, adapters.AuditQuery{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestAuditStore_Append_ContextCancelled(t *testing.T) {
+	store := NewAuditStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := store.Append(ctx, &adapters.AuditEntry{ID: "1", Timestamp: time.Now()})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, store.Len())
+}
+
+func TestAuditStore_Append_ContextCancelledWaitingForLock(t *testing.T) {
+	store := NewAuditStore()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Hold the lock so the concurrent Append below blocks while acquiring it,
+	// then cancel before releasing. The post-lock cancellation check must honor
+	// the cancellation and refuse to append, even though the context was still
+	// live when Append passed its pre-lock fast-fail check.
+	store.mu.Lock()
+	appended := make(chan error, 1)
+	go func() {
+		appended <- store.Append(ctx, &adapters.AuditEntry{ID: "1", Timestamp: time.Now()})
+	}()
+	cancel()
+	store.mu.Unlock()
+
+	require.ErrorIs(t, <-appended, context.Canceled)
+	assert.Equal(t, 0, store.Len())
+}
+
+func TestAuditStore_Find_ByCorrelationID(t *testing.T) {
+	store := NewAuditStore()
+	ctx := context.Background()
+	require.NoError(t, store.Append(ctx, &adapters.AuditEntry{ID: "1", CorrelationID: "corr-A", Timestamp: time.Now()}))
+	require.NoError(t, store.Append(ctx, &adapters.AuditEntry{ID: "2", CorrelationID: "corr-B", Timestamp: time.Now()}))
+	require.NoError(t, store.Append(ctx, &adapters.AuditEntry{ID: "3", CorrelationID: "corr-A", Timestamp: time.Now()}))
+
+	got, err := store.Find(ctx, adapters.AuditQuery{CorrelationID: "corr-A"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"1", "3"}, ids(got))
+
+	n, err := store.Count(ctx, adapters.AuditQuery{CorrelationID: "corr-A"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+}
+
 func TestAuditStore_Find_Filters(t *testing.T) {
 	store, base := seedAuditStore(t)
 	ctx := context.Background()

--- a/adapters/postgres/audit.go
+++ b/adapters/postgres/audit.go
@@ -107,6 +107,9 @@ func (s *AuditStore) Close() error {
 
 // Append writes a single audit entry.
 func (s *AuditStore) Append(ctx context.Context, entry *adapters.AuditEntry) error {
+	if entry == nil {
+		return adapters.ErrNilAuditEntry
+	}
 	tableQ := s.fullTableName()
 
 	// Build the column list. The id and timestamp columns have DB defaults, but
@@ -190,6 +193,9 @@ func buildAuditWhere(q adapters.AuditQuery) (string, []interface{}) {
 	}
 	if q.AggregateID != "" {
 		add("aggregate_id = $%d", q.AggregateID)
+	}
+	if q.CorrelationID != "" {
+		add("correlation_id = $%d", q.CorrelationID)
 	}
 	if !q.From.IsZero() {
 		add("timestamp >= $%d", q.From)

--- a/adapters/postgres/audit_test.go
+++ b/adapters/postgres/audit_test.go
@@ -48,9 +48,9 @@ func seedPGAudit(t *testing.T, store *AuditStore) time.Time {
 	base := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
 
 	entries := []*adapters.AuditEntry{
-		{ID: "11111111-1111-1111-1111-111111111111", CommandType: "CreateOrder", Actor: "alice", TenantID: "t1", AggregateID: "order-1", Success: true, DurationMs: 5, Timestamp: base},
+		{ID: "11111111-1111-1111-1111-111111111111", CommandType: "CreateOrder", Actor: "alice", TenantID: "t1", AggregateID: "order-1", CorrelationID: "req-1", Success: true, DurationMs: 5, Timestamp: base},
 		{ID: "22222222-2222-2222-2222-222222222222", CommandType: "AddItem", Actor: "bob", TenantID: "t1", AggregateID: "order-1", Success: true, DurationMs: 7, Timestamp: base.Add(1 * time.Minute)},
-		{ID: "33333333-3333-3333-3333-333333333333", CommandType: "ShipOrder", Actor: "alice", TenantID: "t2", AggregateID: "order-2", Success: false, Error: "boom", DurationMs: 9, Timestamp: base.Add(2 * time.Minute)},
+		{ID: "33333333-3333-3333-3333-333333333333", CommandType: "ShipOrder", Actor: "alice", TenantID: "t2", AggregateID: "order-2", CorrelationID: "req-1", Success: false, Error: "boom", DurationMs: 9, Timestamp: base.Add(2 * time.Minute)},
 		{ID: "44444444-4444-4444-4444-444444444444", CommandType: "CreateOrder", Actor: "carol", TenantID: "t2", AggregateID: "order-3", Success: true, DurationMs: 3, Timestamp: base.Add(3 * time.Minute)},
 		{ID: "55555555-5555-5555-5555-555555555555", CommandType: "AddItem", Actor: "alice", TenantID: "t1", AggregateID: "order-3", Success: false, Error: "nope", DurationMs: 4, Timestamp: base.Add(4 * time.Minute)},
 	}
@@ -72,6 +72,19 @@ func TestAuditStore_Initialize(t *testing.T) {
 	store := setupAuditTestStore(t)
 	// Calling Initialize again should be idempotent.
 	require.NoError(t, store.Initialize(context.Background()))
+}
+
+func TestAuditStore_Append_NilEntry(t *testing.T) {
+	store := setupAuditTestStore(t)
+	ctx := context.Background()
+
+	err := store.Append(ctx, nil)
+	require.ErrorIs(t, err, adapters.ErrNilAuditEntry)
+
+	// A nil entry must not be inserted.
+	got, err := store.Find(ctx, adapters.AuditQuery{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestAuditStore_AppendAndFind_RoundTrip(t *testing.T) {
@@ -172,6 +185,7 @@ func TestAuditStore_Find_Filters(t *testing.T) {
 		{"actor", adapters.AuditQuery{Actor: "alice"}, 3},
 		{"tenant", adapters.AuditQuery{TenantID: "t1"}, 3},
 		{"aggregate", adapters.AuditQuery{AggregateID: "order-3"}, 2},
+		{"correlation", adapters.AuditQuery{CorrelationID: "req-1"}, 2},
 		{"success true", adapters.AuditQuery{Success: auditBoolPtr(true)}, 3},
 		{"success false", adapters.AuditQuery{Success: auditBoolPtr(false)}, 2},
 		{"from inclusive", adapters.AuditQuery{From: base.Add(2 * time.Minute)}, 3},

--- a/audit.go
+++ b/audit.go
@@ -35,6 +35,9 @@ const (
 	AuditOrderTimestampAsc = adapters.AuditOrderTimestampAsc
 )
 
+// ErrNilAuditEntry is returned by AuditStore.Append when the entry is nil.
+var ErrNilAuditEntry = adapters.ErrNilAuditEntry
+
 // =============================================================================
 // Actor context helpers
 // =============================================================================

--- a/website/docs/advanced/api-design.md
+++ b/website/docs/advanced/api-design.md
@@ -286,7 +286,7 @@ type AuditEntry struct {
 
 // AuditQuery filters and paginates the trail (zero value = all matching).
 type AuditQuery struct {
-    CommandType, Actor, TenantID, AggregateID string
+    CommandType, Actor, TenantID, AggregateID, CorrelationID string
     From, To                                  time.Time
     Success                                   *bool      // nil = both
     Limit, Offset                             int

--- a/website/docs/advanced/audit-logging.md
+++ b/website/docs/advanced/audit-logging.md
@@ -203,16 +203,17 @@ default; the in-memory store returns all unless `Limit` is set).
 
 ```go
 type AuditQuery struct {
-    CommandType string      // exact match
-    Actor       string      // exact match
-    TenantID    string      // exact match
-    AggregateID string      // exact match
-    From        time.Time   // Timestamp >= From (inclusive)
-    To          time.Time   // Timestamp <  To  (exclusive)
-    Success     *bool       // nil = both; &true = successes; &false = failures
-    Limit       int         // <= 0 means the store default
-    Offset      int         // for pagination
-    Order       AuditOrder  // AuditOrderTimestampDesc (default) | AuditOrderTimestampAsc
+    CommandType   string     // exact match
+    Actor         string     // exact match
+    TenantID      string     // exact match
+    AggregateID   string     // exact match
+    CorrelationID string     // exact match (e.g. all commands in one request flow)
+    From          time.Time  // Timestamp >= From (inclusive)
+    To            time.Time  // Timestamp <  To  (exclusive)
+    Success       *bool      // nil = both; &true = successes; &false = failures
+    Limit         int        // <= 0 means the store default
+    Offset        int        // for pagination
+    Order         AuditOrder // AuditOrderTimestampDesc (default) | AuditOrderTimestampAsc
 }
 ```
 


### PR DESCRIPTION
## Summary

Follow-up fixes from the review of the audit logging feature (PR #149 / release PR #150), branched fresh off `develop`.

- **Nil-entry guard:** `AuditStore.Append` (in-memory **and** PostgreSQL) now returns `ErrNilAuditEntry` for a nil entry instead of storing a nil pointer that would later panic `Find`/`Count`/`Cleanup`.
- **Context handling:** the in-memory `Append` now respects context cancellation, consistent with the other in-memory stores (e.g. the outbox store).
- **CorrelationID query:** added `CorrelationID` to `AuditQuery` and implemented it in both stores, so the existing `correlation_id` index is actually queryable (e.g. "all commands in one request flow"). Previously the index added write/storage overhead with no query path.

Docs (the feature guide + API reference) and tests (memory unit + PostgreSQL integration) updated.

## Validation
- `go build` / `-short` suite / `gofmt` / `golangci-lint` — clean.
- PostgreSQL integration tests pass against Postgres 17, including the new `correlation` filter case and the existing round-trip/ordering/limit tests.

_Note: a separate, repo-wide concern (Postgres index names vs. the 63-char identifier limit for very long custom table names) was flagged during review and is tracked as its own task — it spans all schema statements (events/idempotency/outbox/audit), so it belongs in a consistent change rather than an audit-only spot-fix._
