### PR TITLE
[audit] Handle a nil Store without panicking the command pipeline

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -141,6 +141,29 @@ func copyMetadataMap(m map[string]string) map[string]string {
 	return cp
 }
 
+// foldAuditFailure folds an audit-side failure (a store write error, or a nil
+// store under FailClosed) into the command outcome:
+//
+//   - If the command already failed (via err or an error CommandResult), auditErr
+//     is surfaced alongside that failure — joined with the command's error when it
+//     has one — so the command's own failure is preserved and never masked.
+//   - If the command succeeded, there is no prior error to join, so its successful
+//     result is replaced with an error result carrying auditErr: under fail-closed,
+//     an audit failure is itself a command failure.
+func foldAuditFailure(result CommandResult, err, auditErr error) (CommandResult, error) {
+	switch {
+	case err != nil:
+		return result, errors.Join(err, auditErr)
+	case result.IsError():
+		if result.Error != nil {
+			return result, errors.Join(result.Error, auditErr)
+		}
+		return result, auditErr
+	default:
+		return NewErrorResult(auditErr), auditErr
+	}
+}
+
 // AuditMiddleware creates middleware that writes an immutable audit entry for
 // every dispatched command. Both successful and failed executions are audited.
 //
@@ -173,6 +196,24 @@ func AuditMiddleware(config AuditConfig) Middleware {
 	}
 
 	return func(next MiddlewareFunc) MiddlewareFunc {
+		// A nil store can never persist anything, and whether it is nil is fixed at
+		// construction — so decide the policy once here rather than on every
+		// dispatch. Fail-open degenerates to a pass-through (auditing never breaks
+		// command processing); fail-closed surfaces the misconfiguration for every
+		// command that would otherwise be audited.
+		if config.Store == nil {
+			if !config.FailClosed {
+				return next
+			}
+			return func(ctx context.Context, cmd Command) (CommandResult, error) {
+				result, err := next(ctx, cmd)
+				if skipSet[cmd.CommandType()] {
+					return result, err // excluded commands are never audited
+				}
+				return foldAuditFailure(result, err, ErrNilAuditStore)
+			}
+		}
+
 		return func(ctx context.Context, cmd Command) (CommandResult, error) {
 			// Skip auditing for excluded command types.
 			if skipSet[cmd.CommandType()] {
@@ -223,20 +264,7 @@ func AuditMiddleware(config AuditConfig) Middleware {
 			}
 
 			if appendErr := config.Store.Append(ctx, entry); appendErr != nil && config.FailClosed {
-				// Surface the audit-write failure without discarding the command's
-				// result or masking a failure it already reported (via err or via an
-				// error CommandResult with a nil error).
-				switch {
-				case err != nil:
-					return result, errors.Join(err, appendErr)
-				case result.IsError():
-					if result.Error != nil {
-						return result, errors.Join(result.Error, appendErr)
-					}
-					return result, appendErr
-				default:
-					return NewErrorResult(appendErr), appendErr
-				}
+				return foldAuditFailure(result, err, appendErr)
 			}
 
 			return result, err

--- a/audit_test.go
+++ b/audit_test.go
@@ -389,6 +389,69 @@ func TestAuditMiddleware_FailClosed_PreservesErrorResult(t *testing.T) {
 	require.ErrorIs(t, err, appendErr)
 }
 
+func TestAuditMiddleware_NilStore_FailOpen(t *testing.T) {
+	// A nil store must not panic; fail-open returns the command outcome unchanged.
+	mw := AuditMiddleware(DefaultAuditConfig(nil))
+
+	result, err := mw(okHandler("agg-1", 1))(context.Background(), auditTestCommand{Type: "C"})
+	require.NoError(t, err)
+	assert.True(t, result.IsSuccess())
+	assert.Equal(t, "agg-1", result.AggregateID)
+}
+
+func TestAuditMiddleware_NilStore_FailOpen_PreservesHandlerError(t *testing.T) {
+	mw := AuditMiddleware(DefaultAuditConfig(nil))
+
+	handlerErr := errors.New("handler failed")
+	handler := func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewErrorResult(handlerErr), handlerErr
+	}
+	_, err := mw(handler)(context.Background(), auditTestCommand{Type: "C"})
+	// Fail-open: the missing store is ignored; the handler error survives unwrapped.
+	require.ErrorIs(t, err, handlerErr)
+	require.NotErrorIs(t, err, ErrNilAuditStore)
+}
+
+func TestAuditMiddleware_NilStore_FailClosed(t *testing.T) {
+	cfg := DefaultAuditConfig(nil)
+	cfg.FailClosed = true
+	mw := AuditMiddleware(cfg)
+
+	result, err := mw(okHandler("agg-1", 1))(context.Background(), auditTestCommand{Type: "C"})
+	// Fail-closed: a nil store is surfaced as a misconfiguration error.
+	require.ErrorIs(t, err, ErrNilAuditStore)
+	assert.True(t, result.IsError())
+}
+
+func TestAuditMiddleware_NilStore_FailClosed_PreservesHandlerError(t *testing.T) {
+	cfg := DefaultAuditConfig(nil)
+	cfg.FailClosed = true
+	mw := AuditMiddleware(cfg)
+
+	handlerErr := errors.New("handler failed")
+	handler := func(ctx context.Context, cmd Command) (CommandResult, error) {
+		return NewErrorResult(handlerErr), handlerErr
+	}
+	_, err := mw(handler)(context.Background(), auditTestCommand{Type: "C"})
+	// The nil-store error is surfaced but must not mask the handler error.
+	require.ErrorIs(t, err, handlerErr)
+	require.ErrorIs(t, err, ErrNilAuditStore)
+}
+
+func TestAuditMiddleware_NilStore_FailClosed_SkippedCommand(t *testing.T) {
+	// A skipped command is never audited, so a nil store must not fail it even
+	// under fail-closed.
+	cfg := DefaultAuditConfig(nil)
+	cfg.FailClosed = true
+	cfg.SkipCommands = []string{"Skipped"}
+	mw := AuditMiddleware(cfg)
+
+	result, err := mw(okHandler("agg-1", 1))(context.Background(), auditTestCommand{Type: "Skipped"})
+	require.NoError(t, err)
+	assert.True(t, result.IsSuccess())
+	assert.Equal(t, "agg-1", result.AggregateID)
+}
+
 func TestAuditMiddleware_PanicDownstreamStillAudited(t *testing.T) {
 	// The audit middleware wraps the recovery middleware, so when a downstream
 	// handler panics, recovery converts it into an error result *before* the

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,10 @@ var (
 	// ErrNilStore indicates a nil event store was passed.
 	ErrNilStore = errors.New("mink: nil event store")
 
+	// ErrNilAuditStore indicates the audit middleware was configured with a nil
+	// Store. It is surfaced (only) when the middleware is fail-closed.
+	ErrNilAuditStore = errors.New("mink: nil audit store")
+
 	// ErrEmptyStreamID indicates an empty stream ID was provided.
 	ErrEmptyStreamID = adapters.ErrEmptyStreamID
 

--- a/website/docs/advanced/audit-logging.md
+++ b/website/docs/advanced/audit-logging.md
@@ -148,6 +148,10 @@ what happens if that write fails:
 - **Fail-closed** (`FailClosed: true`) — a store error is surfaced as the command
   result/error, so callers can react (e.g. reject the request for compliance).
 
+A nil `Store` follows the same policy rather than panicking the pipeline: fail-open
+returns the command outcome unchanged, while fail-closed surfaces
+`mink.ErrNilAuditStore` (joined with any error the command itself reported).
+
 :::warning Auditing is not transactional
 Because the audit entry is written *after* the command, `FailClosed` surfaces the
 audit-write failure but **the command's side effect has already happened**. Use


### PR DESCRIPTION
## Summary

Closes a panic flagged by review on #150: `AuditMiddleware` called `config.Store.Append` unconditionally, so a **nil `Store`** crashed the process at dispatch — directly contradicting the documented fail-open contract that *"auditing never breaks command processing."*

A nil `Store` now follows the same policy as a failed store write:

- **Fail-open (default)** — returns the command outcome unchanged; auditing is silently skipped.
- **Fail-closed** — surfaces the new `ErrNilAuditStore` sentinel, joined with any error the command itself reported (never masking it).

The fail-closed merge logic is extracted into `foldAuditFailure` and reused for both store-write failures and the nil-store case, so the two paths can't drift.

## Changes

- `errors.go` — add `ErrNilAuditStore` sentinel (sibling of `ErrNilStore`).
- `audit.go` — short-circuit a nil `Store` per policy; extract `foldAuditFailure` helper.
- `audit_test.go` — four tests covering fail-open / fail-closed × success / handler-error.
- `website/docs/advanced/audit-logging.md` — document the nil-store behavior under *Failure semantics*.

## Validation

- `go build ./...`, `go vet`, `gofmt` clean
- `go test -race` on the audit middleware suite (incl. 4 new tests) — all pass
- `golangci-lint run` — 0 issues
- `npm run build` (Docusaurus) — succeeds