### PR TITLE
docs: overhaul README, add example READMEs, refresh contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a problem to help us improve go-mink
 title: ''
 labels: bug
 assignees: ''
@@ -9,24 +9,28 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '...'
-3. Scroll down to '...'
-4. See error
+**Minimal reproduction**
+The smallest possible Go snippet (or link to a repo) that reproduces the problem:
+
+```go
+// go-mink version, adapter, and the code that triggers the bug
+```
+
+Steps to reproduce, if the snippet needs them:
+1. ...
+2. ...
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Actual behavior**
+What actually happened. Include the full error message and stack trace if there is one.
 
-**Environment (please complete the following information):**
- - OS: [e.g. Windows, Linux]
- - Go Version: [e.g. 1.21]
- - Database: [e.g. PostgreSQL 15]
- - go-mink Version: [e.g. v0.1.0]
+**Environment**
+ - go-mink version: [e.g. v1.0.0 — run `go list -m go-mink.dev`]
+ - Go version: [e.g. 1.25 — run `go version`]
+ - Adapter: [e.g. PostgreSQL 16, in-memory]
+ - OS: [e.g. macOS 15, Ubuntu 24.04, Windows 11]
 
 **Additional context**
-Add any other context about the problem here.
+Anything else that might help — related configuration, whether it's intermittent, recent changes, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--
+Thanks for contributing to go-mink! 🦫
+- Please target the `develop` branch (not `main`).
+- See CONTRIBUTING.md for the workflow, style guide, and how to run tests.
+- Link any related issue with "Closes #123".
+-->
+
 ## Summary
 <!-- Brief description of changes -->
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,43 +1,49 @@
 # Security Policy
 
+We take the security of **go-mink** seriously. Thank you for helping keep the project and its users safe.
+
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are currently being supported with security updates.
+go-mink follows [Semantic Versioning](https://semver.org/). Security fixes are applied to the latest stable release line.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.x.x   | :white_check_mark: |
-| < 0.4.0 | :x:                |
+| 1.0.x   | :white_check_mark: |
+| < 1.0.0 (pre-release / RC) | :x: |
+
+Because go-mink is a library, the most effective way to receive security fixes is to stay on the latest tagged release (`go get go-mink.dev@latest`).
 
 ## Reporting a Vulnerability
 
-We take the security of **go-mink** seriously. If you believe you have found a security vulnerability in go-mink, please report it to us as described below.
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+Instead, report them privately through GitHub's coordinated disclosure workflow:
 
-### How to Report
+1. Go to the [**Security** tab](https://github.com/AshkanYarmoradi/go-mink/security) of the repository.
+2. Click **"Report a vulnerability"** to open a private security advisory (GitHub Private Vulnerability Reporting).
+3. Fill in the details described below.
 
-If you believe you have found a security vulnerability, please email us at [security@go-mink.dev](mailto:security@go-mink.dev) (replace with actual email if available, or instruct to use GitHub Security Advisories).
-
-You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+This keeps the report confidential between you and the maintainers until a fix is released.
 
 ### What to Include
 
-Please include the following details in your report:
+A good report helps us reproduce and fix the issue quickly. Please include as much of the following as you can:
 
-- The type of issue (e.g., buffer overflow, SQL injection, cross-site scripting, etc.)
-- Full paths of source file(s) related to the manifestation of the issue
-- The location of the affected source code (tag/branch/commit or direct URL)
-- Any special configuration required to reproduce the issue
-- Step-by-step instructions to reproduce the issue
-- Proof-of-concept or exploit code (if possible)
-- Impact of the issue, including how an attacker might exploit the issue
+- The type of issue (e.g., data exposure, injection, authentication/authorization flaw, cryptographic weakness).
+- The affected component and version (tag/branch/commit, or a direct source URL).
+- Full paths of the source file(s) involved.
+- Any special configuration required to reproduce.
+- Step-by-step instructions to reproduce the behavior.
+- Proof-of-concept or exploit code, if possible.
+- The impact — how an attacker might exploit the issue.
 
-### Disclosure Policy
+### Our Commitment
 
-1.  **Initial Report**: Once we receive your report, we will acknowledge receipt within 48 hours and begin our investigation.
-2.  **Assessment**: We will assess the vulnerability and determine its impact. We may contact you for further information.
-3.  **Fix**: We will work on a fix for the vulnerability. We will keep you updated on our progress.
-4.  **Disclosure**: Once the fix is ready and released, we will publicly disclose the vulnerability. We will give you credit for the discovery if you wish.
+- **Acknowledgement** within **48 hours** of your report.
+- **Assessment** of severity and impact, keeping you updated as we investigate (we may reach out for more detail).
+- **Fix & release** — we develop a fix, release it, and publish an advisory.
+- **Credit** — with your permission, we'll credit you in the advisory and release notes.
 
-Thank you for helping keep go-mink safe!
+If you do not receive an acknowledgement within 48 hours, please open a *non-sensitive* placeholder issue asking us to check our security advisories (without disclosing any details), so we can follow up.
+
+Thank you for practicing responsible disclosure and helping make go-mink safer for everyone. 🔐

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected the read-models documentation, which referenced non-existent symbols (`mink.Eq`, `mink.Contains`, `repo.Query`) instead of the real `mink.FilterOp*` constants and `repo.Find`.
 - **Data race (PostgreSQL adapter):** the `WithHealthCheck` goroutine read the adapter's `closed` flag on every tick while `Close()` wrote it without synchronization. The flag is now an `atomic.Bool`, removing the race flagged by the race detector.
 
+### Documentation
+- Overhauled the root `README.md`: fixed the broken documentation links (they now point to https://go-mink.dev), expanded the feature overview to cover the GDPR erasure/retention, audit-logging, anonymization, and subject-discovery capabilities, added a "Why Event Sourcing?" section and a Mermaid architecture diagram, an examples index, and a Contributing / Community section. Corrected the required Go version to 1.25+.
+- Added a `README.md` to every project under `examples/` (14 new files) plus an `examples/README.md` index with a suggested learning path.
+- Refreshed `CONTRIBUTING.md` (Makefile-based workflow, a project-layout map, and good-first-contribution ideas), `.github/SECURITY.md` (accurate supported-versions table and GitHub private vulnerability reporting), `CODE_OF_CONDUCT.md` (real enforcement contact), and the issue/PR templates.
+
 ## [1.0.0] - 2026-03-02
 
 First stable release consolidating all features from the development phases.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainers responsible for enforcement by contacting the maintainer, [@AshkanYarmoradi](https://github.com/AshkanYarmoradi), on GitHub. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ This section guides you through submitting a bug report for go-mink. Following t
 
 **Before Submitting a Bug Report**
 
-*   **Check the [documentation](docs/)** for a list of common questions and guides.
+*   **Check the [documentation](https://go-mink.dev)** for guides and common questions.
 *   **Search the existing Issues** to see if the problem has already been reported.
 
 **How to Submit a Good Bug Report**
@@ -68,10 +68,13 @@ This section guides you through submitting an enhancement suggestion for go-mink
     git checkout -b feature/amazing-feature
     ```
 4.  **Make your changes**.
-5.  **Run tests** to ensure you haven't broken anything.
+5.  **Run the checks** to make sure everything passes.
     ```bash
-    go test ./...
+    make test-unit   # fast unit tests — no infrastructure required
+    make lint        # golangci-lint
+    make fmt         # go fmt ./...
     ```
+    For the full suite (which spins up PostgreSQL + Kafka via Docker Compose), run `make test`.
 6.  **Commit your changes** using descriptive commit messages.
 
 ### Branching Strategy & Release Process
@@ -129,37 +132,67 @@ Please follow these steps to have your contribution considered by the maintainer
 
 ### Prerequisites
 
-- Go 1.25 or later
-- PostgreSQL 14+ (for integration tests)
-- Docker (optional, for test containers)
+- **Go 1.25+** — the module targets Go 1.25; CI builds on Go 1.25 and 1.26.
+- **Docker** — used by `make test` to spin up PostgreSQL + Kafka for integration tests.
+- **golangci-lint** — for `make lint` ([installation guide](https://golangci-lint.run/welcome/install/)).
 
-### Running Tests
+Infrastructure for integration tests is managed for you via `docker-compose.test.yml` — the Makefile starts and stops it automatically, so you rarely need to touch Docker directly.
+
+### Common Commands
 
 ```bash
-# Run unit tests
-go test -short ./...
-
-# Run all tests (requires PostgreSQL)
-docker-compose -f docker-compose.test.yml up -d
-go test ./...
-
-# Run CLI tests with coverage
-cd cli/commands
-go test -tags=integration -cover -timeout 180s
-
-# Run CLI E2E tests
-go test -tags=integration -run "TestE2E" -v
+make build           # go build ./...
+make test-unit       # unit tests only (no infra, CGO_ENABLED=0 — works everywhere)
+make test-unit-race  # unit tests with the race detector (needs gcc/clang)
+make test            # full suite — auto-starts PostgreSQL + Kafka
+make lint            # golangci-lint run ./...
+make fmt             # go fmt ./...
+make test-coverage   # coverage report (excludes examples/ and testing/)
+make help            # list every target
 ```
+
+To run a single test (integration tests need infra up — `make infra-up`):
+
+```bash
+TEST_DATABASE_URL="postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable" \
+  go test -v -run TestName ./path/to/pkg/...
+```
+
+Integration tests skip themselves automatically under `-short`, or when `TEST_DATABASE_URL` / `TEST_KAFKA_BROKERS` are unset — so `make test-unit` is safe to run anywhere.
 
 ### Test Coverage
 
-The project maintains high test coverage:
+**CI enforces 90% coverage** (excluding `examples/` and `testing/`), so new features are expected to ship with tests. Check coverage locally with `make test-coverage`; overall coverage is tracked on [Codecov](https://codecov.io/gh/AshkanYarmoradi/go-mink) and [SonarCloud](https://sonarcloud.io/summary/new_code?id=AshkanYarmoradi_go-mink).
 
-| Package | Coverage |
-|---------|----------|
-| `cli/commands` | 84.9% |
-| `cli/config` | 95.5% |
-| `cli/styles` | 100% |
-| `cli/ui` | 96.7% |
+## Project Layout
 
-Thank you for contributing!
+A quick map to help you navigate the codebase:
+
+| Path | What lives here |
+|------|-----------------|
+| `*.go` (root, package `mink`) | Core types: event store, command bus, projections, sagas, outbox, encryption, GDPR toolkit, versioning |
+| `adapters/` | Storage adapters — `postgres/` (production), `memory/` (testing), and the shared interfaces in `adapter.go` |
+| `encryption/` | The `Provider` interface plus `local/`, `kms/`, and `vault/` implementations |
+| `outbox/` | Outbox publishers — `webhook/`, `kafka/`, `sns/` |
+| `serializer/` | Alternative serializers — `msgpack/`, `protobuf/` |
+| `middleware/` | `metrics/` (Prometheus) and `tracing/` (OpenTelemetry) |
+| `testing/` | Test utilities — BDD fixtures, assertions, projection/saga harnesses, containers |
+| `cli/`, `cmd/mink/` | The `mink` command-line tool |
+| `examples/` | Runnable example projects (each with its own README) |
+| `website/` | The Docusaurus documentation site ([go-mink.dev](https://go-mink.dev)) |
+
+Adding storage support means implementing the interfaces in [`adapters/adapter.go`](adapters/adapter.go) — see the [Adapters guide](https://go-mink.dev/docs/core/adapters).
+
+## Good First Contributions
+
+Looking for a place to start? Any of these are genuinely useful:
+
+- 📝 Improve a documentation page or an example README.
+- 🧪 Add a test that covers an edge case.
+- 📊 Add a benchmark using the shared helpers in `adapters/common.go`.
+- 🔌 Implement an `EventStoreAdapter` for another database.
+- 🐛 Pick up a [good first issue](https://github.com/AshkanYarmoradi/go-mink/labels/good%20first%20issue).
+
+Not sure where your idea fits? Open a [Discussion](https://github.com/AshkanYarmoradi/go-mink/discussions) — we're happy to help you get started.
+
+Thank you for contributing! 🦫

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-mink 🦫
 
-**A Comprehensive Event Sourcing & CQRS Toolkit for Go**
+**The batteries-included Event Sourcing & CQRS toolkit for Go.**
 
 <p align="center">
   <a href="https://pkg.go.dev/go-mink.dev"><img src="https://pkg.go.dev/badge/go-mink.dev.svg" alt="Go Reference"></a>
@@ -19,453 +19,578 @@
 </p>
 
 <p align="center">
-  <a href="https://sonarcloud.io/summary/new_code?id=AshkanYarmoradi_go-mink"><img src="https://sonarcloud.io/api/project_badges/measure?project=AshkanYarmoradi_go-mink&metric=bugs" alt="Bugs"></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=AshkanYarmoradi_go-mink"><img src="https://sonarcloud.io/api/project_badges/measure?project=AshkanYarmoradi_go-mink&metric=vulnerabilities" alt="Vulnerabilities"></a>
-  <a href="https://sonarcloud.io/summary/new_code?id=AshkanYarmoradi_go-mink"><img src="https://sonarcloud.io/api/project_badges/measure?project=AshkanYarmoradi_go-mink&metric=sqale_index" alt="Technical Debt"></a>
+  <b><a href="https://go-mink.dev">📖 Documentation</a></b> ·
+  <a href="https://go-mink.dev/docs/tutorial/setup">🎓 Tutorial</a> ·
+  <a href="examples/">💡 Examples</a> ·
+  <a href="https://pkg.go.dev/go-mink.dev">🔎 API Reference</a> ·
+  <a href="https://go-mink.dev/docs/roadmap">🗺️ Roadmap</a>
 </p>
 
 ---
 
-## v1.0.0 — Stable Release
+`go-mink` lets you build event-sourced systems in Go without the usual boilerplate. Instead of storing *current state*, it stores every change as an immutable event and rebuilds state by replaying them — giving you a perfect audit log, time travel, and read models for free. It's inspired by [MartenDB](https://martendb.io/) for .NET and ships with everything you need to go from prototype to production: a pluggable event store, a CQRS command bus, projections, sagas, an outbox, field-level encryption, and a full GDPR toolkit.
 
-go-mink includes everything you need to build production event-sourced systems in Go:
+```go
+// Model your domain as events — go-mink handles the rest.
+order := NewOrder("order-123")
+order.Create("customer-456")
+order.AddItem("SKU-001", 2, 29.99)
 
-- **Event Store** with optimistic concurrency, PostgreSQL & in-memory adapters
-- **Command Bus** with middleware pipeline (validation, idempotency, correlation, recovery)
-- **Projection Engine** with inline, async, and live projections
-- **Saga / Process Manager** with compensation handling
-- **Outbox Pattern** for reliable messaging (Webhook, Kafka, SNS publishers)
-- **Event Versioning** with schema evolution via upcasting (zero DB migration)
-- **Field-Level Encryption** with AWS KMS, HashiCorp Vault, and local AES-256-GCM
-- **GDPR Compliance** via crypto-shredding (key revocation) and data export (right to access)
-- **Observability** with Prometheus metrics and OpenTelemetry tracing
-- **Testing Utilities** with BDD fixtures, assertions, and test containers
-- **CLI Tool** for code generation, migrations, and diagnostics
+store.SaveAggregate(ctx, order)              // append events, optimistic concurrency
+loaded := NewOrder("order-123")
+store.LoadAggregate(ctx, loaded)             // rebuild state by replaying events
+```
 
----
+> **Why "go-mink"?** Marten (the animal) inspired the .NET library's name, so we picked the mink — another member of the *Mustelidae* family — for its Go cousin. 🦫
 
-## What is go-mink?
+## Table of Contents
 
-go-mink is a batteries-included Event Sourcing and CQRS (Command Query Responsibility Segregation) library for Go. Inspired by [MartenDB](https://martendb.io/) for .NET, go-mink brings the same developer-friendly experience to the Go ecosystem.
+- [Why Event Sourcing?](#why-event-sourcing)
+- [Features](#features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [How It Fits Together](#how-it-fits-together)
+- [Guided Tour](#guided-tour) — CQRS · Projections · Sagas · Outbox · Versioning · Encryption · GDPR · Observability · Testing
+- [Examples](#examples)
+- [Performance](#performance)
+- [Documentation](#documentation)
+- [Project Status](#project-status)
+- [Contributing](#contributing)
+- [Community & Support](#community--support)
+- [License](#license)
 
-> **Why "go-mink"?** Just as Marten (the animal) inspired the .NET library name, we chose go-mink - another member of the Mustelidae family - for our Go counterpart.
+## Why Event Sourcing?
 
-## Vision
+Traditional CRUD apps overwrite data — the moment you `UPDATE` a row, the previous state is gone. Event sourcing keeps the *entire history* as an append-only log of facts. That single change unlocks a lot:
 
-**"Make Event Sourcing in Go as simple as using a traditional ORM"**
+- **🕰️ Complete audit trail** — every state change is a durable, timestamped fact. Answer "who changed what, when, and why?" without bolt-on logging.
+- **⏪ Time travel & debugging** — replay a stream to any point in time to see exactly how a bug happened.
+- **📊 Purpose-built read models** — project the same events into as many optimized query models as you need (CQRS), and rebuild them from scratch whenever your requirements change.
+- **🔌 Natural integration** — events are a first-class integration point. Publish them reliably to Kafka, webhooks, or SNS with the built-in outbox.
+- **🔐 Compliance by design** — with field-level encryption, crypto-shredding, and a GDPR erasure/export toolkit, "right to be forgotten" is a feature, not a project.
 
-go-mink aims to eliminate the boilerplate code typically required when implementing Event Sourcing in Go, while providing a pluggable architecture that allows teams to choose their preferred storage backends.
+The catch is usually the plumbing: optimistic concurrency, serialization, schema evolution, projection checkpoints, idempotency, sagas. **go-mink is that plumbing** — production-tested, pluggable, and zero-overhead when a feature is unused — so you can focus on your domain.
 
-## Key Features
+> New to the pattern? Start with the [Introduction](https://go-mink.dev/docs/getting-started/introduction) and the [8-part Blog Series](https://go-mink.dev/docs/blog-series/introduction).
 
-| Feature | Status | Description |
-|---------|--------|-------------|
-| 🎯 **Event Store** | ✅ | Append-only event storage with optimistic concurrency |
-| 🔌 **PostgreSQL Adapter** | ✅ | Production-ready PostgreSQL support |
-| 🧪 **Memory Adapter** | ✅ | In-memory adapter for testing |
-| 🧱 **Aggregates** | ✅ | Base implementation with event application |
-| 📋 **Command Bus** | ✅ | Full CQRS with command handlers and middleware |
-| 🔐 **Idempotency** | ✅ | Prevent duplicate command processing |
-| 🔗 **Correlation/Causation** | ✅ | Distributed tracing support |
-| 📖 **Projections** | ✅ | Inline, async, and live projection engine |
-| 📊 **Read Models** | ✅ | Generic repository with query builder |
-| 📡 **Subscriptions** | ✅ | Catch-up and polling event subscriptions |
-| 🧪 **Testing Utilities** | ✅ | BDD fixtures, assertions, test containers |
-| 📊 **Observability** | ✅ | Prometheus metrics & OpenTelemetry tracing |
-| 📦 **MessagePack** | ✅ | Alternative serializer for performance |
-| 🛠️ **CLI Tool** | ✅ | Code generation, migrations, diagnostics |
-| � **Sagas** | ✅ | Process manager for long-running workflows |
-| 🔄 **Event Versioning** | ✅ | Schema evolution with upcasting (zero DB migration) |
-| 🔐 **Security** | ✅ | Field-level encryption and GDPR compliance |
-| 📦 **Data Export** | ✅ | GDPR right to access / data portability |
-| 📤 **Outbox Pattern** | ✅ | Reliable event publishing to external systems |
+## Features
 
-## Quick Example
+Everything below is included, works together, and is covered by tests (**CI enforces 90% coverage**).
+
+| Area | What you get |
+|------|--------------|
+| 🎯 **Event Store** | Append-only storage, optimistic concurrency, global ordering, snapshots, catch-up subscriptions |
+| 🔌 **Adapters** | Production **PostgreSQL** adapter and an **in-memory** adapter for tests — swap with one line |
+| 🧱 **Aggregates** | `AggregateBase` with event application & uncommitted-event tracking |
+| 📋 **Command Bus** | Full CQRS dispatch with a composable **middleware** pipeline |
+| 🧩 **Middleware** | Validation, recovery, logging, correlation/causation IDs, idempotency, timeout, metrics, tracing, audit |
+| 📖 **Projections** | Inline (strong), async (eventual), and live (real-time) projections with checkpoints, pause/resume & rebuild |
+| 📊 **Read Models** | Generic repository + fluent query builder (filter/order/paginate) over memory or PostgreSQL |
+| 🔁 **Sagas** | Process managers for long-running workflows with automatic **compensation** and timeouts |
+| 📤 **Outbox** | Transactional outbox for reliable publishing to **Webhook · Kafka · SNS**, with retry & dead-letter |
+| 🔄 **Versioning** | Schema evolution via **upcasting** (zero DB migration) + a schema-compatibility registry |
+| 📦 **Serializers** | JSON (default), **MessagePack**, and **Protobuf** |
+| 🔐 **Encryption** | Field-level encryption via **AWS KMS · HashiCorp Vault · local AES-256-GCM** (envelope encryption, per-tenant keys) |
+| 🧹 **GDPR Toolkit** | Data **export** (Art. 15/20), **erasure** (Art. 17) via crypto-shredding, **retention** policies, **anonymization**, subject discovery |
+| 📝 **Audit Logging** | Immutable, queryable audit trail of every command (who/what/when/outcome) |
+| 📈 **Observability** | First-class **Prometheus** metrics and **OpenTelemetry** tracing |
+| 🛠️ **CLI** | `mink` — project init, code generation, migrations, projection & stream inspection, diagnostics, GDPR ops |
+| 🧪 **Testing** | BDD fixtures, event assertions, projection/saga test harnesses, and Docker test containers |
+
+## Installation
+
+Requires **Go 1.25+** (matches `go.mod`; CI builds on Go 1.25 and 1.26).
+
+```bash
+go get go-mink.dev                      # core library (memory adapter included)
+go get go-mink.dev/adapters/postgres    # PostgreSQL adapter for production
+```
+
+Optionally grab the `mink` CLI for scaffolding and operations:
+
+```bash
+go install go-mink.dev/cmd/mink@latest
+mink --help
+```
+
+## Quick Start
+
+Define events, model an aggregate, and let the store persist and replay them. This runs against the in-memory adapter — no infrastructure required.
 
 ```go
 package main
 
 import (
-    "context"
-    
-    "go-mink.dev"
-    "go-mink.dev/adapters/postgres"
+	"context"
+	"fmt"
+
+	"go-mink.dev"
+	"go-mink.dev/adapters/memory"
 )
 
+// 1. Events are plain structs — the immutable facts of your domain.
+type OrderCreated struct{ OrderID, CustomerID string }
+type ItemAdded struct {
+	OrderID string
+	SKU     string
+	Qty     int
+}
+
+// 2. An aggregate embeds AggregateBase and applies events to build state.
+type Order struct {
+	mink.AggregateBase
+	CustomerID string
+	Items      int
+}
+
+func NewOrder(id string) *Order {
+	o := &Order{}
+	o.SetID(id)
+	o.SetType("Order")
+	return o
+}
+
+func (o *Order) Create(customerID string) {
+	o.Apply(OrderCreated{OrderID: o.AggregateID(), CustomerID: customerID})
+}
+
+func (o *Order) AddItem(sku string, qty int) {
+	o.Apply(ItemAdded{OrderID: o.AggregateID(), SKU: sku, Qty: qty})
+}
+
+// ApplyEvent mutates state — called both for new and replayed events.
+func (o *Order) ApplyEvent(event interface{}) error {
+	switch e := event.(type) {
+	case OrderCreated:
+		o.CustomerID = e.CustomerID
+	case ItemAdded:
+		o.Items += e.Qty
+	}
+	return nil
+}
+
 func main() {
-    ctx := context.Background()
-    
-    // Initialize PostgreSQL adapter
-    adapter, _ := postgres.NewAdapter("postgres://localhost/mydb")
-    defer adapter.Close()
-    
-    // Create event store
-    store := mink.New(adapter)
-    
-    // Create and populate an aggregate
-    order := NewOrder("order-123")
-    order.Create("customer-456")
-    order.AddItem("SKU-001", 2, 29.99)
-    
-    // Save aggregate (events are persisted)
-    store.SaveAggregate(ctx, order)
-    
-    // Load aggregate (events are replayed)
-    loaded := NewOrder("order-123")
-    store.LoadAggregate(ctx, loaded)
+	ctx := context.Background()
+	store := mink.New(memory.NewAdapter())
+	store.RegisterEvents(OrderCreated{}, ItemAdded{})
+
+	// Write: emit events and persist them.
+	order := NewOrder("order-123")
+	order.Create("customer-456")
+	order.AddItem("SKU-001", 2)
+	if err := store.SaveAggregate(ctx, order); err != nil {
+		panic(err)
+	}
+
+	// Read: rebuild state by replaying the stream.
+	loaded := NewOrder("order-123")
+	if err := store.LoadAggregate(ctx, loaded); err != nil {
+		panic(err)
+	}
+	fmt.Printf("Order for %s has %d items (v%d)\n",
+		loaded.CustomerID, loaded.Items, loaded.Version())
+	// → Order for customer-456 has 2 items (v2)
 }
 ```
 
-## CQRS with Command Bus
+**Going to production?** Swap the adapter — everything else stays the same:
 
 ```go
-package main
+adapter, _ := postgres.NewAdapter("postgres://localhost/mydb")
+defer adapter.Close()
+store := mink.New(adapter)
+```
 
-import (
-    "context"
-    
-    "go-mink.dev"
-    "go-mink.dev/adapters/memory"
-)
+The PostgreSQL adapter auto-creates its schema (`streams` + `events`, plus `snapshots`/`checkpoints`) on first use. See the [Event Store guide](https://go-mink.dev/docs/core/event-store).
 
-// Define a command
+## How It Fits Together
+
+Commands flow through a middleware pipeline into handlers that load aggregates and emit events. The event store is the source of truth; projections, sagas, and the outbox all react to the same durable log.
+
+```mermaid
+flowchart LR
+    CMD[Commands] --> BUS
+    subgraph BUS[Command Bus]
+      direction TB
+      MW[validation · idempotency · correlation<br/>audit · metrics · tracing · recovery]
+    end
+    BUS --> H[Handlers]
+    H --> AGG[Aggregates]
+    AGG -- events --> ES[(Event Store<br/>optimistic concurrency)]
+    ES --> PE[Projection Engine]
+    ES --> SM[Saga Manager]
+    ES --> OP[Outbox Processor]
+    PE --> RM[(Read Models)]
+    SM -- compensation --> BUS
+    OP --> EXT[Kafka · Webhooks · SNS]
+```
+
+- **Command Bus** dispatches commands through middleware to handlers ([`bus.go`](bus.go), [`middleware.go`](middleware.go)).
+- **Aggregates** run domain logic and produce events ([`aggregate.go`](aggregate.go)).
+- **Event Store** appends events with optimistic concurrency and replays them ([`store.go`](store.go)).
+- **Projection Engine** builds read models — inline, async, or live ([`projection_engine.go`](projection_engine.go)).
+- **Saga Manager** orchestrates multi-step workflows and compensates on failure ([`saga_manager.go`](saga_manager.go)).
+- **Outbox Processor** reliably publishes events to external systems ([`outbox_processor.go`](outbox_processor.go)).
+
+Full write-up in the [Architecture guide](https://go-mink.dev/docs/getting-started/architecture).
+
+## Guided Tour
+
+<details>
+<summary><b>⚙️ CQRS with the Command Bus</b></summary>
+
+```go
+// Commands are validated, deduplicated intents.
 type CreateOrder struct {
-    mink.CommandBase
-    CustomerID string `json:"customerId"`
+	mink.CommandBase
+	CustomerID string `json:"customerId"`
 }
 
 func (c CreateOrder) CommandType() string { return "CreateOrder" }
 func (c CreateOrder) Validate() error {
-    if c.CustomerID == "" {
-        return mink.NewValidationError("CreateOrder", "CustomerID", "required")
-    }
-    return nil
+	if c.CustomerID == "" {
+		return mink.NewValidationError("CreateOrder", "CustomerID", "required")
+	}
+	return nil
 }
 
-func main() {
-    ctx := context.Background()
-    
-    // Create command bus with middleware
-    bus := mink.NewCommandBus()
-    bus.Use(mink.ValidationMiddleware())
-    bus.Use(mink.RecoveryMiddleware())
-    bus.Use(mink.CorrelationIDMiddleware(nil))
-    
-    // Add idempotency (prevents duplicate processing)
-    idempotencyStore := memory.NewIdempotencyStore()
-    bus.Use(mink.IdempotencyMiddleware(mink.DefaultIdempotencyConfig(idempotencyStore)))
-    
-    // Register command handler
-    bus.RegisterFunc("CreateOrder", func(ctx context.Context, cmd mink.Command) (mink.CommandResult, error) {
-        c := cmd.(CreateOrder)
-        // Process command...
-        return mink.NewSuccessResult("order-123", 1), nil
-    })
-    
-    // Dispatch command
-    result, err := bus.Dispatch(ctx, CreateOrder{CustomerID: "cust-456"})
-    if err != nil {
-        panic(err)
-    }
-    
-    fmt.Printf("Created order: %s (version %d)\n", result.AggregateID, result.Version)
-}
-```
+bus := mink.NewCommandBus()
+bus.Use(mink.RecoveryMiddleware())        // panics → errors
+bus.Use(mink.ValidationMiddleware())      // reject invalid commands
+bus.Use(mink.CorrelationIDMiddleware(nil))
 
-## Projections & Read Models
+// Idempotency: the same command is processed exactly once.
+idem := memory.NewIdempotencyStore()
+bus.Use(mink.IdempotencyMiddleware(mink.DefaultIdempotencyConfig(idem)))
 
-```go
-package main
-
-import (
-    "context"
-    "time"
-
-    "go-mink.dev"
-    "go-mink.dev/adapters/memory"
-)
-
-// Define a read model
-type OrderSummary struct {
-    OrderID    string
-    CustomerID string
-    Status     string
-    ItemCount  int
-    Total      float64
-}
-
-// Define a projection
-type OrderSummaryProjection struct {
-    mink.ProjectionBase
-    repo *mink.InMemoryRepository[OrderSummary]
-}
-
-func (p *OrderSummaryProjection) Apply(ctx context.Context, event mink.StoredEvent) error {
-    // Transform events into read model updates
-    // ...
-    return nil
-}
-
-func main() {
-    ctx := context.Background()
-
-    // Create projection engine
-    checkpointStore := memory.NewCheckpointStore()
-    engine := mink.NewProjectionEngine(store,
-        mink.WithCheckpointStore(checkpointStore),
-    )
-
-    // Register projections
-    repo := mink.NewInMemoryRepository[OrderSummary](func(o *OrderSummary) string {
-        return o.OrderID
-    })
-    engine.RegisterInline(&OrderSummaryProjection{repo: repo})
-
-    // Start engine
-    engine.Start(ctx)
-    defer engine.Stop(ctx)
-
-    // Query read models with fluent API
-    orders, _ := repo.Query(ctx, mink.NewQuery().
-        Where("Status", mink.Eq, "Pending").
-        OrderByDesc("Total").
-        WithLimit(10))
-
-    // Rebuild projections when needed
-    rebuilder := mink.NewProjectionRebuilder(store, checkpointStore)
-    rebuilder.RebuildInline(ctx, projection, mink.RebuildOptions{BatchSize: 1000})
-}
-```
-
-## Testing Utilities
-
-```go
-import (
-    "go-mink.dev/testing/bdd"
-    "go-mink.dev/testing/assertions"
-    "go-mink.dev/testing/containers"
-)
-
-// BDD-style aggregate testing
-func TestOrderCreation(t *testing.T) {
-    order := NewOrder("order-123")
-
-    bdd.Given(t, order).
-        When(func() error {
-            return order.Create("customer-456")
-        }).
-        Then(OrderCreated{OrderID: "order-123", CustomerID: "customer-456"})
-}
-
-// Event assertions
-assertions.AssertEventTypes(t, events, "OrderCreated", "ItemAdded")
-
-// PostgreSQL test containers
-container := containers.StartPostgres(t)
-db := container.MustDB(ctx)
-```
-
-## Observability
-
-```go
-import (
-    "go-mink.dev/middleware/metrics"
-    "go-mink.dev/middleware/tracing"
-)
-
-// Prometheus metrics
-m := metrics.New(metrics.WithMetricsServiceName("order-service"))
-m.MustRegister()
-bus.Use(m.CommandMiddleware())
-
-// OpenTelemetry tracing
-tracer := tracing.NewTracer(tracing.WithServiceName("order-service"))
-bus.Use(tracer.CommandMiddleware())
-```
-
-## Outbox Pattern
-
-```go
-import (
-    "go-mink.dev"
-    "go-mink.dev/adapters/memory"
-    "go-mink.dev/outbox/webhook"
-)
-
-// Wrap event store with outbox for reliable publishing
-outboxStore := memory.NewOutboxStore()
-esWithOutbox := mink.NewEventStoreWithOutbox(store, outboxStore, []mink.OutboxRoute{
-    {EventTypes: []string{"OrderCreated"}, Destination: "webhook:https://partner.example.com/events"},
-    {Destination: "kafka:all-events"}, // All events
+bus.RegisterFunc("CreateOrder", func(ctx context.Context, cmd mink.Command) (mink.CommandResult, error) {
+	c := cmd.(CreateOrder)
+	// load aggregate, run domain logic, save events...
+	return mink.NewSuccessResult("order-123", 1), nil
 })
 
-// Append events - outbox messages scheduled automatically
-esWithOutbox.Append(ctx, "Order-123", []interface{}{OrderCreated{OrderID: "123"}})
+result, err := bus.Dispatch(ctx, CreateOrder{CustomerID: "cust-456"})
+```
 
-// Start background processor with publishers
+See the [`cqrs`](examples/cqrs) example and the [Advanced Patterns guide](https://go-mink.dev/docs/advanced/advanced-patterns).
+</details>
+
+<details>
+<summary><b>📖 Projections & Read Models</b></summary>
+
+```go
+type OrderSummary struct {
+	OrderID   string
+	Status    string
+	ItemCount int
+	Total     float64
+}
+
+type OrderSummaryProjection struct {
+	mink.ProjectionBase
+	repo *mink.InMemoryRepository[OrderSummary]
+}
+
+func (p *OrderSummaryProjection) Apply(ctx context.Context, e mink.StoredEvent) error {
+	// transform events into read-model updates...
+	return nil
+}
+
+engine := mink.NewProjectionEngine(store, mink.WithCheckpointStore(memory.NewCheckpointStore()))
+engine.RegisterInline(&OrderSummaryProjection{repo: repo})
+engine.Start(ctx)
+defer engine.Stop(ctx)
+
+// Query with the fluent builder.
+orders, _ := repo.Find(ctx, mink.NewQuery().
+	Where("Status", mink.FilterOpEq, "Pending").
+	OrderByDesc("Total").
+	WithLimit(10))
+
+// Rebuild from scratch whenever requirements change.
+mink.NewProjectionRebuilder(store, checkpointStore).
+	RebuildInline(ctx, projection, mink.RebuildOptions{BatchSize: 1000})
+```
+
+See the [`projections`](examples/projections) example and the [Read Models guide](https://go-mink.dev/docs/core/read-models).
+</details>
+
+<details>
+<summary><b>🔁 Sagas / Process Managers</b></summary>
+
+Orchestrate multi-step workflows that span aggregates, with automatic compensation when a step fails.
+
+```go
+type OrderFulfillmentSaga struct {
+	mink.SagaBase
+	PaymentID   string
+	ShipmentID  string
+}
+
+// React to events by emitting the next command; compensate on failure.
+func (s *OrderFulfillmentSaga) HandleEvent(ctx context.Context, e mink.StoredEvent) ([]mink.Command, error) {
+	switch e.Type {
+	case "OrderPlaced":
+		return []mink.Command{ProcessPayment{...}}, nil
+	case "PaymentFailed":
+		return []mink.Command{CancelOrder{...}}, nil // compensation
+	}
+	return nil, nil
+}
+```
+
+See the [`sagas`](examples/sagas) example and the [Sagas section](https://go-mink.dev/docs/advanced/advanced-patterns).
+</details>
+
+<details>
+<summary><b>📤 Outbox — reliable publishing to Kafka / Webhooks / SNS</b></summary>
+
+```go
+outboxStore := memory.NewOutboxStore()
+es := mink.NewEventStoreWithOutbox(store, outboxStore, []mink.OutboxRoute{
+	{EventTypes: []string{"OrderCreated"}, Destination: "webhook:https://partner.example.com/events"},
+	{Destination: "kafka:all-events"}, // every event
+})
+
+// Events and outbox messages are written atomically.
+es.Append(ctx, "Order-123", []interface{}{OrderCreated{OrderID: "123"}})
+
+// A background processor delivers them with retry + dead-letter.
 processor := mink.NewOutboxProcessor(outboxStore,
-    mink.WithPublisher(webhook.New()),
-    mink.WithPollInterval(time.Second),
+	mink.WithPublisher(webhook.New()),
+	mink.WithPollInterval(time.Second),
 )
 processor.Start(ctx)
 defer processor.Stop(ctx)
 ```
 
-## Event Versioning & Upcasting
+Publishers: [`outbox/webhook`](outbox/webhook), [`outbox/kafka`](outbox/kafka), [`outbox/sns`](outbox/sns).
+</details>
+
+<details>
+<summary><b>🔄 Event Versioning & Upcasting (zero DB migration)</b></summary>
 
 ```go
-import (
-    "encoding/json"
-    "go-mink.dev"
-)
-
-// Define upcaster: v1 → v2 (add Currency field)
+// Upcast v1 → v2 by adding a default Currency field.
 type orderCreatedV1ToV2 struct{}
 
 func (u orderCreatedV1ToV2) EventType() string { return "OrderCreated" }
 func (u orderCreatedV1ToV2) FromVersion() int  { return 1 }
 func (u orderCreatedV1ToV2) ToVersion() int    { return 2 }
 func (u orderCreatedV1ToV2) Upcast(data []byte, m mink.Metadata) ([]byte, error) {
-    var obj map[string]interface{}
-    json.Unmarshal(data, &obj)
-    obj["currency"] = "USD" // default for old events
-    return json.Marshal(obj)
+	var obj map[string]interface{}
+	json.Unmarshal(data, &obj)
+	obj["currency"] = "USD"
+	return json.Marshal(obj)
 }
 
-// Register with event store — old events upcasted transparently on load
 chain := mink.NewUpcasterChain()
 chain.Register(orderCreatedV1ToV2{})
-
 store := mink.New(adapter, mink.WithUpcasters(chain))
-
-// Schema compatibility checking
-registry := mink.NewSchemaRegistry()
-registry.Register("OrderCreated", mink.SchemaDefinition{Version: 1, Fields: v1Fields})
-registry.Register("OrderCreated", mink.SchemaDefinition{Version: 2, Fields: v2Fields})
-compat, _ := registry.CheckCompatibility("OrderCreated", 1, 2)
-// compat == SchemaBackwardCompatible
+// Old events are upcasted transparently on Load — the schema version lives in metadata.
 ```
 
-## Field-Level Encryption
+See the [`versioning`](examples/versioning) example and the [Versioning guide](https://go-mink.dev/docs/advanced/versioning).
+</details>
+
+<details>
+<summary><b>🔐 Field-Level Encryption & Crypto-Shredding</b></summary>
 
 ```go
-import (
-    "go-mink.dev"
-    "go-mink.dev/encryption/local"
-)
-
-// Set up encryption provider (local for dev, KMS/Vault for production)
-provider := local.New(local.WithKey("master-1", myKey))
+provider, _ := local.New(local.WithKey("master-1", myKey)) // KMS/Vault in production
 defer provider.Close()
 
-// Configure which fields to encrypt per event type
 encConfig := mink.NewFieldEncryptionConfig(
-    mink.WithEncryptionProvider(provider),
-    mink.WithDefaultKeyID("master-1"),
-    mink.WithEncryptedFields("CustomerCreated", "email", "phone", "ssn"),
-    // Per-tenant keys for multi-tenant apps
-    mink.WithTenantKeyResolver(func(tenantID string) string {
-        return "tenant-" + tenantID
-    }),
-    // Crypto-shredding: graceful degradation when key is revoked
-    mink.WithDecryptionErrorHandler(func(err error, eventType string, meta mink.Metadata) error {
-        if errors.Is(err, encryption.ErrKeyRevoked) {
-            return nil // Return encrypted data as-is
-        }
-        return err
-    }),
+	mink.WithEncryptionProvider(provider),
+	mink.WithDefaultKeyID("master-1"),
+	mink.WithEncryptedFields("CustomerCreated", "email", "phone", "ssn"),
+	mink.WithTenantKeyResolver(func(tenantID string) string { return "tenant-" + tenantID }),
 )
 
-// Create event store with encryption
 store := mink.New(adapter, mink.WithFieldEncryption(encConfig))
-
-// PII fields are encrypted at rest, decrypted transparently on load
-// Revoking a key makes that tenant's data permanently unrecoverable (GDPR)
+// PII is encrypted at rest and decrypted transparently on load.
+// Revoking a key makes that data permanently unrecoverable — GDPR crypto-shredding.
+store.EncryptionConfig().RevokeKey("tenant-42")
 ```
 
-## GDPR Data Export
+Providers: [`encryption/local`](encryption/local), [`encryption/kms`](encryption/kms), [`encryption/vault`](encryption/vault). See the [Security guide](https://go-mink.dev/docs/advanced/security).
+</details>
+
+<details>
+<summary><b>🧹 GDPR — Export, Erasure & Retention</b></summary>
+
+go-mink treats data governance as a first-class concern.
 
 ```go
-import "go-mink.dev"
-
+// Right to access / portability (Article 15 & 20)
 exporter := mink.NewDataExporter(store)
-
-// Export by known stream IDs (efficient)
 result, _ := exporter.Export(ctx, mink.ExportRequest{
-    SubjectID: "user-123",
-    Streams:   []string{"Customer-user-123", "Order-ord-456"},
-})
-// result.Events, result.TotalEvents, result.RedactedCount
-
-// Or scan all events with filters
-result, _ = exporter.Export(ctx, mink.ExportRequest{
-    SubjectID: "tenant-A",
-    Filter: mink.CombineFilters(
-        mink.FilterByTenantID("A"),
-        mink.FilterByEventTypes("CustomerCreated", "OrderPlaced"),
-    ),
+	SubjectID: "user-123",
+	Filter:    mink.FilterByUserID("user-123"),
 })
 
-// Stream for large exports (no memory accumulation)
-exporter.ExportStream(ctx, mink.ExportRequest{
-    SubjectID: "user-123",
-    Streams:   []string{"Customer-user-123"},
-}, func(ctx context.Context, event mink.ExportedEvent) error {
-    if event.Redacted {
-        return nil // Key revoked — crypto-shredded
-    }
-    return writeToFile(event)
+// Right to erasure (Article 17) — one call: revoke keys, redact read models,
+// run external-PII hooks, and emit a verifiable erasure certificate.
+eraser := mink.NewDataEraser(store,
+	mink.WithEraseSubjectResolver(resolver),
+	mink.WithSharedKeyGuard(),                 // don't nuke a shared tenant key
+	mink.WithReadModelRedactor(readModels...),
+	mink.WithSubjectStore(mink.NewAuditSubjectEraser(auditStore)),
+)
+res, _ := eraser.Erase(ctx, mink.ErasureRequest{SubjectID: "user-123"})
+
+// Scheduled retention: shred / redact / anonymize by age, category, or tenant.
+rm := mink.NewRetentionManager(store, []mink.RetentionPolicy{
+	{Name: "shred-old-pii", Category: "user", MaxAge: 365 * 24 * time.Hour, Action: mink.ActionShred},
 })
+report, _ := rm.Apply(ctx)
 ```
+
+Explore [`export`](examples/export) & [`encryption`](examples/encryption), or read the [Security & GDPR guide](https://go-mink.dev/docs/security). The `mink gdpr` CLI can `discover`, `verify`, `erase`, and dry-run `retain`.
+</details>
+
+<details>
+<summary><b>📝 Audit Logging</b></summary>
+
+```go
+auditStore := memory.NewAuditStore() // PostgreSQL store for production
+bus.Use(mink.AuditMiddleware(mink.DefaultAuditConfig(auditStore)))
+
+ctx = mink.WithActor(ctx, "alice@example.com")
+bus.Dispatch(ctx, cmd) // records who/what/when/outcome, immutably
+
+entries, _ := auditStore.Find(ctx, mink.AuditQuery{CommandType: "WithdrawFunds"})
+```
+
+See the [`audit`](examples/audit) example and the [Audit Logging guide](https://go-mink.dev/docs/advanced/audit-logging).
+</details>
+
+<details>
+<summary><b>📈 Observability — Prometheus & OpenTelemetry</b></summary>
+
+```go
+// Prometheus metrics
+m := metrics.New(metrics.WithMetricsServiceName("order-service"))
+bus.Use(m.CommandMiddleware())
+
+// OpenTelemetry tracing
+tracer := tracing.NewTracer(tracing.WithServiceName("order-service"))
+bus.Use(tracing.CommandMiddleware(tracer))
+```
+
+See the [`metrics`](examples/metrics) & [`tracing`](examples/tracing) examples.
+</details>
+
+<details>
+<summary><b>🧪 Testing utilities</b></summary>
+
+```go
+// BDD-style aggregate tests: Given → When → Then
+bdd.Given(t, NewOrder("order-123")).
+	When(func() error { return order.Create("customer-456") }).
+	Then(OrderCreated{OrderID: "order-123", CustomerID: "customer-456"})
+
+// Fluent event assertions
+assertions.AssertEventTypes(t, events, "OrderCreated", "ItemAdded")
+
+// Real PostgreSQL in tests via containers
+container := containers.StartPostgres(t)
+db := container.MustDB(ctx)
+```
+
+See the [`bdd-testing`](examples/bdd-testing) example and the [Testing guide](https://go-mink.dev/docs/guide/testing).
+</details>
+
+## Examples
+
+Fifteen runnable, self-contained examples live in [`examples/`](examples/) — each with its own README. Most need **zero infrastructure** (`go run ./examples/<name>`); two use PostgreSQL via `docker compose`.
+
+| Example | Demonstrates | Infra |
+|---------|--------------|:-----:|
+| [basic](examples/basic) | Minimal event sourcing: events, aggregates, save/load | — |
+| [cqrs](examples/cqrs) | Command bus + full middleware pipeline | — |
+| [cqrs-postgres](examples/cqrs-postgres) | CQRS backed by PostgreSQL | 🐘 |
+| [projections](examples/projections) | Inline & live read models, query builder | — |
+| [sagas](examples/sagas) | Process manager with compensation | — |
+| [versioning](examples/versioning) | Schema evolution via upcasting (v1→v2→v3) | — |
+| [encryption](examples/encryption) | Field-level encryption + crypto-shredding | — |
+| [export](examples/export) | GDPR data export strategies | — |
+| [audit](examples/audit) | Command audit-logging middleware | — |
+| [metrics](examples/metrics) | Prometheus instrumentation | — |
+| [tracing](examples/tracing) | OpenTelemetry distributed tracing | — |
+| [msgpack](examples/msgpack) | MessagePack serialization | — |
+| [protobuf](examples/protobuf) | Protobuf serialization | — |
+| [bdd-testing](examples/bdd-testing) | Given/When/Then aggregate testing | — |
+| [full-ecommerce](examples/full-ecommerce) | **Everything together** — a realistic system | 🐘 |
+
+New here? Read [`basic`](examples/basic) → [`cqrs`](examples/cqrs) → [`projections`](examples/projections) → [`full-ecommerce`](examples/full-ecommerce).
 
 ## Performance
 
-go-mink is benchmarked on every commit with a shared adapter benchmark suite. Key metrics from CI (ubuntu-latest):
+go-mink is benchmarked on every commit with a shared adapter benchmark suite. Representative figures from CI (`ubuntu-latest`):
 
 | Adapter | Append (single) | Append (batch 100) | Load (1000 events) | Concurrent (8 workers) |
 |---------|-----------------|--------------------|--------------------|------------------------|
 | **Memory** | ~2.5M events/sec | ~6M events/sec | ~60M events/sec | ~1.5M events/sec |
 | **PostgreSQL** | ~5K events/sec | ~30K events/sec | ~300K events/sec | ~15K events/sec |
 
-Scale tests: Memory adapter processes **1M events** in under 1 second. PostgreSQL adapter handles **100K events** with p99 append latency under 2ms.
+Scale tests: the memory adapter processes **1M events** in under a second; the PostgreSQL adapter handles **100K events** with p99 append latency under 2 ms.
 
-Run benchmarks locally:
 ```bash
-make benchmark-adapters      # Memory adapter (no infra)
+make benchmark-adapters      # memory adapter (no infra)
 make benchmark-adapters-pg   # PostgreSQL adapter (needs infra)
 ```
 
-See [full benchmark results](docs/benchmarks.md) for detailed throughput, latency percentiles, and instructions for adding benchmarks to new adapters.
-
-## Installation
-
-```bash
-go get go-mink.dev
-go get go-mink.dev/adapters/postgres
-```
+Details, latency percentiles, and a guide for benchmarking new adapters: [Benchmarks](https://go-mink.dev/docs/guide/benchmarks).
 
 ## Documentation
 
-| Document | Description |
-|----------|-------------|
-| [Introduction](docs/introduction.md) | Problem statement and goals |
-| [Architecture](docs/architecture.md) | System design and components |
-| [Event Store](docs/event-store.md) | Event storage design |
-| [Read Models](docs/read-models.md) | Projection system |
-| [Adapters](docs/adapters.md) | Database adapter system |
-| [CLI](docs/cli.md) | Command-line tooling |
-| [API Design](docs/api-design.md) | Public API reference |
-| [Roadmap](docs/roadmap.md) | Future development plans |
-| [Advanced Patterns](docs/advanced-patterns.md) | Commands, Sagas, Outbox, Encryption, Data Export |
-| [Event Versioning](docs/versioning.md) | Schema evolution & upcasting |
-| [Security](docs/security.md) | Encryption, GDPR compliance |
-| [Testing](docs/testing.md) | BDD fixtures and test utilities |
-| [Benchmarks](docs/benchmarks.md) | Performance results and benchmark guide |
+Full documentation lives at **[go-mink.dev](https://go-mink.dev)**.
+
+| | |
+|---|---|
+| 🚀 **Get started** | [Introduction](https://go-mink.dev/docs/getting-started/introduction) · [Architecture](https://go-mink.dev/docs/getting-started/architecture) · [Tutorial](https://go-mink.dev/docs/tutorial/setup) |
+| 🧠 **Core concepts** | [Event Store](https://go-mink.dev/docs/core/event-store) · [Read Models](https://go-mink.dev/docs/core/read-models) · [Adapters](https://go-mink.dev/docs/core/adapters) |
+| 🔬 **Advanced** | [Advanced Patterns](https://go-mink.dev/docs/advanced/advanced-patterns) · [Versioning](https://go-mink.dev/docs/advanced/versioning) · [Security & GDPR](https://go-mink.dev/docs/advanced/security) · [Audit Logging](https://go-mink.dev/docs/advanced/audit-logging) · [API Design](https://go-mink.dev/docs/advanced/api-design) |
+| 🛠️ **Guides** | [CLI](https://go-mink.dev/docs/guide/cli) · [Testing](https://go-mink.dev/docs/guide/testing) · [Benchmarks](https://go-mink.dev/docs/guide/benchmarks) |
+| 📚 **Learn by reading** | [Blog Series](https://go-mink.dev/docs/blog-series/introduction) · [Architecture Decision Records](https://go-mink.dev/docs/adr/) · [Roadmap](https://go-mink.dev/docs/roadmap) |
+| 🔎 **Reference** | [pkg.go.dev/go-mink.dev](https://pkg.go.dev/go-mink.dev) |
+
+## Project Status
+
+**Current release: [v1.0.0](CHANGELOG.md) — stable.** All core features are complete and the public API is stable under [Semantic Versioning](https://semver.org/). Active development continues on the `develop` branch (see the [roadmap](https://go-mink.dev/docs/roadmap) and [CHANGELOG](CHANGELOG.md)).
+
+Releases are automated: every merge to `develop` publishes a release candidate (`v1.0.4-rc.1`, …), and merging `develop` into `main` cuts the next stable release. Opt into an RC with `go get go-mink.dev@v1.0.4-rc.1`.
+
+## Contributing
+
+Contributions are very welcome — whether it's a bug report, a docs fix, a new adapter, or a feature. 🙌
+
+1. Read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
+2. Branch from `develop` (`feature/your-thing` or `fix/your-thing`).
+3. Write tests (we hold **90%+ coverage**) and run the checks below.
+4. Open a PR against `develop` with a clear description.
+
+```bash
+make test-unit     # fast unit tests, no infrastructure needed
+make test          # full suite (auto-starts PostgreSQL + Kafka via docker-compose)
+make lint          # golangci-lint
+make fmt           # go fmt ./...
+```
+
+**Great first contributions:** try an example, improve a doc page, add a benchmark, or implement an [`EventStoreAdapter`](adapters/adapter.go) for your favorite database. Browse [good first issues](https://github.com/AshkanYarmoradi/go-mink/labels/good%20first%20issue) to get started.
+
+## Community & Support
+
+- 💬 [**GitHub Discussions**](https://github.com/AshkanYarmoradi/go-mink/discussions) — questions, ideas, and show-and-tell
+- 🐛 [**Issues**](https://github.com/AshkanYarmoradi/go-mink/issues) — bugs and feature requests
+- 🔐 [**Security Policy**](.github/SECURITY.md) — report vulnerabilities privately
+- ⭐ **Star the repo** if go-mink is useful to you — it genuinely helps others discover it.
 
 ## License
 
-Apache License 2.0 - See [LICENSE](LICENSE) for details.
+[Apache License 2.0](LICENSE) © go-mink contributors.
 
 ---
 
-**go-mink** - Event Sourcing for Go, Done Right.
+<p align="center"><b>go-mink</b> — Event Sourcing for Go, done right. 🦫</p>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,88 @@
+# go-mink Examples
+
+Fifteen self-contained, runnable programs that show every major go-mink feature in action. Each lives in its own folder with a dedicated README explaining what it does, how to run it, and what to look for.
+
+Most examples need **zero infrastructure** — just `go run`. Two use PostgreSQL (marked 🐘) and start it for you via Docker Compose.
+
+## Prerequisites
+
+- **Go 1.25+**
+- **Docker** (only for the 🐘 PostgreSQL examples)
+
+## Running an example
+
+```bash
+# From the repository root:
+go run ./examples/basic          # in-memory examples — no setup
+
+# bdd-testing is a test suite, run it with `go test`:
+go test -v ./examples/bdd-testing
+```
+
+For the PostgreSQL examples, start infra first and stop it after:
+
+```bash
+docker compose -f docker-compose.test.yml up -d --wait
+go run ./examples/cqrs-postgres
+docker compose -f docker-compose.test.yml down
+```
+
+The adapter auto-creates its schema on first use, so there's nothing to migrate by hand.
+
+## The examples
+
+### Start here
+
+| Example | What it shows | Infra |
+|---------|---------------|:-----:|
+| [basic](basic) | The fundamentals — define events, model an aggregate, save and replay a stream | — |
+| [cqrs](cqrs) | Dispatch commands through a bus with a full middleware pipeline | — |
+| [projections](projections) | Turn events into queryable read models (inline & live) | — |
+
+### Core patterns
+
+| Example | What it shows | Infra |
+|---------|---------------|:-----:|
+| [sagas](sagas) | Coordinate multi-step workflows with automatic compensation | — |
+| [cqrs-postgres](cqrs-postgres) | The `cqrs` example backed by a real PostgreSQL database | 🐘 |
+| [full-ecommerce](full-ecommerce) | **Everything together** — a realistic order-fulfillment system | 🐘 |
+
+### Schema & serialization
+
+| Example | What it shows | Infra |
+|---------|---------------|:-----:|
+| [versioning](versioning) | Evolve event schemas (v1 → v2 → v3) with upcasting — no DB migration | — |
+| [msgpack](msgpack) | Swap in MessagePack serialization for smaller, faster payloads | — |
+| [protobuf](protobuf) | Strongly-typed, schema-enforced Protocol Buffers serialization | — |
+
+### Security, privacy & compliance
+
+| Example | What it shows | Infra |
+|---------|---------------|:-----:|
+| [encryption](encryption) | Field-level encryption at rest, per-tenant keys, crypto-shredding | — |
+| [export](export) | GDPR data export (right to access / portability) | — |
+| [audit](audit) | An immutable audit trail of every command (who/what/when/outcome) | — |
+
+### Observability & testing
+
+| Example | What it shows | Infra |
+|---------|---------------|:-----:|
+| [metrics](metrics) | Prometheus metrics for commands and event-store operations | — |
+| [tracing](tracing) | OpenTelemetry distributed tracing | — |
+| [bdd-testing](bdd-testing) | Behavior-driven aggregate tests with Given/When/Then | — |
+
+## Suggested learning path
+
+1. **[basic](basic)** — understand events, aggregates, and the event store.
+2. **[cqrs](cqrs)** — add commands, handlers, and middleware.
+3. **[projections](projections)** — build read models for queries.
+4. **[sagas](sagas)** — orchestrate workflows across aggregates.
+5. Pick the production concerns you care about — **[versioning](versioning)**, **[encryption](encryption)**, **[export](export)**, **[audit](audit)**, **[metrics](metrics)**, **[tracing](tracing)**.
+6. **[full-ecommerce](full-ecommerce)** — see how it all composes into one system.
+
+## Learn more
+
+- 📖 **Documentation:** [go-mink.dev](https://go-mink.dev)
+- 🎓 **Guided tutorial:** [Build an e-commerce system](https://go-mink.dev/docs/tutorial/setup)
+- 🔎 **API reference:** [pkg.go.dev/go-mink.dev](https://pkg.go.dev/go-mink.dev)
+- 🏠 **Project README:** [../README.md](../README.md)

--- a/examples/audit/README.md
+++ b/examples/audit/README.md
@@ -1,0 +1,38 @@
+# Command Audit Logging Example
+
+> Record who did what, when, and with what outcome — an immutable audit trail for every command.
+
+Regulated and security-sensitive systems need a tamper-evident record of every action taken and by whom, including the ones that failed. go-mink's `AuditMiddleware` writes one immutable entry per command dispatched through the bus, capturing the actor, command type, success/failure, error, and duration. Because it lives in the middleware pipeline, auditing is transparent to your handlers and applies uniformly to every command.
+
+## What this demonstrates
+- **Audit middleware** — `AuditMiddleware(DefaultAuditConfig(store))` records one entry per command with no changes to handler code.
+- **Success and failure captured** — both a passing `CreateAccount` and a failing `Withdraw` are recorded, the latter with its error message.
+- **Nested recovery** — `RecoveryMiddleware` sits inside the audit middleware, so even a panicking handler is still recorded as a failed entry.
+- **Actor attribution** — `WithActor(ctx, "user-42")` stamps every audit entry with who initiated the command.
+- **Selective skipping** — `cfg.SkipCommands = []string{"HealthCheck"}` keeps noisy commands out of the trail.
+- **Querying the trail** — `AuditQuery{}` (zero value) returns all entries, most recent first.
+
+## Running
+```bash
+go run ./examples/audit
+```
+No infrastructure required — the audit store is in-memory (`memory.NewAuditStore`). For production, swap in `postgres.NewAuditStore(db, ...)` and call its `Initialize` (the audit table is created by the store, not by the adapter's migrations).
+
+## What happens
+1. An in-memory `AuditStore` and a `HandlerRegistry` with three handlers are created: `CreateAccount` (returns success), `Withdraw` (always fails with "insufficient funds"), and `HealthCheck` (success).
+2. A `CommandBus` is built with `AuditMiddleware` wrapping `RecoveryMiddleware`; the audit config skips `HealthCheck` and enables `IncludeMetadata`.
+3. `WithActor(ctx, "user-42")` identifies the caller, then three commands are dispatched: `CreateAccount` (succeeds), `Withdraw` (fails — the expected error is printed), and `HealthCheck` (skipped from the audit trail).
+4. `auditStore.Find(ctx, AuditQuery{})` returns the trail. Only **two** entries appear — `HealthCheck` was skipped — printed with command type, actor, success flag, `OK`/`FAILED` status, error message, and duration in milliseconds.
+
+## Key APIs
+- `mink.AuditMiddleware(config)` — middleware that writes an audit entry per command.
+- `mink.DefaultAuditConfig(store)` — sensible defaults; here extended with `SkipCommands` and `IncludeMetadata`.
+- `memory.NewAuditStore()` — in-memory audit store for tests/examples (production: `postgres.NewAuditStore`).
+- `mink.WithActor(ctx, actor)` — attach the acting principal to the context so it lands on each entry.
+- `mink.RecoveryMiddleware()` — converts handler panics into errors; nested inside audit so panics are still recorded.
+- `mink.AuditQuery{}` — filter/paginate the audit trail; the zero value returns everything.
+- `mink.NewHandlerRegistry()` / `mink.RegisterGenericHandler(...)` — register the command handlers dispatched through the bus.
+
+## Related
+- **Examples:** [full-ecommerce](../full-ecommerce) · [cqrs-postgres](../cqrs-postgres)
+- **Docs:** [Audit Logging](https://go-mink.dev/docs/advanced/audit-logging) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,45 @@
+# Basic Event Sourcing Example
+
+> The smallest end-to-end go-mink program: define events, model an aggregate, and persist it to an event store.
+
+This example introduces the core idea behind event sourcing — instead of storing an order's current state, you store the immutable events that led to it (`OrderCreated`, `ItemAdded`, `OrderShipped`) and rebuild state by replaying them. It's the foundation every other example builds on, so start here if go-mink is new to you.
+
+## What this demonstrates
+- **Domain events** — `OrderCreated`, `ItemAdded`, and `OrderShipped` are plain structs registered with `store.RegisterEvents` so they can be serialized and replayed.
+- **Aggregate root** — `Order` embeds `mink.AggregateBase` and enforces business rules in `Create`, `AddItem`, and `Ship` (e.g. you can't add items to a shipped order).
+- **Apply / rebuild split** — command methods call `Apply` to record new events, while `ApplyEvent` rebuilds state from stored history and bumps the version via `IncrementVersion`.
+- **Save and load** — `SaveAggregate` persists uncommitted events; `LoadAggregate` replays them into a fresh instance, restoring identical state.
+- **Working with the store directly** — `LoadRaw` reads the raw event records off a stream, and `GetStreamInfo` reports stream metadata (version, event count, timestamps).
+
+## Running
+```bash
+go run ./examples/basic
+```
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+The program runs six numbered steps and prints the result of each:
+
+1. **Create a new order** — builds `order-001`, adds two items, and prints the in-memory state (customer, item count, total, and the count of uncommitted events), then calls `SaveAggregate` and confirms the uncommitted events have been flushed.
+2. **Load from the event store** — creates a fresh `Order` and calls `LoadAggregate`, printing the reconstructed status, items, total, and version to show state was rebuilt purely from events.
+3. **Add another item and ship** — mutates the loaded order (`AddItem` + `Ship`) and saves it again, appending more events to the same stream.
+4. **Load raw events** — reads the stream via `LoadRaw(ctx, "Order-order-001", 0)` and lists each event's version, type, and global position.
+5. **Get stream information** — prints the `StreamInfo`: stream ID, category, current version, event count, and creation timestamp.
+6. **Final state** — reloads the order one last time and prints the complete order, including tracking number and a line-by-line item breakdown.
+
+## Key APIs
+- `mink.New(adapter)` — constructs an `EventStore` over a storage adapter.
+- `memory.NewAdapter()` — in-memory `EventStoreAdapter` for tests and demos.
+- `store.RegisterEvents(...)` — registers event types for serialization.
+- `mink.AggregateBase` / `mink.NewAggregateBase(id, type)` — embeddable base providing identity, versioning, and event tracking.
+- `(*Order).Apply(event)` — records a new uncommitted event and applies it.
+- `(*Order).ApplyEvent(event)` — rebuilds state from a historical event.
+- `IncrementVersion()`, `Version()`, `AggregateID()`, `UncommittedEvents()` — aggregate bookkeeping from `AggregateBase`.
+- `store.SaveAggregate(ctx, agg)` — appends uncommitted events to the aggregate's stream.
+- `store.LoadAggregate(ctx, agg)` — loads and replays a stream into an aggregate.
+- `store.LoadRaw(ctx, streamID, fromVersion)` — returns raw `StoredEvent` records.
+- `store.GetStreamInfo(ctx, streamID)` — returns `StreamInfo` (version, event count, timestamps).
+
+## Related
+- **Examples:** [cqrs](../cqrs) · [projections](../projections) · [full-ecommerce](../full-ecommerce)
+- **Docs:** [Event Store](https://go-mink.dev/docs/core/event-store) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/bdd-testing/README.md
+++ b/examples/bdd-testing/README.md
@@ -1,0 +1,43 @@
+# BDD Testing Example
+
+> Test event-sourced aggregates with Given/When/Then using the go-mink `bdd` package.
+
+Behavior-Driven Development expresses aggregate behavior as readable specifications: given a history of past events, when a command runs, then specific new events are emitted — or a specific error is returned. This example specs out a `BankAccount` aggregate (deposits, withdrawals, daily limits, closing) so its rules are verified without any database or serialization.
+
+## What this demonstrates
+- **Given / When / Then** — `bdd.Given(t, account, pastEvents...)` seeds state, `.When(func() error {...})` runs a command, and `.Then(expectedEvent)` asserts the uncommitted events produced.
+- **Error assertions** — `.ThenError(err)` verifies a command rejects invalid operations (insufficient funds, exceeded daily limit, closed account).
+- **State reconstruction from events** — the fixture replays the `Given` events through `ApplyEvent` to rebuild the aggregate before the command runs.
+- **Rich domain rules** — `BankAccount` enforces positive amounts, balance sufficiency, per-day withdrawal limits, and closed-account guards.
+- **Table-driven subtests** — ~12 `t.Run` cases across opening, deposits, withdrawals, daily limits, and closing, plus a full-lifecycle scenario.
+
+## Running
+```bash
+go test -v ./examples/bdd-testing
+```
+No infrastructure required — uses the in-memory adapter.
+
+This is a test file, not a program — run it with `go test`, not `go run`.
+
+## What happens
+Each subtest builds a `BankAccount`, seeds it with prior events, executes one command, and asserts the outcome:
+1. **Opening** — an empty account opens and emits `AccountOpened`.
+2. **Deposits** — a deposit emits `MoneyDeposited`; negative amounts fail with `ErrNegativeAmount`; depositing to a closed account fails with `ErrAccountClosed`.
+3. **Withdrawals** — a funded account withdraws and emits `MoneyWithdrawn`; over-balance fails with `ErrInsufficientFunds`; exceeding the daily limit fails with `ErrDailyLimitExceeded`; a closed account fails with `ErrAccountClosed`.
+4. **Daily limit** — `SetDailyLimit` emits `DailyLimitSet`; multiple withdrawals succeed while their running total stays under the limit.
+5. **Closing** — an open account closes and emits `AccountClosed`; closing an already-closed account fails with `ErrAccountClosed`.
+6. **Complete lifecycle** — open → deposit → withdraw → close, asserting balances (1000 → 750) and the final closed state.
+
+Because timestamps are set at command time, event assertions copy the generated time from `account.UncommittedEvents()[0]` so comparisons stay deterministic.
+
+## Key APIs
+- `bdd.Given(t, aggregate, events ...interface{}) *TestFixture` — seed the aggregate with prior events.
+- `(*TestFixture).When(func() error) *TestFixture` — execute the command under test.
+- `(*TestFixture).Then(expectedEvents ...interface{})` — assert the emitted uncommitted events.
+- `(*TestFixture).ThenError(err error)` — assert the command returned the expected error.
+- `mink.AggregateBase` — embedded base providing `SetID`, `SetType`, `Apply`, `IncrementVersion`, `UncommittedEvents`, `ClearUncommittedEvents`.
+- `ApplyEvent(event interface{}) error` — the aggregate method that folds events into state.
+
+## Related
+- **Examples:** [full-ecommerce](../full-ecommerce) · [basic](../basic) · [cqrs-postgres](../cqrs-postgres)
+- **Docs:** [Testing](https://go-mink.dev/docs/guide/testing) · [API reference](https://pkg.go.dev/go-mink.dev/testing/bdd)

--- a/examples/cqrs-postgres/README.md
+++ b/examples/cqrs-postgres/README.md
@@ -1,0 +1,53 @@
+# CQRS with PostgreSQL Example
+
+> The same CQRS order domain as [cqrs](../cqrs), but persisted durably to PostgreSQL.
+
+This example swaps the in-memory adapters for their PostgreSQL counterparts, showing how the exact same commands, handlers, and middleware pipeline run unchanged against a real database. The payoff is durability: both the event store and the idempotency store survive process restarts, so replayed commands stay deduplicated and event history is permanent.
+
+## What this demonstrates
+- **PostgreSQL event store** — `postgres.NewAdapter` creates a durable `EventStoreAdapter`; `Initialize` auto-creates the schema and tables.
+- **PostgreSQL idempotency store** — `postgres.NewIdempotencyStore` persists command keys so duplicate detection outlives restarts.
+- **Custom schema** — `postgres.WithSchema` and `postgres.WithIdempotencySchema` place everything under a dedicated `mink_example` schema.
+- **Unchanged domain layer** — the `Order` aggregate, commands, and full eight-middleware pipeline are identical to the in-memory `cqrs` example; only the adapters differ.
+- **Durable idempotency & metadata** — the idempotency test and correlation-ID tracking are demonstrated end-to-end against Postgres.
+
+## Running
+```bash
+# From the repo root: start PostgreSQL
+docker compose -f docker-compose.test.yml up -d --wait
+
+go run ./examples/cqrs-postgres
+
+# Stop PostgreSQL when done
+docker compose -f docker-compose.test.yml down
+```
+
+Requires PostgreSQL. The example reads `TEST_DATABASE_URL` and falls back to the default DSN `postgres://postgres:postgres@localhost:5432/mink_test?sslmode=disable`. Tables are created automatically under the `mink_example` schema on first run.
+
+## What happens
+The program runs ten numbered steps:
+
+1. **Initialize adapters** — creates and `Initialize`s the PostgreSQL event store adapter and the idempotency store.
+2. **Create event store** — wraps the adapter with `mink.New` and registers the event types.
+3. **Set up the command bus** — builds the handler registry and command bus with eight middlewares (recovery, logging, metrics, correlation, causation, validation, PostgreSQL-backed idempotency, and a 30-second timeout).
+4. **Execute commands** — dispatches `CreateOrderCommand`, then three `AddItemCommand`s (laptop, mouse, USB hub), printing the version after each.
+5. **Idempotency (PostgreSQL)** — dispatches a fixed-ID command (`cmd-idempotent-postgres-test`) twice and shows the duplicate returns the result stored in Postgres.
+6. **Validation** — dispatches an invalid `AddItemCommand` and prints the field errors from the `*mink.MultiValidationError`.
+7. **Ship the order** — dispatches `ShipOrderCommand` with tracking number `TRACK-PG-12345`.
+8. **Load final state** — reloads the order from PostgreSQL with `LoadAggregate` and prints the full order.
+9. **Event stream** — reads events via `LoadRaw` and prints each version, type, and correlation ID.
+10. **Metrics summary** — prints per-command statistics, followed by a recap of the key points demonstrated.
+
+## Key APIs
+- `postgres.NewAdapter(connStr, postgres.WithSchema("mink_example"))` — durable PostgreSQL `EventStoreAdapter`.
+- `eventAdapter.Initialize(ctx)` — creates the event store schema/tables.
+- `postgres.NewIdempotencyStore(db, postgres.WithIdempotencySchema(...), postgres.WithIdempotencyTable(...))` — PostgreSQL-backed idempotency store.
+- `idempotencyStore.Initialize(ctx)` — creates the idempotency table.
+- `mink.New(eventAdapter)` — event store over the PostgreSQL adapter.
+- `mink.NewCommandBus`, `mink.NewHandlerRegistry`, `mink.RegisterGenericHandler`, `mink.NewAggregateHandler` with `mink.AggregateHandlerConfig` — same command/handler wiring as the `cqrs` example.
+- `mink.IdempotencyMiddleware` + `mink.IdempotencyConfig` + `mink.GenerateIdempotencyKey` — configured here with the PostgreSQL store.
+- `bus.Dispatch(ctx, cmd)`, `store.LoadAggregate`, `store.LoadRaw` — dispatch commands and read back state/events.
+
+## Related
+- **Examples:** [cqrs](../cqrs) · [basic](../basic) · [full-ecommerce](../full-ecommerce)
+- **Docs:** [Adapters](https://go-mink.dev/docs/core/adapters) · [API reference](https://pkg.go.dev/go-mink.dev/adapters/postgres)

--- a/examples/cqrs/README.md
+++ b/examples/cqrs/README.md
@@ -1,0 +1,48 @@
+# CQRS & Command Bus Example
+
+> Dispatch commands through a full middleware pipeline into type-safe handlers backed by the event store.
+
+This example layers CQRS on top of the basic event-sourced `Order`: instead of calling aggregate methods directly, callers send commands (`CreateOrderCommand`, `AddItemCommand`, `ShipOrderCommand`) through a `CommandBus`. The bus threads every command through a middleware pipeline — recovery, logging, metrics, correlation/causation tracking, validation, idempotency, and timeout — which is how you get cross-cutting concerns without cluttering domain logic.
+
+## What this demonstrates
+- **Commands and validation** — each command embeds `mink.CommandBase` and implements `Validate()`, using `mink.NewValidationError` and `mink.NewMultiValidationError` to report field-level problems.
+- **Two handler styles** — `mink.RegisterGenericHandler` handles `CreateOrder` (which mints a new aggregate), while `mink.NewAggregateHandler` with `AggregateHandlerConfig` wires `AddItem` and `ShipOrder` to load, mutate, and save an existing `Order`.
+- **Middleware pipeline** — `mink.NewCommandBus` composes eight middlewares via `WithMiddleware`, applied in order to every dispatch.
+- **Idempotency** — `IdempotencyMiddleware` (backed by `memory.NewIdempotencyStore`) returns a cached result when the same `CommandID` is dispatched twice.
+- **Correlation & causation** — commands carry `CorrelationID`/`CausationID` in `CommandBase`, which the middleware stamps onto stored event metadata for traceability.
+- **Metrics** — a custom `SimpleMetrics` (implementing `mink.MetricsCollector`) tallies command counts and success/failure per type.
+
+## Running
+```bash
+go run ./examples/cqrs
+```
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+The program runs eight numbered scenarios:
+
+1. **Create an order** — dispatches `CreateOrderCommand` (command `cmd-001`, correlation `request-123`); the generic handler generates an order ID, saves the aggregate, and returns a `CommandResult` with the new ID and version.
+2. **Add items** — dispatches two `AddItemCommand`s through the aggregate handler, each carrying a `CausationID` linking it to the previous command, and prints the resulting version.
+3. **Validation** — dispatches an invalid `AddItemCommand` (empty SKU, negative quantity); the validation middleware rejects it and the example prints each field error from the `*mink.MultiValidationError`.
+4. **Idempotency** — dispatches the same command (`cmd-idempotent-001`) twice and shows the duplicate returns the cached result rather than re-executing.
+5. **Ship the order** — dispatches `ShipOrderCommand` with a tracking number and prints the new version.
+6. **Load final state** — reloads the `Order` with `LoadAggregate` and prints customer, status, tracking, items, total, and version.
+7. **Event stream with metadata** — reads events via `LoadRaw` and prints each event's version, type, and any `CorrelationID`/`CausationID` from its metadata.
+8. **Metrics** — prints the collected per-command statistics.
+
+## Key APIs
+- `mink.NewCommandBus(mink.WithHandlerRegistry(...), mink.WithMiddleware(...))` — builds the command bus.
+- `mink.NewHandlerRegistry()` — registry that maps command types to handlers.
+- `mink.RegisterGenericHandler(registry, fn)` — registers a function handler returning `(mink.CommandResult, error)`.
+- `mink.NewAggregateHandler(mink.AggregateHandlerConfig[Cmd, *Agg]{...})` — load/mutate/save handler for aggregate commands.
+- `mink.CommandBase` — embeddable fields (`CommandID`, `CorrelationID`, `CausationID`) for commands.
+- `bus.Dispatch(ctx, cmd)` — runs a command through the pipeline and returns a `CommandResult`.
+- `mink.NewSuccessResult(id, version)` / `mink.NewErrorResult(err)` — construct command results.
+- Middleware: `mink.RecoveryMiddleware`, `mink.NewLoggingMiddleware(logger).Middleware()`, `mink.MetricsMiddleware`, `mink.CorrelationIDMiddleware`, `mink.CausationIDMiddleware`, `mink.ValidationMiddleware`, `mink.IdempotencyMiddleware`, `mink.TimeoutMiddleware`.
+- `mink.IdempotencyConfig` + `mink.GenerateIdempotencyKey` — configure duplicate detection; `memory.NewIdempotencyStore()` backs it.
+- `mink.NewValidationError` / `mink.NewMultiValidationError` / `*mink.MultiValidationError` — validation error types.
+- `mink.Logger` / `mink.MetricsCollector` — interfaces implemented by the example's `SimpleLogger` and `SimpleMetrics`.
+
+## Related
+- **Examples:** [basic](../basic) · [cqrs-postgres](../cqrs-postgres) · [full-ecommerce](../full-ecommerce)
+- **Docs:** [Advanced Patterns](https://go-mink.dev/docs/advanced/advanced-patterns) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/encryption/README.md
+++ b/examples/encryption/README.md
@@ -1,0 +1,41 @@
+# Field-Level Encryption Example
+
+> Encrypt PII at rest, decrypt transparently on load, and crypto-shred per tenant for GDPR erasure.
+
+Event stores keep every change forever, so any PII written today lives in your history indefinitely — that is a compliance liability unless it is protected. go-mink encrypts individual event fields (email, phone) with envelope encryption while leaving other fields (name, country) as plaintext so they stay queryable. Because each tenant has its own key, revoking a key permanently destroys that tenant's data — satisfying the GDPR "right to erasure" without rewriting immutable events.
+
+## What this demonstrates
+- **Field-level encryption** — `WithEncryptedFields("CustomerCreated", "email", "phone")` encrypts only the named fields; `name` and `country` remain plaintext and queryable.
+- **Transparent decryption** — `LoadAggregate` / `Load` decrypt automatically, so domain code never sees ciphertext.
+- **Per-tenant keys** — `WithTenantKeyResolver` maps each event's `Metadata.TenantID` to a key ID, isolating tenants cryptographically.
+- **Crypto-shredding** — `provider.RevokeKey("tenant-B")` makes that tenant's data permanently unrecoverable (GDPR right to erasure), while other tenants stay readable.
+- **Graceful degradation** — `WithDecryptionErrorHandler` catches `encryption.ErrKeyRevoked` and returns the still-encrypted payload instead of failing the load.
+
+## Running
+```bash
+go run ./examples/encryption
+```
+No infrastructure required — encryption keys and the event store are in-memory (`local.New` + `memory.NewAdapter`).
+
+## What happens
+1. Two random 32-byte keys are generated and registered with a `local` provider as `tenant-A` and `tenant-B`. A `FieldEncryptionConfig` marks `email` and `phone` on `CustomerCreated` as encrypted.
+2. **Encrypt on save, decrypt on load** — a customer is saved with the tenant-A key. `LoadRaw` prints the ciphertext at rest plus the encrypted-field list and key ID from metadata, then `LoadAggregate` prints the fully decrypted name, email, and phone.
+3. **Per-tenant keys** — a second customer is appended with `Metadata{TenantID: "B"}`. The resolver picks `tenant-B`; the printed key ID confirms it, and `Load` returns the decrypted email.
+4. **Crypto-shredding** — `provider.RevokeKey("tenant-B")` is called. Reloading tenant B's event triggers the decryption-error handler, which prints `[SHREDDED]` and leaves the email encrypted.
+5. **Isolation** — tenant A's customer is loaded one last time and still decrypts normally, proving revocation only affected tenant B.
+
+## Key APIs
+- `mink.NewFieldEncryptionConfig(...)` — build the encryption config from options.
+- `mink.WithEncryptionProvider(provider)` — supply the key provider that performs envelope encryption.
+- `mink.WithDefaultKeyID("tenant-A")` — key used when no tenant-specific key is resolved.
+- `mink.WithEncryptedFields(eventType, fields...)` — declare which fields on an event type are encrypted.
+- `mink.WithTenantKeyResolver(func(tenantID) string)` — derive a key ID from each event's tenant.
+- `mink.WithDecryptionErrorHandler(func(err, eventType, metadata) error)` — decide what happens when decryption fails (e.g. after key revocation).
+- `mink.WithFieldEncryption(encConfig)` — attach the config to the event store via `mink.New`.
+- `mink.GetEncryptedFields(metadata)` / `mink.GetEncryptionKeyID(metadata)` — read encryption metadata off a stored event.
+- `local.New(local.WithKey(...))` — in-memory AES-256-GCM provider; returns `(*Provider, error)`.
+- `provider.RevokeKey(keyID)` — crypto-shred: destroy a key so its data can no longer be decrypted.
+
+## Related
+- **Examples:** [export](../export) · [full-ecommerce](../full-ecommerce)
+- **Docs:** [Security](https://go-mink.dev/docs/advanced/security) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/export/README.md
+++ b/examples/export/README.md
@@ -1,0 +1,41 @@
+# GDPR Data Export Example
+
+> Export every event belonging to a data subject — the GDPR right to access (Art. 15) and data portability (Art. 20).
+
+When a user invokes their GDPR rights, you must produce a complete, portable copy of the data you hold on them. In an event-sourced system that data is spread across many streams, so go-mink's `DataExporter` gathers it by explicit stream ID or by scanning with filters, decrypts protected fields, and returns a structured result. It also handles the awkward case where a key was already crypto-shredded: those events come back marked `Redacted` rather than crashing the export.
+
+## What this demonstrates
+- **Stream-based export** — pass known stream IDs in `ExportRequest.Streams` for an efficient, scan-free export.
+- **Scan-based export with filters** — `FilterByTenantID`, `FilterByEventTypes`, `FilterByStreamPrefix`, `FilterByUserID`, and `CombineFilters` select a subject's events when you don't know the stream IDs.
+- **Streaming export** — `ExportStream` invokes a callback per event so large exports never materialize the whole result in memory.
+- **Time-range filtering** — `FromTime` / `ToTime` scope an export to a date window.
+- **Crypto-shredding + export** — after `provider.RevokeKey`, encrypted events export as `Redacted` (nil `Data`, `RedactedCount` incremented) instead of failing.
+
+## Running
+```bash
+go run ./examples/export
+```
+No infrastructure required — encryption keys and the event store are in-memory (`local.New` + `memory.NewAdapter`).
+
+## What happens
+The example seeds five events across two tenants (Alice under tenant A, Bob under tenant B), with `email`/`phone` encrypted, then runs five demos:
+
+1. **Stream-based export** — Alice's three known streams are exported by ID. It prints the subject, total event count, stream list, export timestamp, and each decrypted event.
+2. **Scan-based export** — `Export` scans all events with filters and prints counts for: all tenant-A events, tenant-A `OrderPlaced` events (via `CombineFilters`), all `Customer-` streams (via `FilterByStreamPrefix`), and everything for user `alice-1` (via `FilterByUserID`).
+3. **Streaming export** — `ExportStream` walks two of Alice's streams, printing one line per streamed event and the final count.
+4. **Time-range export** — one export limited to the last hour (`FromTime`) and one limited to events before a future cutoff (`ToTime`), printing each matching count.
+5. **Crypto-shredding + export** — Bob's data exports cleanly first; then `provider.RevokeKey("tenant-B")` is called and the re-export reports the encrypted `CustomerCreated` as `[REDACTED]` while the unencrypted `OrderPlaced` still exports as `[OK]`.
+
+## Key APIs
+- `mink.NewDataExporter(store, opts...)` — construct an exporter over an event store.
+- `mink.WithExportBatchSize(n)` — events loaded per batch during scan-based export (default 1000).
+- `mink.ExportRequest{...}` — describes the export: `SubjectID`, `Streams`, `Filter`, `FromTime`, `ToTime`.
+- `exporter.Export(ctx, req)` — returns an `*ExportResult` with `Events`, `Streams`, `TotalEvents`, `RedactedCount`, and `ExportedAt`.
+- `exporter.ExportStream(ctx, req, handler)` — memory-efficient export invoking `handler` per `ExportedEvent`.
+- `mink.FilterByTenantID(id)` / `mink.FilterByEventTypes(types...)` / `mink.FilterByStreamPrefix(prefix)` / `mink.FilterByUserID(id)` — built-in export filters.
+- `mink.CombineFilters(filters...)` — AND-compose multiple filters.
+- `provider.RevokeKey(keyID)` — crypto-shred a tenant's key; subsequent exports redact its encrypted events.
+
+## Related
+- **Examples:** [encryption](../encryption) · [full-ecommerce](../full-ecommerce)
+- **Docs:** [Security](https://go-mink.dev/docs/security) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/full-ecommerce/README.md
+++ b/examples/full-ecommerce/README.md
@@ -45,7 +45,7 @@ This comprehensive example demonstrates all major go-mink features working toget
 
 ## Prerequisites
 
-- Go 1.21+
+- Go 1.25+
 - PostgreSQL 16+ running locally
 - Database credentials: `postgres:postgres@localhost:5432/mink_test`
 

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -1,0 +1,43 @@
+# Prometheus Metrics Example
+
+> Instrument a go-mink event store with Prometheus metrics for observability.
+
+Production event-sourcing systems need visibility into throughput, latency, and error rates. This example wires the go-mink metrics middleware into an event store, exercises it with simulated user traffic, and exposes a live Prometheus scrape endpoint so you can watch the counters and histograms fill up.
+
+## What this demonstrates
+- **Metrics instance** — `minkmetrics.New(...)` builds a `*Metrics` configured with `WithNamespace("mink_example")` and `WithMetricsServiceName("user-service")`, which prefix and label every metric.
+- **Prometheus registration** — `MustRegister()` registers the collectors with the default Prometheus registry so they can be gathered and scraped.
+- **Command middleware** — `CommandMiddleware()` returns a `mink.Middleware` you plug into a command bus to record per-command counts, statuses, and durations.
+- **Live scrape endpoint** — a background HTTP server serves `promhttp.Handler()` at `:9090/metrics` for Prometheus to poll.
+- **Simulated workload** — appends registration, login, and profile-update events against the in-memory store to generate realistic metric activity.
+
+## Running
+```bash
+go run ./examples/metrics
+```
+No infrastructure required — uses the in-memory adapter.
+
+This example starts an HTTP server on `:9090/metrics` and then runs until you press Ctrl+C.
+
+## What happens
+1. Creates a `memory.NewAdapter()` event store and a metrics instance (`namespace=mink_example`, `service=user-service`), then calls `MustRegister()`.
+2. Launches the Prometheus HTTP server in a goroutine at `http://localhost:9090/metrics`.
+3. Registers 5 users (`user-001` … `user-005`) by appending a `UserRegistered` event per stream, printing each with its append latency in milliseconds.
+4. Simulates 20 logins — loads a random user's stream, then appends a `UserLoggedIn` event.
+5. Simulates 10 profile updates by appending `ProfileUpdated` events to random user streams.
+6. Prints a metrics summary showing sample metric names, the final per-stream event counts, and the list of registered `mink`-prefixed metrics gathered from Prometheus.
+7. Prints observability tips and keeps the `/metrics` endpoint alive until Ctrl+C.
+
+## Key APIs
+- `minkmetrics.New(opts ...MetricsOption) *Metrics` — construct the metrics collector set.
+- `minkmetrics.WithNamespace(string)` — set the metric name prefix (e.g. `mink_example_...`).
+- `minkmetrics.WithMetricsServiceName(string)` — set the `service` label on all metrics.
+- `(*Metrics).MustRegister()` — register the collectors with the default Prometheus registry.
+- `(*Metrics).CommandMiddleware() mink.Middleware` — middleware to instrument command dispatch.
+- `mink.New(adapter)` — create the event store over the memory adapter.
+- `store.Append(ctx, streamID, events, ...)` / `store.Load(ctx, streamID)` — the operations being measured.
+- `promhttp.Handler()` — Prometheus HTTP handler exposed at `:9090/metrics`.
+
+## Related
+- **Examples:** [tracing](../tracing) · [full-ecommerce](../full-ecommerce) · [basic](../basic)
+- **Docs:** [Advanced Patterns](https://go-mink.dev/docs/advanced/advanced-patterns) · [API reference](https://pkg.go.dev/go-mink.dev/middleware/metrics)

--- a/examples/msgpack/README.md
+++ b/examples/msgpack/README.md
@@ -1,0 +1,46 @@
+# MessagePack Serializer Example
+
+> Store events as compact MessagePack binaries instead of JSON.
+
+By default go-mink serializes events to JSON, which is human-readable but larger and slower to encode. Swapping in the MessagePack serializer yields smaller payloads and faster serialization — valuable for high-throughput or storage-sensitive systems. This example compares the two formats side by side, then wires MessagePack into a real `EventStore`.
+
+## What this demonstrates
+
+- **Pluggable serialization** — `msgpack.NewSerializer()` produces a serializer that drops into an `EventStore` via `mink.WithSerializer(...)`, no other code changes.
+- **Payload size savings** — the same `ProductCreated` and a larger array/map-heavy `LargeEvent` are serialized with both JSON and MessagePack, printing byte counts and the percentage saved.
+- **Typed deserialization** — event types are registered with `msgpackSerializer.Register(...)`, so `Deserialize` returns the concrete `ProductCreated` struct rather than a generic map.
+- **Speed benchmark** — 10,000 serialization iterations per format, reporting duration, ops/sec, and the speedup factor.
+- **Event store integration** — three events are appended and reloaded through a store backed by the MessagePack serializer.
+
+## Running
+
+```bash
+go run ./examples/msgpack
+```
+
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+
+1. **Set up serializers** — a JSON serializer (`mink.NewJSONSerializer()`) and a MessagePack serializer are created; the four event types (`ProductCreated`, `ProductPriceChanged`, `ProductInventoryUpdated`, `LargeEvent`) are registered with the MessagePack serializer.
+2. **Compare a typical event** — a `ProductCreated` is serialized both ways; JSON and MessagePack byte sizes and the savings percentage are printed.
+3. **Compare a large event** — a `LargeEvent` with a 1000-byte blob, a map, a 100-element int slice, and nested data repeats the comparison.
+4. **Deserialization test** — the JSON bytes deserialize to a `map[string]interface{}` (type not registered) while the MessagePack bytes deserialize to a concrete `ProductCreated`; both print the recovered ProductID.
+5. **Speed benchmark** — each format serializes the event 10,000 times; durations, ops/sec, and the MessagePack speedup are reported.
+6. **Store and load** — a store built with `mink.WithSerializer(msgpackSerializer)` appends three events with `mink.ExpectVersion(mink.NoStream)`, then loads them back and prints each event's type and version.
+7. **Guidance** — the program closes with notes on when to prefer MessagePack versus JSON.
+
+## Key APIs
+
+- `msgpack.NewSerializer()` — creates a MessagePack-backed `Serializer`.
+- `msgpackSerializer.Register("ProductCreated", ProductCreated{})` — registers an event type for typed deserialization.
+- `serializer.Serialize(event)` / `serializer.Deserialize(data, "ProductCreated")` — encode and decode event payloads.
+- `mink.NewJSONSerializer()` — the default JSON serializer, used here as the comparison baseline.
+- `mink.WithSerializer(msgpackSerializer)` — option that sets the store's serializer.
+- `mink.ExpectVersion(mink.NoStream)` — optimistic-concurrency option asserting the stream does not yet exist.
+- `store.Append(...)` / `store.Load(...)` — persist and read events from the store.
+
+## Related
+
+- **Examples:** [protobuf](../protobuf) · [full-ecommerce](../full-ecommerce) · [basic](../basic)
+- **Docs:** [Event Store](https://go-mink.dev/docs/core/event-store) · [API reference](https://pkg.go.dev/go-mink.dev/serializer/msgpack)

--- a/examples/projections/README.md
+++ b/examples/projections/README.md
@@ -1,0 +1,54 @@
+# Projections & Read Models Example
+
+> Build queryable read models from events using inline (synchronous) and live (real-time) projections.
+
+Event sourcing stores the *history* of changes, but applications usually need to *query* current state. This example shows how the projection engine turns an event stream into read models: an inline projection that updates a queryable `OrderSummary` synchronously (strong consistency), and a live projection that pushes real-time updates to a dashboard channel.
+
+## What this demonstrates
+
+- **Inline projections** — `OrderSummaryProjection` embeds `mink.ProjectionBase` and implements `Apply`, folding `OrderCreated`, `ItemAdded`, and `OrderShipped` into an `OrderSummary` read model synchronously via `engine.ProcessInlineProjections`.
+- **Live projections** — `OrderDashboardProjection` embeds `mink.LiveProjectionBase` and implements `OnEvent`, emitting human-readable updates on a channel as events are notified via `engine.NotifyLiveProjections`.
+- **Read model repository** — `mink.NewInMemoryRepository` stores `OrderSummary` documents keyed by `OrderID`, with `Insert`/`Update` from the projection and `Get`/`Find`/`Count` for queries.
+- **Checkpoints** — `memory.NewCheckpointStore` tracks projection progress, wired into the engine with `mink.WithCheckpointStore`.
+- **Projection status** — `engine.GetAllStatuses` reports each projection's `Name` and `State`.
+
+## Running
+
+```bash
+go run ./examples/projections
+```
+
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+
+1. An in-memory `EventStore`, an `OrderSummary` repository, a checkpoint store, and a `ProjectionEngine` are created, then the engine is started. Both projections (`OrderSummary` inline, `OrderDashboard` live) are registered.
+2. **Order 1 created** — `OrderCreated` is appended (`Order-001`), reloaded with `store.LoadRaw`, and fed to `ProcessInlineProjections` + `NotifyLiveProjections`. The dashboard prints a `📦 New order` line.
+3. **Items added to Order 1** — two `ItemAdded` events are appended and processed inline, incrementing `ItemCount` and `TotalAmount` on the summary.
+4. **Order 2 created** — a second `OrderCreated` (`Order-002`) is appended and projected; the dashboard announces it.
+5. **Order 1 shipped** — `OrderShipped` is appended; the inline projection flips `Status` to `Shipped` and the dashboard prints a `🚚 Order ... shipped` line.
+6. **Query read model** — `orderRepo.Get` prints both order summaries, showing item counts, totals, and shipped status.
+7. **Query builder** — `orderRepo.Find(ctx, mink.Query{})` and `orderRepo.Count(ctx, mink.Query{})` report the total number of orders.
+8. **Projection status** — `engine.GetAllStatuses` prints the name and state of each registered projection, then the demo exits.
+
+## Key APIs
+
+- `mink.New(adapter)` — create the `EventStore` over the memory adapter.
+- `mink.NewProjectionEngine(store, mink.WithCheckpointStore(...))` — the engine that drives projections.
+- `engine.RegisterInline` / `engine.RegisterLive` — register synchronous and real-time projections.
+- `engine.Start` / `engine.Stop` — start and shut down the engine.
+- `engine.ProcessInlineProjections` — synchronously apply a batch of events to inline projections.
+- `engine.NotifyLiveProjections` — push a batch of events to live projections.
+- `engine.GetAllStatuses` — retrieve `[]*mink.ProjectionStatus` (name, state, lag).
+- `mink.ProjectionBase` / `mink.NewProjectionBase` — base for an inline projection; `Apply(ctx, mink.StoredEvent)` handles events.
+- `mink.LiveProjectionBase` / `mink.NewLiveProjectionBase` — base for a live projection; `OnEvent(ctx, mink.StoredEvent)` reacts in real time.
+- `mink.NewInMemoryRepository` — generic read model store with `Insert`, `Update`, `Get`, `Find`, `Count`.
+- `mink.Query` — the query value passed to `Find`/`Count`.
+- `memory.NewCheckpointStore` — in-memory checkpoint tracking.
+- `store.Append` / `store.LoadRaw` — append events and load them back as raw `StoredEvent`s.
+- `mink.ExpectVersion(mink.NoStream)` — optimistic-concurrency expected-version option.
+
+## Related
+
+- **Examples:** [full-ecommerce](../full-ecommerce) · [sagas](../sagas) · [cqrs-postgres](../cqrs-postgres) · [basic](../basic)
+- **Docs:** [Read Models](https://go-mink.dev/docs/core/read-models) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/protobuf/README.md
+++ b/examples/protobuf/README.md
@@ -1,0 +1,45 @@
+# Protocol Buffers Serializer Example
+
+> Serialize events as compact, strongly-typed Protocol Buffers.
+
+Protocol Buffers give you the smallest binary payloads of go-mink's built-in serializers, plus schema-enforced typing and field-numbered forward/backward compatibility. This example uses the protobuf well-known wrapper types (`wrapperspb`, `timestamppb`) as stand-in events across four demos, from basic round-tripping to building a projection.
+
+## What this demonstrates
+
+- **Strongly-typed serialization** — `protobuf.NewSerializer()` with `s.MustRegister(...)` binds event type names to protobuf message types; in production you would register your own `.proto`-generated types.
+- **Round-tripping well-known types** — string, int32, double, bool, and timestamp wrappers are serialized, sized, and deserialized back to their values.
+- **Direct adapter integration** — pre-serialized payloads are appended as `adapters.EventRecord`s straight to the memory adapter and loaded back for deserialization.
+- **Size comparison vs JSON** — a table pits protobuf byte sizes against `mink.NewJSONSerializer()` across seven data types, with per-row and total savings.
+- **Projection building** — a stream of protobuf events is folded into an `OrderSummary` read model by type-switching on each deserialized message.
+
+## Running
+
+```bash
+go run ./examples/protobuf
+```
+
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+
+1. **Basic serialization** — a serializer registers five wrapper types (`OrderID`, `ItemCount`, `TotalAmount`, `IsShipped`, `Timestamp`), then serializes one event of each, printing its byte size and the value recovered by `Deserialize`.
+2. **Event store integration** — five `adapters.EventRecord`s (customer ID, two item-added events, order total, shipped flag) are appended to stream `order-12345` via `adapter.Append(ctx, streamID, events, mink.NoStream)`, then reloaded with `adapter.Load` and deserialized one by one.
+3. **Size comparison** — a formatted table serializes seven values (small/large strings, integers, double, boolean, binary) with both JSON and protobuf, printing each row's sizes and savings plus a total row.
+4. **Projection building** — five protobuf events are deserialized and folded into an `OrderSummary` (customer ID, item batches, total items, complete flag); the final projection state is printed.
+5. The program prints a success line once all four demos complete.
+
+## Key APIs
+
+- `protobuf.NewSerializer()` — creates a Protocol Buffers `Serializer`.
+- `s.MustRegister("OrderID", &wrapperspb.StringValue{})` — registers an event type to a protobuf message type, panicking on error.
+- `serializer.Serialize(event)` / `serializer.Deserialize(data, typ)` — encode and decode protobuf payloads (Deserialize returns the message by value).
+- `adapters.EventRecord` — the pre-serialized event record (`Type` + `Data`) appended directly to an adapter.
+- `adapter.Append(ctx, streamID, events, mink.NoStream)` / `adapter.Load(ctx, streamID, 0)` — low-level append and load on the memory adapter.
+- `mink.NoStream` — expected-version constant asserting the stream does not yet exist.
+- `mink.NewJSONSerializer()` — the JSON serializer used as the size-comparison baseline.
+- `wrapperspb` / `timestamppb` — protobuf well-known types used as stand-in events.
+
+## Related
+
+- **Examples:** [msgpack](../msgpack) · [full-ecommerce](../full-ecommerce) · [projections](../projections)
+- **Docs:** [Event Store](https://go-mink.dev/docs/core/event-store) · [API reference](https://pkg.go.dev/go-mink.dev/serializer/protobuf)

--- a/examples/sagas/README.md
+++ b/examples/sagas/README.md
@@ -1,0 +1,48 @@
+# Saga (Process Manager) Example
+
+> Coordinate a long-running, multi-step business process with automatic compensation on failure.
+
+A saga (process manager) reacts to events and issues the next commands, driving a workflow that spans multiple aggregates. This example implements an `OrderFulfillmentSaga` that orchestrates payment → inventory → shipment, tracks its state across steps, and — when a step fails — emits compensating commands to undo the work already done.
+
+## What this demonstrates
+
+- **Event-driven orchestration** — `OrderFulfillmentSaga.HandleEvent` receives each `mink.StoredEvent` and returns the `[]mink.Command`s to run next (e.g. `OrderPlaced` → `ProcessPaymentCommand`).
+- **Explicit state machine** — the saga advances through `SagaState` values (`Started`, `PaymentPending`, `InventoryPending`, `ShipmentPending`, `Completed`, `Cancelled`, `Compensating`) as events arrive.
+- **Happy path** — `OrderPlaced` → `PaymentProcessed` → `InventoryReserved` → `ShipmentCreated` walks the saga to `Completed`, generating one command per step.
+- **Compensation** — when `InventoryReservationFailed` arrives after payment, the saga moves to `Compensating` and emits `RefundPaymentCommand` + `CancelOrderCommand` to roll back.
+- **Completion check** — `IsComplete` reports whether the saga reached a terminal state (`Completed` or `Cancelled`).
+- **Event persistence** — the same events are appended to and reloaded from an in-memory `EventStore`.
+
+## Running
+
+```bash
+go run ./examples/sagas
+```
+
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+
+1. An in-memory `EventStore` and a fresh `OrderFulfillmentSaga` are created.
+2. **Happy path** — four events (`OrderPlaced`, `PaymentProcessed`, `InventoryReserved`, `ShipmentCreated`) are fed one at a time to `saga.HandleEvent`. Each prints a progress line (`📦 Order placed…`, `💳 Payment received…`, `📦 Inventory reserved…`, `✅ Shipment created…`) and returns the next command.
+3. The saga state is printed: order ID, final `State` (`Completed`), the `PaymentProcessed`/`InventoryReserved`/`ShipmentCreated` flags, and `IsComplete` (`true`).
+4. The generated commands are listed: `ProcessPayment`, `ReserveInventory`, `CreateShipment`, `CompleteOrder`.
+5. **Failure path** — a second saga processes `OrderPlaced`, `PaymentProcessed`, then `InventoryReservationFailed`. It prints `⚠️ compensating…`, sets `State` to `Compensating`, and returns the compensation commands.
+6. The failed saga's state is printed, followed by its compensation commands: `RefundPayment` and `CancelOrder`.
+7. **Event store** — the happy-path events are appended to stream `saga-order-001` with `store.Append`, then reloaded with `store.Load`; the count of stored events is printed and the demo exits.
+
+## Key APIs
+
+- `mink.New(adapter)` — create the `EventStore` over the memory adapter.
+- `mink.StoredEvent` — the stored event value passed into the saga's `HandleEvent`.
+- `mink.Command` — interface for commands returned by the saga; each defines `CommandType()`.
+- `mink.CommandBase` — embedded base for the concrete commands (`ProcessPaymentCommand`, `ReserveInventoryCommand`, `CreateShipmentCommand`, `CompleteOrderCommand`, `CancelOrderCommand`, `RefundPaymentCommand`).
+- `store.Append` — persist events to a stream (with `mink.ExpectVersion(mink.NoStream)`).
+- `store.Load` — read events back from a stream.
+
+> Note: this example runs the saga logic directly to keep the workflow readable — it collects the commands each step returns rather than dispatching them through a command bus. See [full-ecommerce](../full-ecommerce) for a saga wired into an end-to-end pipeline.
+
+## Related
+
+- **Examples:** [full-ecommerce](../full-ecommerce) · [projections](../projections) · [cqrs-postgres](../cqrs-postgres) · [basic](../basic)
+- **Docs:** [Advanced Patterns](https://go-mink.dev/docs/advanced/advanced-patterns) · [API reference](https://pkg.go.dev/go-mink.dev)

--- a/examples/tracing/README.md
+++ b/examples/tracing/README.md
@@ -1,0 +1,44 @@
+# Distributed Tracing Example
+
+> Instrument a go-mink event store with OpenTelemetry spans for end-to-end tracing.
+
+Distributed tracing ties a single business operation together across every step it touches, so you can see where time is spent and where failures originate. This example traces an order-creation workflow — one root span with a child span per event-store operation — and exports the spans to stdout via the OpenTelemetry stdout exporter.
+
+## What this demonstrates
+- **OTel tracer provider** — `initTracer()` builds an `sdktrace.NewTracerProvider` with a `stdouttrace` exporter and a service-named resource, registered globally via `otel.SetTracerProvider`.
+- **go-mink tracer** — `minktracing.NewTracer(...)` with `WithTracerProvider(tp)` and `WithServiceName("order-service")` constructs the middleware tracer.
+- **Command middleware** — `minktracing.CommandMiddleware(tracer)` returns a `mink.Middleware` (a package-level function taking the tracer) to auto-span command dispatch.
+- **Manual spans** — a root `CreateOrderWorkflow` span wraps child spans (`EventStore.CreateOrder`, `EventStore.AddOrderItem`, `EventStore.SubmitOrder`), each carrying attributes and recording errors.
+- **Stdout export** — spans print as pretty JSON so you can inspect them without external infrastructure.
+
+## Running
+```bash
+go run ./examples/tracing
+```
+No infrastructure required — uses the in-memory adapter.
+
+The stdout exporter is for the demo only. In production, swap it for a Jaeger, Zipkin, or Datadog exporter to visualize traces.
+
+## What happens
+1. Initializes OpenTelemetry with a pretty-printing stdout exporter and an `order-service` resource, then defers `tp.Shutdown`.
+2. Creates a `memory.NewAdapter()` event store and a `minktracing` tracer.
+3. Starts a root span `CreateOrderWorkflow` with `order.id` and `customer.id` attributes.
+4. Appends `OrderCreated` for `ORD-12345` inside an `EventStore.CreateOrder` child span.
+5. Adds three items (`WIDGET-001`, `GADGET-002`, `THING-003`) — each an `OrderItemAdded` event under an `EventStore.AddOrderItem` span with SKU/quantity/price attributes.
+6. Appends `OrderSubmitted` inside an `EventStore.SubmitOrder` span, then loads the stream to record `events.total` on the span.
+7. Ends the root span. The batched spans flush to stdout as JSON.
+8. Loads and prints the order's event history (type + version per event) and trace-inspection tips.
+
+## Key APIs
+- `minktracing.NewTracer(opts ...TracerOption) *Tracer` — construct the middleware tracer.
+- `minktracing.WithTracerProvider(trace.TracerProvider)` — supply the OTel tracer provider.
+- `minktracing.WithServiceName(string)` — set the service name on emitted spans.
+- `minktracing.CommandMiddleware(tracer *Tracer) mink.Middleware` — middleware to span command dispatch.
+- `mink.New(adapter)` — create the event store over the memory adapter.
+- `store.Append(ctx, streamID, events, ...)` / `store.Load(ctx, streamID)` — traced operations; `ctx` carries the span.
+- `tracer.Start(ctx, name, trace.WithAttributes(...))` — open a span (from `go.opentelemetry.io/otel`).
+- `stdouttrace.New(...)` / `sdktrace.NewTracerProvider(...)` — the OTel exporter and provider used in the demo.
+
+## Related
+- **Examples:** [metrics](../metrics) · [full-ecommerce](../full-ecommerce) · [basic](../basic)
+- **Docs:** [Advanced Patterns](https://go-mink.dev/docs/advanced/advanced-patterns) · [API reference](https://pkg.go.dev/go-mink.dev/middleware/tracing)

--- a/examples/versioning/README.md
+++ b/examples/versioning/README.md
@@ -1,0 +1,48 @@
+# Event Versioning Example
+
+> Evolve your event schema over time without rewriting stored events.
+
+Events are immutable once written, but their shape needs to change as your domain grows. go-mink solves this with **upcasters** — small, ordered transformations that rebuild old events into the latest schema at read time. This example evolves a `ProductAdded` event from v1 (Name, Price) to v2 (adds Currency) to v3 (adds TaxRate), and loads a v1 event back as if it had always been v3.
+
+## What this demonstrates
+
+- **Schema-agnostic upcasters** — `productAddedV1ToV2` and `productAddedV2ToV3` transform raw JSON bytes; each declares `FromVersion()`/`ToVersion()` (must differ by exactly 1) and defaults the newly added field.
+- **Transparent upcasting on load** — a v1 event stored before any upcasters existed is read back through `storeV3.Load` / `storeV3.LoadAggregate` already carrying Currency and TaxRate.
+- **Automatic version stamping** — newly saved events are marked with the latest schema version in metadata, read back via `mink.GetSchemaVersion`.
+- **Upcaster chains** — `mink.NewUpcasterChain` collects upcasters; `chain.Validate` checks for gaps and `chain.LatestVersion` reports the target version per event type.
+- **Compatibility checking** — `mink.NewSchemaRegistry` records field-level schema definitions and `registry.CheckCompatibility` classifies each version bump.
+
+## Running
+
+```bash
+go run ./examples/versioning
+```
+
+No infrastructure required — uses the in-memory adapter.
+
+## What happens
+
+1. **Store a v1 event** — a store with no upcasters appends a `ProductAdded` with only Name (`Wireless Mouse`) and Price (`29.99`); Currency and TaxRate are zero-valued, representing the old schema.
+2. **Register upcasters** — `productAddedV1ToV2` and `productAddedV2ToV3` are registered into an `UpcasterChain`, which is then validated. The chain reports its registered event types and that the latest version for `ProductAdded` is v3.
+3. **Load the old event** — a second store over the *same* adapter but configured with `mink.WithUpcasters(chain)` loads the v1 event; it comes back with `Currency: USD` (from the v1→v2 upcaster) and `TaxRate: 0.0%` (from the v2→v3 upcaster).
+4. **Rebuild the aggregate** — `LoadAggregate` replays the upcasted events into a `Product`, showing the fully-populated state and version.
+5. **Save a v3 event** — a new `Product` (`Mechanical Keyboard`, EUR, 19% tax) is saved; `LoadRaw` plus `mink.GetSchemaVersion` confirms the schema version stamped into metadata.
+6. **Inspect the registry** — three schema definitions (v1, v2, v3) are registered and `CheckCompatibility` is called for v1→v2 and v2→v3, printing the compatibility classification for each field addition.
+
+## Key APIs
+
+- `mink.NewUpcasterChain()` — creates an ordered chain of upcasters.
+- `chain.Register(...)` — adds an upcaster (implementing `EventType`, `FromVersion`, `ToVersion`, `Upcast`) to the chain.
+- `chain.Validate()` — verifies the chain has no version gaps.
+- `chain.RegisteredEventTypes()` — lists event types the chain can upcast.
+- `chain.LatestVersion("ProductAdded")` — returns the highest target version for an event type.
+- `mink.WithUpcasters(chain)` — option that wires the chain into an `EventStore`.
+- `mink.GetSchemaVersion(metadata)` — reads the schema version stamped in event metadata.
+- `mink.NewSchemaRegistry()` — creates a registry of `SchemaDefinition`s with `FieldDefinition`s.
+- `registry.Register(...)` / `registry.GetLatestVersion(...)` — record and query schema versions.
+- `registry.CheckCompatibility("ProductAdded", 1, 2)` — classifies compatibility between two schema versions.
+
+## Related
+
+- **Examples:** [full-ecommerce](../full-ecommerce) · [basic](../basic) · [msgpack](../msgpack)
+- **Docs:** [Event Versioning](https://go-mink.dev/docs/advanced/versioning) · [API reference](https://pkg.go.dev/go-mink.dev)


### PR DESCRIPTION
docs: overhaul README, add example READMEs, refresh contributor docs

Make the repo more welcoming and comprehensive for new contributors.

- README.md: fix the 13 broken docs/ links (now point to go-mink.dev), add a "Why Event Sourcing?" section, a Mermaid architecture diagram, a collapsible guided tour, an examples index, and a Contributing/Community section. Surface newer features (GDPR erasure/retention, audit logging, anonymization, subject discovery). Correct required Go version to 1.25+. Fix a broken emoji and verify every snippet against the real API.
- examples/: add a README.md to all 14 examples lacking one, plus an examples/README.md index with a suggested learning path. Grounded in each example's source.
- CONTRIBUTING.md: align with the Makefile workflow, add a project-layout map and good-first-contribution ideas, fix a broken docs/ link and the stale coverage table.
- .github/SECURITY.md: correct the supported-versions table (v1.0.x) and use GitHub private vulnerability reporting; CODE_OF_CONDUCT.md: real enforcement contact; refresh bug-report and PR templates.
- CHANGELOG.md: add a Documentation entry under [Unreleased].

## Documentation
<!-- Did you update the docs? -->
- [X] Code comments added
- [X] README updated (if applicable)
- [X] API docs updated

## Checklist
- [X] Code follows project style guidelines
- [X] All tests pass
- [X] No breaking changes (or documented if intentional)
