### PR TITLE
[audit] Cap Postgres index names at 63 chars and fix duration measurement

### DIFF
--- a/adapters/postgres/audit_test.go
+++ b/adapters/postgres/audit_test.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"context"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -366,4 +368,56 @@ func TestAuditSchemaStatements(t *testing.T) {
 	assert.Contains(t, stmts[0], "metadata JSONB")
 	// One table + six indexes.
 	assert.Len(t, stmts, 7)
+
+	// Short index names keep their original, stable, bare identifiers (no schema
+	// prefix), so re-running Initialize never creates a second, redundant set.
+	joined := strings.Join(stmts, "\n")
+	assert.Contains(t, joined, `"idx_mink_audit_timestamp"`)
+	assert.Contains(t, joined, `"idx_mink_audit_correlation_id"`)
+	// The schema-prefix marker only appears if an index name was rewritten via
+	// safeIndexName; short names must keep their bare identifiers.
+	assert.NotContains(t, joined, "public_idx")
+}
+
+func TestAuditSchemaStatements_IndexNamesWithinLimit(t *testing.T) {
+	// A long custom audit table name (via WithAuditTable) must not produce index
+	// identifiers exceeding PostgreSQL's 63-character limit, which would otherwise
+	// make Initialize/GenerateSchema fail even though the table name validates.
+	indexName := regexp.MustCompile(`CREATE INDEX IF NOT EXISTS "([^"]+)"`)
+	stmts := auditSchemaStatements("public", strings.Repeat("a", 60))
+
+	var checked int
+	for _, s := range stmts {
+		m := indexName.FindStringSubmatch(s)
+		if m == nil {
+			continue
+		}
+		checked++
+		assert.LessOrEqualf(t, len(m[1]), 63, "index name %q exceeds 63 chars (%d)", m[1], len(m[1]))
+	}
+	assert.Equal(t, 6, checked, "expected all six audit indexes to be length-checked")
+}
+
+func TestAuditStore_Initialize_LongTableName(t *testing.T) {
+	// Regression: a long (but valid) custom table name produces raw index names
+	// well over Postgres's 63-char limit. Initialize must still succeed because
+	// the index names are passed through safeIndexName.
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	connStr := os.Getenv("TEST_DATABASE_URL")
+	if connStr == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+
+	adapter, err := NewAdapter(connStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	// 61-char table name: valid (<=63), but "idx_<table>_correlation_id" is ~80.
+	longTable := "mink_audit_" + strings.Repeat("x", 50)
+	require.LessOrEqual(t, len(longTable), 63)
+
+	store := NewAuditStore(adapter.db, WithAuditTable(longTable))
+	require.NoError(t, store.Initialize(context.Background()))
 }

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -337,6 +337,18 @@ func idempotencySchemaStatements(schemaName, tableName string) []string {
 	}
 }
 
+// boundedIndexName returns base unchanged when it already fits PostgreSQL's
+// 63-character identifier limit, and otherwise falls back to safeIndexName
+// (truncate + hash). Keeping short names bare preserves the original, stable
+// identifiers so re-running Initialize never creates a second, redundant set of
+// indexes; only oversized names (from long custom table names) are rewritten.
+func boundedIndexName(schema, base string) string {
+	if len(base) <= 63 {
+		return base
+	}
+	return safeIndexName(schema, base)
+}
+
 func auditSchemaStatements(schemaName, tableName string) []string {
 	tableQ := quoteQualifiedTable(schemaName, tableName)
 	return []string{
@@ -356,12 +368,12 @@ func auditSchemaStatements(schemaName, tableName string) []string {
 			duration_ms BIGINT NOT NULL DEFAULT 0,
 			metadata JSONB
 		)`,
-		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_timestamp") + ` ON ` + tableQ + ` (timestamp)`,
-		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_command_type") + ` ON ` + tableQ + ` (command_type)`,
-		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_actor") + ` ON ` + tableQ + ` (actor)`,
-		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_tenant_id") + ` ON ` + tableQ + ` (tenant_id)`,
-		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_aggregate_id") + ` ON ` + tableQ + ` (aggregate_id)`,
-		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier("idx_"+tableName+"_correlation_id") + ` ON ` + tableQ + ` (correlation_id)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier(boundedIndexName(schemaName, "idx_"+tableName+"_timestamp")) + ` ON ` + tableQ + ` (timestamp)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier(boundedIndexName(schemaName, "idx_"+tableName+"_command_type")) + ` ON ` + tableQ + ` (command_type)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier(boundedIndexName(schemaName, "idx_"+tableName+"_actor")) + ` ON ` + tableQ + ` (actor)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier(boundedIndexName(schemaName, "idx_"+tableName+"_tenant_id")) + ` ON ` + tableQ + ` (tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier(boundedIndexName(schemaName, "idx_"+tableName+"_aggregate_id")) + ` ON ` + tableQ + ` (aggregate_id)`,
+		`CREATE INDEX IF NOT EXISTS ` + quoteIdentifier(boundedIndexName(schemaName, "idx_"+tableName+"_correlation_id")) + ` ON ` + tableQ + ` (correlation_id)`,
 	}
 }
 

--- a/audit.go
+++ b/audit.go
@@ -222,10 +222,11 @@ func AuditMiddleware(config AuditConfig) Middleware {
 
 			start := config.now()
 			result, err := next(ctx, cmd)
+			end := config.now()
 
 			entry := &AuditEntry{
 				ID:            config.idgen(),
-				Timestamp:     config.now(),
+				Timestamp:     end,
 				CommandType:   cmd.CommandType(),
 				AggregateID:   result.AggregateID,
 				Version:       result.Version,
@@ -235,7 +236,9 @@ func AuditMiddleware(config AuditConfig) Middleware {
 				CausationID:   CausationIDFromContext(ctx),
 				Success:       err == nil && result.IsSuccess(),
 			}
-			entry.DurationMs = config.now().Sub(start).Milliseconds()
+			// DurationMs reflects only handler execution time (start→end) and shares
+			// the same end reading as Timestamp, so the two never drift.
+			entry.DurationMs = end.Sub(start).Milliseconds()
 
 			// Command ID, if the command exposes one.
 			if c, ok := cmd.(interface{ GetCommandID() string }); ok {

--- a/audit_test.go
+++ b/audit_test.go
@@ -50,26 +50,33 @@ func (s *failingAuditStore) Append(ctx context.Context, entry *adapters.AuditEnt
 
 // fixedConfig returns a config with a deterministic clock and ID generator.
 //
-// AuditMiddleware calls now() three times per command, in order:
-//  1. start (captured before the handler runs)
-//  2. entry.Timestamp (after the handler returns)
-//  3. the end time used to compute DurationMs
+// AuditMiddleware calls now() twice per command, in order:
+//  1. start — captured immediately before the handler runs
+//  2. end   — captured immediately after the handler returns; used for both
+//     entry.Timestamp and DurationMs
 //
-// The clock below returns base, base+1500ms, base+1500ms, so Timestamp is
-// base+1500ms and DurationMs is 1500.
-func fixedConfig(store AuditStore) AuditConfig {
+// The clock below returns base, then base+1500ms, so Timestamp is base+1500ms
+// and DurationMs is 1500.
+func fixedConfig(t *testing.T, store AuditStore) AuditConfig {
+	t.Helper()
 	cfg := DefaultAuditConfig(store)
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	times := []time.Time{
 		base,
 		base.Add(1500 * time.Millisecond),
-		base.Add(1500 * time.Millisecond),
 	}
 	calls := 0
 	cfg.now = func() time.Time {
-		t := times[calls%len(times)]
+		if calls >= len(times) {
+			// Fail fast instead of wrapping: the middleware must read the clock
+			// exactly twice (start, end), and a regression that reads it more
+			// often should break the test rather than be masked.
+			t.Fatalf("now() called more than %d times", len(times))
+			return time.Time{} // unreachable: t.Fatalf ends the test goroutine
+		}
+		ts := times[calls]
 		calls++
-		return t
+		return ts
 	}
 	cfg.idgen = func() string { return "fixed-id" }
 	return cfg
@@ -85,7 +92,7 @@ func okHandler(aggID string, version int64) MiddlewareFunc {
 
 func TestAuditMiddleware_RecordsSuccess(t *testing.T) {
 	store := memory.NewAuditStore()
-	cfg := fixedConfig(store)
+	cfg := fixedConfig(t, store)
 	mw := AuditMiddleware(cfg)
 
 	ctx := WithActor(context.Background(), "alice")
@@ -111,6 +118,38 @@ func TestAuditMiddleware_RecordsSuccess(t *testing.T) {
 	assert.Empty(t, e.Error)
 	assert.Equal(t, int64(1500), e.DurationMs)
 	assert.Equal(t, time.Date(2026, 1, 1, 0, 0, 1, 500000000, time.UTC), e.Timestamp)
+}
+
+func TestAuditMiddleware_DurationUsesSingleEndReading(t *testing.T) {
+	// now() must be read exactly twice — start and end — with end reused for both
+	// Timestamp and DurationMs, so DurationMs measures only handler execution time
+	// and never drifts past Timestamp (independent of entry-building cost).
+	store := memory.NewAuditStore()
+	base := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	var calls int
+	cfg := DefaultAuditConfig(store)
+	cfg.now = func() time.Time {
+		defer func() { calls++ }()
+		switch calls {
+		case 0:
+			return base // start
+		case 1:
+			return base.Add(2 * time.Second) // end
+		default:
+			return base.Add(time.Hour) // any extra reading would be a regression
+		}
+	}
+	cfg.idgen = func() string { return "id" }
+
+	_, err := AuditMiddleware(cfg)(okHandler("agg", 1))(context.Background(), auditTestCommand{Type: "C"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "now() must be read exactly twice (start, end)")
+
+	entries, ferr := store.Find(context.Background(), AuditQuery{})
+	require.NoError(t, ferr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, base.Add(2*time.Second), entries[0].Timestamp)
+	assert.Equal(t, int64(2000), entries[0].DurationMs)
 }
 
 func TestAuditMiddleware_RecordsHandlerError(t *testing.T) {


### PR DESCRIPTION
## Summary

Two follow-ups flagged by review on #150, both in the audit logging feature.

### 1. Postgres index names can exceed the 63-char limit (`postgres.go`)

`auditSchemaStatements` built index names as `idx_<table>_<column>`. With a long custom table name via `WithAuditTable`, those identifiers run past PostgreSQL's 63-character limit, so `Initialize`/`GenerateSchema` failed **even though the table name itself validated**.

Audit index names now pass through the existing `safeIndexName` helper — the same one read-model indexes already use — which truncates and appends a short hash to guarantee `<= 63` chars.

### 2. `DurationMs` drifted from `Timestamp` (`audit.go`)

`Timestamp` and `DurationMs` were taken from two separate `now()` calls *after* the handler returned, so `DurationMs` included entry-building work (actor/context lookups, metadata copy) and could drift relative to `Timestamp`. The middleware now captures a single `end := now()` immediately after the handler and reuses it for both — `DurationMs` reflects handler execution time alone.

## Tests

- `TestAuditSchemaStatements_IndexNamesWithinLimit` — unit: every audit index name stays `<= 63` chars for a 60-char table.
- `TestAuditStore_Initialize_LongTableName` — integration: `Initialize` succeeds end-to-end with a 61-char table name.
- `TestAuditMiddleware_DurationUsesSingleEndReading` — asserts `now()` is read exactly twice (start, end) and both `Timestamp` and `DurationMs` derive from `end`.

## Validation

- `go build ./...`, `go vet`, `gofmt` clean
- `go test -race` on the audit middleware suite — all pass
- Postgres audit suite (incl. both new regression tests) green against PG 17
- `golangci-lint run` — 0 issues

Note: the broader sweep to apply `safeIndexName` to the other schema generators (events, outbox, saga, etc.) remains tracked separately; this PR fixes the audit table that review flagged.